### PR TITLE
feat: Define MicroAgent async trait

### DIFF
--- a/.claude/tasks/issue-3.md
+++ b/.claude/tasks/issue-3.md
@@ -6,12 +6,12 @@
 
 _Tasks in this group can be done in parallel._
 
-- [ ] **Add `async-trait` dependency to `agent-sdk/Cargo.toml`** `[S]`
+- [x] **Add `async-trait` dependency to `agent-sdk/Cargo.toml`** `[S]`
       Add `async-trait = "0.1"` to `[dependencies]` in `crates/agent-sdk/Cargo.toml`. This is required because native async traits in Rust 1.94 are not dyn-compatible, and the orchestrator needs `Box<dyn MicroAgent>`. Also add `tokio = { version = "1", features = ["macros", "rt"] }` to `[dev-dependencies]` so async tests can use `#[tokio::test]`.
       Files: `crates/agent-sdk/Cargo.toml`
       Blocking: "Define `MicroAgent` trait", "Write object-safety and mock-implementation tests"
 
-- [ ] **Add `uuid` and `serde_json` dependencies to `agent-sdk/Cargo.toml`** `[S]`
+- [x] **Add `uuid` and `serde_json` dependencies to `agent-sdk/Cargo.toml`** `[S]`
       Add `uuid = { version = "1", features = ["v4", "serde"] }` and `serde_json = "1"` to `[dependencies]`. These are required by the issue #4 types (`AgentRequest.id` is `Uuid`, `AgentResponse.output` and `AgentRequest.context` use `serde_json::Value`).
       Files: `crates/agent-sdk/Cargo.toml`
       Blocking: All issue #4 type definitions in Group 2
@@ -22,27 +22,27 @@ _Depends on: Group 1. Tasks in this group can be done in parallel._
 
 _Note: These types are part of issue #4 but are prerequisites for the MicroAgent trait. If issue #4 is worked separately, skip this group and mark the trait as blocked on issue #4. If working both together (as the triage recommends), implement these here._
 
-- [ ] **Define `ToolCallRecord` struct** `[S]`
+- [x] **Define `ToolCallRecord` struct** `[S]`
       Create `crates/agent-sdk/src/tool_call_record.rs` with fields: `tool_name: String`, `input: serde_json::Value`, `output: serde_json::Value`. Derive `Debug`, `Clone`, `Serialize`, `Deserialize`. Follow the existing pattern from `model_config.rs`.
       Files: `crates/agent-sdk/src/tool_call_record.rs`
       Blocking: "Define `AgentResponse` struct"
 
-- [ ] **Define `AgentRequest` struct** `[S]`
+- [x] **Define `AgentRequest` struct** `[S]`
       Create `crates/agent-sdk/src/agent_request.rs` with fields: `id: uuid::Uuid`, `input: String`, `context: Option<serde_json::Value>`, `caller: Option<String>`. Derive `Debug`, `Clone`, `Serialize`, `Deserialize`. Add a `new(input: String)` constructor that generates a UUID v4.
       Files: `crates/agent-sdk/src/agent_request.rs`
       Blocking: "Define `MicroAgent` trait"
 
-- [ ] **Define `AgentResponse` struct** `[S]`
+- [x] **Define `AgentResponse` struct** `[S]`
       Create `crates/agent-sdk/src/agent_response.rs` with fields: `id: uuid::Uuid`, `output: serde_json::Value`, `confidence: f32`, `escalated: bool`, `tool_calls: Vec<ToolCallRecord>`. Derive `Debug`, `Clone`, `Serialize`, `Deserialize`.
       Files: `crates/agent-sdk/src/agent_response.rs`
       Blocking: "Define `MicroAgent` trait"
 
-- [ ] **Define `AgentError` enum** `[S]`
+- [x] **Define `AgentError` enum** `[S]`
       Create `crates/agent-sdk/src/agent_error.rs` with variants: `ToolCallFailed { tool: String, reason: String }`, `ConfidenceTooLow { confidence: f32, threshold: f32 }`, `MaxTurnsExceeded { turns: u32 }`, `Internal(String)`. Derive `Debug`, `Clone`, `PartialEq`. Implement `std::fmt::Display` and `std::error::Error`.
       Files: `crates/agent-sdk/src/agent_error.rs`
       Blocking: "Define `MicroAgent` trait"
 
-- [ ] **Define `HealthStatus` enum** `[S]`
+- [x] **Define `HealthStatus` enum** `[S]`
       Create `crates/agent-sdk/src/health_status.rs` with variants: `Healthy`, `Degraded(String)`, `Unhealthy(String)`. Derive `Debug`, `Clone`, `PartialEq`, `Serialize`, `Deserialize`.
       Files: `crates/agent-sdk/src/health_status.rs`
       Blocking: "Define `MicroAgent` trait"
@@ -51,13 +51,13 @@ _Note: These types are part of issue #4 but are prerequisites for the MicroAgent
 
 _Depends on: Group 2_
 
-- [ ] **Define `MicroAgent` trait** `[S]`
+- [x] **Define `MicroAgent` trait** `[S]`
       Create `crates/agent-sdk/src/micro_agent.rs`. Define the trait using the `#[async_trait]` macro with three methods: `fn manifest(&self) -> &SkillManifest` (synchronous, returns reference), `async fn invoke(&self, request: AgentRequest) -> Result<AgentResponse, AgentError>`, and `async fn health(&self) -> HealthStatus`. The trait must have `Send + Sync` supertraits for object safety. Import types from sibling modules via `crate::`.
       Files: `crates/agent-sdk/src/micro_agent.rs`
       Blocked by: All Group 2 types
       Blocking: "Update `lib.rs` with new module declarations and re-exports"
 
-- [ ] **Update `lib.rs` with new module declarations and re-exports** `[S]`
+- [x] **Update `lib.rs` with new module declarations and re-exports** `[S]`
       Add `mod` declarations for all new modules (`tool_call_record`, `agent_request`, `agent_response`, `agent_error`, `health_status`, `micro_agent`) and corresponding `pub use` re-exports. Also re-export `async_trait::async_trait` so downstream crates can use `#[async_trait]` when implementing `MicroAgent` without adding `async-trait` as a direct dependency.
       Files: `crates/agent-sdk/src/lib.rs`
       Blocked by: "Define `MicroAgent` trait"
@@ -67,19 +67,19 @@ _Depends on: Group 2_
 
 _Depends on: Group 3. Tasks in this group can be done in parallel (except the final verification)._
 
-- [ ] **Write object-safety and mock-implementation tests** `[M]`
+- [x] **Write object-safety and mock-implementation tests** `[M]`
       Create `crates/agent-sdk/tests/micro_agent_test.rs`. Write tests that: (1) create a `MockAgent` struct implementing `MicroAgent` to verify the trait compiles and is implementable; (2) verify `Box<dyn MicroAgent>` is valid (object safety) by boxing a `MockAgent` and calling methods through the trait object; (3) test that `invoke` returns both `Ok` and `Err` variants correctly; (4) test all three `HealthStatus` variants. Use `#[tokio::test]` for async tests. Follow the existing test pattern from `skill_manifest_test.rs`.
       Files: `crates/agent-sdk/tests/micro_agent_test.rs`
       Blocked by: lib.rs re-exports
       Blocking: "Run verification suite"
 
-- [ ] **Write serialization tests for envelope types** `[S]`
+- [x] **Write serialization tests for envelope types** `[S]`
       Create `crates/agent-sdk/tests/envelope_types_test.rs`. Write round-trip serialization tests for `AgentRequest`, `AgentResponse`, `ToolCallRecord`, and `AgentError`. Test `AgentError`'s `Display` output. Test `AgentRequest::new()` constructor. Follow the round-trip pattern from `skill_manifest_test.rs`.
       Files: `crates/agent-sdk/tests/envelope_types_test.rs`
       Blocked by: lib.rs re-exports
       Blocking: "Run verification suite"
 
-- [ ] **Run `cargo check`, `cargo clippy`, `cargo test` to verify** `[S]`
+- [x] **Run `cargo check`, `cargo clippy`, `cargo test` to verify** `[S]`
       Run the full verification suite per CLAUDE.md project commands. Ensure no clippy warnings, all tests pass, and the crate compiles cleanly. Verify that `Box<dyn MicroAgent>` compiles without errors.
       Files: (none — command-line only)
       Blocked by: All tests in Group 4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,10 +10,12 @@ version = "0.1.0"
 name = "agent-sdk"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
+ "tokio",
  "uuid",
 ]
 
@@ -22,6 +24,17 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -160,6 +173,12 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 [[package]]
 name = "orchestrator"
 version = "0.1.0"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prettyplease"
@@ -318,6 +337,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/agent-sdk/Cargo.toml
+++ b/crates/agent-sdk/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 schemars = { version = "0.8", features = ["derive", "uuid1"] }
 uuid = { version = "1", features = ["v4", "serde"] }
@@ -11,3 +12,4 @@ serde_json = "1"
 
 [dev-dependencies]
 serde_yaml = "0.9"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/agent-sdk/src/agent_response.rs
+++ b/crates/agent-sdk/src/agent_response.rs
@@ -1,5 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
 
 use crate::tool_call_record::ToolCallRecord;
 
@@ -13,7 +15,7 @@ pub struct AgentResponse {
 }
 
 impl AgentResponse {
-    pub fn success(id: uuid::Uuid, output: serde_json::Value) -> Self {
+    pub fn success(id: Uuid, output: Value) -> Self {
         Self {
             id,
             output,

--- a/crates/agent-sdk/src/lib.rs
+++ b/crates/agent-sdk/src/lib.rs
@@ -1,19 +1,25 @@
-mod agent_error;
-mod agent_request;
-mod agent_response;
 mod constraints;
-mod health_status;
 mod model_config;
 mod output_schema;
 mod skill_manifest;
-mod tool_call_record;
 
-pub use agent_error::AgentError;
-pub use agent_request::AgentRequest;
-pub use agent_response::AgentResponse;
+mod tool_call_record;
+mod agent_request;
+mod agent_response;
+mod agent_error;
+mod health_status;
+mod micro_agent;
+
 pub use constraints::Constraints;
-pub use health_status::HealthStatus;
 pub use model_config::ModelConfig;
 pub use output_schema::OutputSchema;
 pub use skill_manifest::SkillManifest;
+
 pub use tool_call_record::ToolCallRecord;
+pub use agent_request::AgentRequest;
+pub use agent_response::AgentResponse;
+pub use agent_error::AgentError;
+pub use health_status::HealthStatus;
+pub use micro_agent::MicroAgent;
+
+pub use async_trait::async_trait;

--- a/crates/agent-sdk/src/micro_agent.rs
+++ b/crates/agent-sdk/src/micro_agent.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+
+use crate::agent_error::AgentError;
+use crate::agent_request::AgentRequest;
+use crate::agent_response::AgentResponse;
+use crate::health_status::HealthStatus;
+use crate::skill_manifest::SkillManifest;
+
+/// Core trait for all micro-agents.
+///
+/// Uses `#[async_trait]` instead of native async trait methods because native
+/// async methods are not dyn-compatible — the orchestrator requires `Box<dyn MicroAgent>`.
+#[async_trait]
+pub trait MicroAgent: Send + Sync {
+    fn manifest(&self) -> &SkillManifest;
+    async fn invoke(&self, request: AgentRequest) -> Result<AgentResponse, AgentError>;
+    async fn health(&self) -> HealthStatus;
+}

--- a/crates/agent-sdk/src/tool_call_record.rs
+++ b/crates/agent-sdk/src/tool_call_record.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ToolCallRecord {

--- a/crates/agent-sdk/tests/envelope_types_test.rs
+++ b/crates/agent-sdk/tests/envelope_types_test.rs
@@ -128,3 +128,50 @@ fn tool_call_record_json_round_trip_with_nested_values() {
 
     assert_eq!(original, deserialized);
 }
+
+#[test]
+fn agent_request_none_fields_round_trip() {
+    let original = AgentRequest {
+        id: Uuid::nil(),
+        input: "test input".to_string(),
+        context: None,
+        caller: None,
+    };
+
+    let json_str = serde_json::to_string(&original).unwrap();
+    let deserialized: AgentRequest = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(original, deserialized);
+}
+
+#[test]
+fn agent_response_empty_tool_calls_round_trip() {
+    let original = AgentResponse {
+        id: Uuid::nil(),
+        output: json!("done"),
+        confidence: 0.75,
+        escalated: true,
+        tool_calls: vec![],
+    };
+
+    let json_str = serde_json::to_string(&original).unwrap();
+    let deserialized: AgentResponse = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(original, deserialized);
+}
+
+#[test]
+fn agent_error_equality() {
+    assert_eq!(
+        AgentError::MaxTurnsExceeded { turns: 5 },
+        AgentError::MaxTurnsExceeded { turns: 5 }
+    );
+    assert_ne!(
+        AgentError::Internal("a".to_string()),
+        AgentError::Internal("b".to_string())
+    );
+    assert_ne!(
+        AgentError::Internal("x".to_string()),
+        AgentError::MaxTurnsExceeded { turns: 1 }
+    );
+}

--- a/crates/agent-sdk/tests/micro_agent_test.rs
+++ b/crates/agent-sdk/tests/micro_agent_test.rs
@@ -1,0 +1,151 @@
+use std::collections::HashMap;
+
+use agent_sdk::{
+    async_trait, AgentError, AgentRequest, AgentResponse, Constraints, HealthStatus, MicroAgent,
+    ModelConfig, OutputSchema, SkillManifest,
+};
+use serde_json::json;
+
+struct MockAgent {
+    manifest: SkillManifest,
+    should_fail: bool,
+    health_status: HealthStatus,
+}
+
+fn make_manifest() -> SkillManifest {
+    SkillManifest {
+        name: "test-agent".to_string(),
+        description: "A mock agent for testing".to_string(),
+        version: "1.0.0".to_string(),
+        model: ModelConfig {
+            provider: "test-provider".to_string(),
+            name: "test-model".to_string(),
+            temperature: 0.7,
+        },
+        preamble: "You are a test agent.".to_string(),
+        tools: vec!["test_tool".to_string()],
+        constraints: Constraints {
+            max_turns: 10,
+            confidence_threshold: 0.85,
+            escalate_to: "human".to_string(),
+            allowed_actions: vec!["test".to_string()],
+        },
+        output: OutputSchema {
+            format: "json".to_string(),
+            schema: HashMap::from([("result".to_string(), "string".to_string())]),
+        },
+    }
+}
+
+fn make_mock(should_fail: bool, health: HealthStatus) -> MockAgent {
+    MockAgent {
+        manifest: make_manifest(),
+        should_fail,
+        health_status: health,
+    }
+}
+
+#[async_trait]
+impl MicroAgent for MockAgent {
+    fn manifest(&self) -> &SkillManifest {
+        &self.manifest
+    }
+
+    async fn invoke(&self, request: AgentRequest) -> Result<AgentResponse, AgentError> {
+        if self.should_fail {
+            return Err(AgentError::Internal("mock failure".to_string()));
+        }
+        Ok(AgentResponse {
+            id: request.id,
+            output: json!({"result": "ok"}),
+            confidence: 0.95,
+            escalated: false,
+            tool_calls: vec![],
+        })
+    }
+
+    async fn health(&self) -> HealthStatus {
+        self.health_status.clone()
+    }
+}
+
+#[tokio::test]
+async fn mock_agent_implements_trait() {
+    let agent = make_mock(false, HealthStatus::Healthy);
+    let manifest = agent.manifest();
+    assert_eq!(manifest.name, "test-agent");
+
+    let request = AgentRequest::new("test input".to_string());
+    let response = agent.invoke(request).await.unwrap();
+    assert_eq!(response.output, json!({"result": "ok"}));
+
+    let health = agent.health().await;
+    assert_eq!(health, HealthStatus::Healthy);
+}
+
+#[tokio::test]
+async fn trait_object_is_dyn_compatible() {
+    let mock = make_mock(false, HealthStatus::Healthy);
+    let agent: Box<dyn MicroAgent> = Box::new(mock);
+
+    let manifest = agent.manifest();
+    assert_eq!(manifest.name, "test-agent");
+
+    let request = AgentRequest::new("boxed test".to_string());
+    let req_id = request.id;
+    let response = agent.invoke(request).await.unwrap();
+    assert_eq!(response.id, req_id);
+
+    let health = agent.health().await;
+    assert_eq!(health, HealthStatus::Healthy);
+}
+
+#[tokio::test]
+async fn invoke_returns_ok() {
+    let agent = make_mock(false, HealthStatus::Healthy);
+    let request = AgentRequest::new("hello".to_string());
+    let req_id = request.id;
+    let result = agent.invoke(request).await;
+
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.id, req_id);
+    assert_eq!(response.output, json!({"result": "ok"}));
+    assert!((response.confidence - 0.95).abs() < f32::EPSILON);
+    assert!(!response.escalated);
+    assert!(response.tool_calls.is_empty());
+}
+
+#[tokio::test]
+async fn invoke_returns_err() {
+    let agent = make_mock(true, HealthStatus::Healthy);
+    let request = AgentRequest::new("will fail".to_string());
+    let result = agent.invoke(request).await;
+
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err(),
+        AgentError::Internal("mock failure".to_string())
+    );
+}
+
+#[tokio::test]
+async fn health_status_healthy() {
+    let agent = make_mock(false, HealthStatus::Healthy);
+    let health = agent.health().await;
+    assert_eq!(health, HealthStatus::Healthy);
+}
+
+#[tokio::test]
+async fn health_status_degraded() {
+    let agent = make_mock(false, HealthStatus::Degraded("high latency".to_string()));
+    let health = agent.health().await;
+    assert_eq!(health, HealthStatus::Degraded("high latency".to_string()));
+}
+
+#[tokio::test]
+async fn health_status_unhealthy() {
+    let agent = make_mock(false, HealthStatus::Unhealthy("database down".to_string()));
+    let health = agent.health().await;
+    assert_eq!(health, HealthStatus::Unhealthy("database down".to_string()));
+}


### PR DESCRIPTION
## Summary

- Defines the `MicroAgent` async trait using `#[async_trait]` with `Send + Sync` supertraits, enabling `Box<dyn MicroAgent>` for the orchestrator's dynamic dispatch
- Adds `async-trait` dependency and `tokio` dev-dependency to `agent-sdk`
- Re-exports `MicroAgent` and `async_trait` from the crate root
- Fixes missing `use` imports for `Uuid`/`Value` in `agent_response.rs` and `tool_call_record.rs`
- Adds 7 object-safety tests (`micro_agent_test.rs`) proving trait implementability and dyn-compatibility
- Adds 3 envelope type tests (`envelope_types_test.rs`) for None-field round-trips, empty tool_calls, and error equality

## Test plan

- [x] `cargo check -p agent-sdk --tests` — compiles cleanly
- [x] `cargo clippy -p agent-sdk --tests -- -D warnings` — zero warnings
- [x] `cargo test -p agent-sdk` — 21 tests pass (7 micro_agent + 10 envelope + 4 skill_manifest)
- [x] `Box<dyn MicroAgent>` compiles (`trait_object_is_dyn_compatible` test)

Closes #3