### PR TITLE
feat: implement startup-time skill validation

### DIFF
--- a/crates/agent-sdk/src/constraints.rs
+++ b/crates/agent-sdk/src/constraints.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct Constraints {
     pub max_turns: u32,
     pub confidence_threshold: f64,
-    pub escalate_to: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub escalate_to: Option<String>,
     pub allowed_actions: Vec<String>,
 }

--- a/crates/agent-sdk/src/lib.rs
+++ b/crates/agent-sdk/src/lib.rs
@@ -13,6 +13,7 @@ mod micro_agent;
 pub use constraints::Constraints;
 pub use model_config::ModelConfig;
 pub use output_schema::OutputSchema;
+pub use output_schema::ALLOWED_OUTPUT_FORMATS;
 pub use skill_manifest::SkillManifest;
 
 pub use tool_call_record::ToolCallRecord;

--- a/crates/agent-sdk/src/output_schema.rs
+++ b/crates/agent-sdk/src/output_schema.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+pub const ALLOWED_OUTPUT_FORMATS: &[&str] = &["json", "structured_json", "text"];
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct OutputSchema {
     pub format: String,

--- a/crates/agent-sdk/tests/micro_agent_test.rs
+++ b/crates/agent-sdk/tests/micro_agent_test.rs
@@ -27,7 +27,7 @@ fn make_manifest() -> SkillManifest {
         constraints: Constraints {
             max_turns: 10,
             confidence_threshold: 0.85,
-            escalate_to: "human".to_string(),
+            escalate_to: Some("human".to_string()),
             allowed_actions: vec!["test".to_string()],
         },
         output: OutputSchema {

--- a/crates/agent-sdk/tests/skill_manifest_test.rs
+++ b/crates/agent-sdk/tests/skill_manifest_test.rs
@@ -47,7 +47,10 @@ fn deserialize_readme_skill_file() {
 
     assert_eq!(manifest.constraints.max_turns, 5);
     assert!((manifest.constraints.confidence_threshold - 0.85).abs() < f64::EPSILON);
-    assert_eq!(manifest.constraints.escalate_to, "human_reviewer");
+    assert_eq!(
+        manifest.constraints.escalate_to,
+        Some("human_reviewer".to_string())
+    );
     assert_eq!(
         manifest.constraints.allowed_actions,
         vec!["summarize", "clarify"]
@@ -75,7 +78,7 @@ fn serialize_deserialize_round_trip() {
         constraints: Constraints {
             max_turns: 10,
             confidence_threshold: 0.9,
-            escalate_to: "senior_analyst".to_string(),
+            escalate_to: Some("senior_analyst".to_string()),
             allowed_actions: vec!["analyze".to_string(), "report".to_string()],
         },
         output: OutputSchema {
@@ -151,4 +154,69 @@ output:
         serde_yaml::from_str(yaml).expect("failed to deserialize YAML with empty schema");
 
     assert!(manifest.output.schema.is_empty());
+}
+
+#[test]
+fn deserialize_missing_escalate_to() {
+    let yaml = r#"
+name: no-escalation
+version: "1.0"
+description: Skill without escalation
+model:
+  provider: anthropic
+  name: claude-3-haiku
+  temperature: 0.5
+preamble: You are an assistant.
+tools:
+  - web_search
+constraints:
+  max_turns: 3
+  confidence_threshold: 0.7
+  allowed_actions:
+    - search
+output:
+  format: text
+  schema:
+    body: string
+"#;
+
+    let manifest: SkillManifest =
+        serde_yaml::from_str(yaml).expect("failed to deserialize YAML without escalate_to");
+
+    assert_eq!(manifest.constraints.escalate_to, None);
+}
+
+#[test]
+fn round_trip_none_escalate_to() {
+    let original = SkillManifest {
+        name: "no-escalation".to_string(),
+        version: "1.0".to_string(),
+        description: "Skill without escalation".to_string(),
+        model: ModelConfig {
+            provider: "anthropic".to_string(),
+            name: "claude-3-haiku".to_string(),
+            temperature: 0.5,
+        },
+        preamble: "You are an assistant.".to_string(),
+        tools: vec!["web_search".to_string()],
+        constraints: Constraints {
+            max_turns: 3,
+            confidence_threshold: 0.7,
+            escalate_to: None,
+            allowed_actions: vec!["search".to_string()],
+        },
+        output: OutputSchema {
+            format: "text".to_string(),
+            schema: HashMap::from([("body".to_string(), "string".to_string())]),
+        },
+    };
+
+    let yaml = serde_yaml::to_string(&original).expect("failed to serialize");
+    assert!(
+        !yaml.contains("escalate_to"),
+        "YAML should not contain escalate_to when None"
+    );
+
+    let deserialized: SkillManifest = serde_yaml::from_str(&yaml).expect("failed to deserialize");
+    assert_eq!(deserialized.constraints.escalate_to, None);
 }

--- a/crates/skill-loader/src/lib.rs
+++ b/crates/skill-loader/src/lib.rs
@@ -1,7 +1,9 @@
 mod error;
 mod frontmatter;
+pub mod validation;
 
 pub use error::SkillError;
+pub use validation::{AllToolsExist, ToolExists, validate};
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -13,13 +15,19 @@ pub struct SkillLoader {
     skill_dir: PathBuf,
     #[allow(dead_code)]
     tool_registry: Arc<ToolRegistry>,
+    tool_checker: Box<dyn ToolExists + Send + Sync>,
 }
 
 impl SkillLoader {
-    pub fn new(skill_dir: PathBuf, tool_registry: Arc<ToolRegistry>) -> Self {
+    pub fn new(
+        skill_dir: PathBuf,
+        tool_registry: Arc<ToolRegistry>,
+        tool_checker: Box<dyn ToolExists + Send + Sync>,
+    ) -> Self {
         Self {
             skill_dir,
             tool_registry,
+            tool_checker,
         }
     }
 
@@ -47,7 +55,7 @@ impl SkillLoader {
                 source: err.to_string(),
             })?;
 
-        Ok(SkillManifest {
+        let manifest = SkillManifest {
             name: fm.name,
             version: fm.version,
             description: fm.description,
@@ -56,6 +64,8 @@ impl SkillLoader {
             tools: fm.tools,
             constraints: fm.constraints,
             output: fm.output,
-        })
+        };
+        validate(&manifest, &*self.tool_checker)?;
+        Ok(manifest)
     }
 }

--- a/crates/skill-loader/src/validation.rs
+++ b/crates/skill-loader/src/validation.rs
@@ -1,0 +1,131 @@
+use agent_sdk::{SkillManifest, ALLOWED_OUTPUT_FORMATS};
+
+use crate::SkillError;
+
+/// Trait for checking whether a tool name is registered.
+///
+/// Used by the `validate` function to verify that all tool names
+/// referenced in a `SkillManifest` actually exist in the runtime.
+pub trait ToolExists {
+    fn tool_exists(&self, name: &str) -> bool;
+}
+
+/// Stub implementation that always returns `true`.
+///
+/// Useful in tests that exercise validation rules unrelated to tool
+/// name checking (e.g., confidence threshold, output format).
+#[derive(Debug, Clone, Copy)]
+pub struct AllToolsExist;
+
+impl ToolExists for AllToolsExist {
+    fn tool_exists(&self, _name: &str) -> bool {
+        true
+    }
+}
+
+pub fn validate(manifest: &SkillManifest, tool_checker: &dyn ToolExists) -> Result<(), SkillError> {
+    let mut reasons: Vec<String> = Vec::new();
+
+    check_required_strings(manifest, &mut reasons);
+    check_preamble(&manifest.preamble, &mut reasons);
+    check_confidence_threshold(manifest.constraints.confidence_threshold, &mut reasons);
+    check_max_turns(manifest.constraints.max_turns, &mut reasons);
+    check_tools_exist(&manifest.tools, tool_checker, &mut reasons);
+    check_output_format(&manifest.output.format, &mut reasons);
+    check_escalate_to(&manifest.constraints.escalate_to, &mut reasons);
+
+    if reasons.is_empty() {
+        Ok(())
+    } else {
+        Err(SkillError::ValidationError {
+            skill_name: manifest.name.clone(),
+            reasons,
+        })
+    }
+}
+
+fn check_required_strings(manifest: &SkillManifest, reasons: &mut Vec<String>) {
+    let fields: [(&str, &str); 4] = [
+        ("name", &manifest.name),
+        ("version", &manifest.version),
+        ("model.provider", &manifest.model.provider),
+        ("model.name", &manifest.model.name),
+    ];
+
+    for (label, value) in &fields {
+        if value.trim().is_empty() {
+            reasons.push(format!("'{label}' must not be empty"));
+        }
+    }
+}
+
+fn check_preamble(preamble: &str, reasons: &mut Vec<String>) {
+    if preamble.trim().is_empty() {
+        reasons.push("'preamble' must not be empty".to_string());
+    }
+}
+
+fn check_confidence_threshold(value: f64, reasons: &mut Vec<String>) {
+    if !(0.0..=1.0).contains(&value) {
+        reasons.push(format!(
+            "'confidence_threshold' must be between 0.0 and 1.0, got {value}"
+        ));
+    }
+}
+
+fn check_max_turns(value: u32, reasons: &mut Vec<String>) {
+    if value == 0 {
+        reasons.push("'max_turns' must be greater than 0".to_string());
+    }
+}
+
+fn check_tools_exist(tools: &[String], tool_checker: &dyn ToolExists, reasons: &mut Vec<String>) {
+    let missing: Vec<&str> = tools
+        .iter()
+        .filter(|name| !tool_checker.tool_exists(name))
+        .map(|s| s.as_str())
+        .collect();
+
+    if !missing.is_empty() {
+        reasons.push(format!("tools not found: {}", missing.join(", ")));
+    }
+}
+
+fn check_output_format(format: &str, reasons: &mut Vec<String>) {
+    if !ALLOWED_OUTPUT_FORMATS.contains(&format) {
+        reasons.push(format!("unrecognized output format '{format}'"));
+    }
+}
+
+fn check_escalate_to(escalate_to: &Option<String>, reasons: &mut Vec<String>) {
+    // TODO: full cross-agent escalation validation deferred to orchestrator
+    if let Some(name) = escalate_to
+        && name.trim().is_empty()
+    {
+        reasons.push("'escalate_to' must not be empty when provided".to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_tools_exist_returns_true() {
+        let checker = AllToolsExist;
+        assert!(checker.tool_exists("any_tool_name"));
+    }
+
+    #[test]
+    fn all_tools_exist_returns_true_for_empty_string() {
+        let checker = AllToolsExist;
+        assert!(checker.tool_exists(""));
+    }
+
+    #[test]
+    fn trait_is_object_safe() {
+        let checker = AllToolsExist;
+        let dyn_checker: &dyn ToolExists = &checker;
+        assert!(dyn_checker.tool_exists("some_tool"));
+    }
+}

--- a/crates/skill-loader/tests/skill_loader_test.rs
+++ b/crates/skill-loader/tests/skill_loader_test.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use skill_loader::{SkillError, SkillLoader};
+use skill_loader::{AllToolsExist, SkillError, SkillLoader};
 use tempfile::tempdir;
 use tokio::fs;
 use tool_registry::ToolRegistry;
 
 fn make_loader(dir: &std::path::Path) -> SkillLoader {
     let registry = Arc::new(ToolRegistry);
-    SkillLoader::new(dir.to_path_buf(), registry)
+    SkillLoader::new(dir.to_path_buf(), registry, Box::new(AllToolsExist))
 }
 
 #[tokio::test]
@@ -61,7 +61,7 @@ You are a summarization assistant.";
     assert!(
         (manifest.constraints.confidence_threshold - 0.85).abs() < f64::EPSILON
     );
-    assert_eq!(manifest.constraints.escalate_to, "human_reviewer");
+    assert_eq!(manifest.constraints.escalate_to, Some("human_reviewer".to_string()));
     assert_eq!(
         manifest.constraints.allowed_actions,
         vec!["summarize", "clarify"]
@@ -174,9 +174,16 @@ output:
         .unwrap();
 
     let loader = make_loader(dir.path());
-    let manifest = loader.load("minimal").await.unwrap();
+    let result = loader.load("minimal").await;
+    assert!(result.is_err());
 
-    assert_eq!(manifest.preamble, "");
+    let err = result.unwrap_err();
+    match err {
+        SkillError::ValidationError { reasons, .. } => {
+            assert!(reasons.iter().any(|r| r == "'preamble' must not be empty"));
+        }
+        other => panic!("expected ValidationError, got: {:?}", other),
+    }
 }
 
 #[tokio::test]
@@ -201,7 +208,7 @@ constraints:
     - search
     - analyze
 output:
-  format: markdown
+  format: text
   schema:
     report: string
 ---

--- a/crates/skill-loader/tests/validation_integration_test.rs
+++ b/crates/skill-loader/tests/validation_integration_test.rs
@@ -1,0 +1,265 @@
+use std::sync::Arc;
+
+use skill_loader::{AllToolsExist, SkillError, SkillLoader};
+use tempfile::tempdir;
+use tokio::fs;
+use tool_registry::ToolRegistry;
+
+fn make_loader(dir: &std::path::Path) -> SkillLoader {
+    let registry = Arc::new(ToolRegistry);
+    SkillLoader::new(dir.to_path_buf(), registry, Box::new(AllToolsExist))
+}
+
+const VALID_FRONTMATTER: &str = "\
+---
+name: test-skill
+version: \"1.0\"
+description: A test skill
+model:
+  provider: anthropic
+  name: claude-3-haiku
+  temperature: 0.3
+tools:
+  - web_search
+constraints:
+  max_turns: 5
+  confidence_threshold: 0.85
+  allowed_actions:
+    - search
+output:
+  format: json
+  schema:
+    result: string
+---
+You are a helpful test assistant.";
+
+#[tokio::test]
+async fn load_invalid_confidence_threshold_returns_validation_error() {
+    let dir = tempdir().unwrap();
+    let content = VALID_FRONTMATTER.replace("confidence_threshold: 0.85", "confidence_threshold: 2.0");
+
+    fs::write(dir.path().join("test-skill.md"), content)
+        .await
+        .unwrap();
+
+    let loader = make_loader(dir.path());
+    let result = loader.load("test-skill").await;
+    assert!(result.is_err());
+
+    let err = result.unwrap_err();
+    match err {
+        SkillError::ValidationError { skill_name, reasons } => {
+            assert_eq!(skill_name, "test-skill");
+            assert!(
+                reasons.iter().any(|r| r.contains("confidence_threshold")),
+                "expected reason about confidence_threshold, got: {:?}",
+                reasons
+            );
+        }
+        other => panic!("expected ValidationError, got: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn load_negative_confidence_threshold_returns_validation_error() {
+    let dir = tempdir().unwrap();
+    let content =
+        VALID_FRONTMATTER.replace("confidence_threshold: 0.85", "confidence_threshold: -0.5");
+
+    fs::write(dir.path().join("test-skill.md"), content)
+        .await
+        .unwrap();
+
+    let loader = make_loader(dir.path());
+    let result = loader.load("test-skill").await;
+    assert!(result.is_err());
+
+    let err = result.unwrap_err();
+    match err {
+        SkillError::ValidationError { skill_name, reasons } => {
+            assert_eq!(skill_name, "test-skill");
+            assert!(
+                reasons.iter().any(|r| r.contains("confidence_threshold")),
+                "expected reason about confidence_threshold, got: {:?}",
+                reasons
+            );
+        }
+        other => panic!("expected ValidationError, got: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn load_multiple_violations_returns_all_reasons() {
+    let dir = tempdir().unwrap();
+    let content = VALID_FRONTMATTER
+        .replace("confidence_threshold: 0.85", "confidence_threshold: 2.0")
+        .replace("max_turns: 5", "max_turns: 0")
+        .replace("name: test-skill", "name: \"\"");
+
+    fs::write(dir.path().join("test-skill.md"), content)
+        .await
+        .unwrap();
+
+    let loader = make_loader(dir.path());
+    let result = loader.load("test-skill").await;
+    assert!(result.is_err());
+
+    let err = result.unwrap_err();
+    match err {
+        SkillError::ValidationError { skill_name, reasons } => {
+            assert_eq!(skill_name, "");
+            assert!(
+                reasons.len() >= 3,
+                "expected at least 3 reasons, got {}: {:?}",
+                reasons.len(),
+                reasons
+            );
+            assert!(
+                reasons.iter().any(|r| r.contains("confidence_threshold")),
+                "expected reason about confidence_threshold, got: {:?}",
+                reasons
+            );
+            assert!(
+                reasons.iter().any(|r| r.contains("max_turns")),
+                "expected reason about max_turns, got: {:?}",
+                reasons
+            );
+            assert!(
+                reasons.iter().any(|r| r.contains("name")),
+                "expected reason about name, got: {:?}",
+                reasons
+            );
+        }
+        other => panic!("expected ValidationError, got: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn load_valid_skill_passes_validation() {
+    let dir = tempdir().unwrap();
+
+    fs::write(dir.path().join("test-skill.md"), VALID_FRONTMATTER)
+        .await
+        .unwrap();
+
+    let loader = make_loader(dir.path());
+    let result = loader.load("test-skill").await;
+    assert!(result.is_ok(), "expected Ok, got: {:?}", result.unwrap_err());
+
+    let manifest = result.unwrap();
+    assert_eq!(manifest.name, "test-skill");
+    assert_eq!(manifest.version, "1.0");
+    assert_eq!(manifest.description, "A test skill");
+    assert_eq!(manifest.model.provider, "anthropic");
+    assert_eq!(manifest.model.name, "claude-3-haiku");
+    assert!((manifest.model.temperature - 0.3).abs() < f64::EPSILON);
+    assert_eq!(manifest.tools, vec!["web_search"]);
+    assert_eq!(manifest.constraints.max_turns, 5);
+    assert!((manifest.constraints.confidence_threshold - 0.85).abs() < f64::EPSILON);
+    assert_eq!(manifest.constraints.escalate_to, None);
+    assert_eq!(manifest.constraints.allowed_actions, vec!["search"]);
+    assert_eq!(manifest.output.format, "json");
+    assert_eq!(manifest.output.schema.get("result").unwrap(), "string");
+    assert_eq!(manifest.preamble, "You are a helpful test assistant.");
+}
+
+#[tokio::test]
+async fn load_invalid_output_format_returns_validation_error() {
+    let dir = tempdir().unwrap();
+    let content = VALID_FRONTMATTER.replace("format: json", "format: raw");
+
+    fs::write(dir.path().join("test-skill.md"), content)
+        .await
+        .unwrap();
+
+    let loader = make_loader(dir.path());
+    let result = loader.load("test-skill").await;
+    assert!(result.is_err());
+
+    let err = result.unwrap_err();
+    match err {
+        SkillError::ValidationError { skill_name, reasons } => {
+            assert_eq!(skill_name, "test-skill");
+            assert!(
+                reasons.iter().any(|r| r.contains("format")),
+                "expected reason about format, got: {:?}",
+                reasons
+            );
+        }
+        other => panic!("expected ValidationError, got: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn load_zero_max_turns_returns_validation_error() {
+    let dir = tempdir().unwrap();
+    let content = VALID_FRONTMATTER.replace("max_turns: 5", "max_turns: 0");
+
+    fs::write(dir.path().join("test-skill.md"), content)
+        .await
+        .unwrap();
+
+    let loader = make_loader(dir.path());
+    let result = loader.load("test-skill").await;
+    assert!(result.is_err());
+
+    let err = result.unwrap_err();
+    match err {
+        SkillError::ValidationError { skill_name, reasons } => {
+            assert_eq!(skill_name, "test-skill");
+            assert!(
+                reasons.iter().any(|r| r.contains("max_turns")),
+                "expected reason about max_turns, got: {:?}",
+                reasons
+            );
+        }
+        other => panic!("expected ValidationError, got: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn load_empty_preamble_returns_validation_error() {
+    let dir = tempdir().unwrap();
+    let content = "\
+---
+name: test-skill
+version: \"1.0\"
+description: A test skill
+model:
+  provider: anthropic
+  name: claude-3-haiku
+  temperature: 0.3
+tools:
+  - web_search
+constraints:
+  max_turns: 5
+  confidence_threshold: 0.85
+  allowed_actions:
+    - search
+output:
+  format: json
+  schema:
+    result: string
+---";
+
+    fs::write(dir.path().join("test-skill.md"), content)
+        .await
+        .unwrap();
+
+    let loader = make_loader(dir.path());
+    let result = loader.load("test-skill").await;
+    assert!(result.is_err());
+
+    let err = result.unwrap_err();
+    match err {
+        SkillError::ValidationError { skill_name, reasons } => {
+            assert_eq!(skill_name, "test-skill");
+            assert!(
+                reasons.iter().any(|r| r.contains("preamble")),
+                "expected reason about preamble, got: {:?}",
+                reasons
+            );
+        }
+        other => panic!("expected ValidationError, got: {:?}", other),
+    }
+}

--- a/crates/skill-loader/tests/validation_test.rs
+++ b/crates/skill-loader/tests/validation_test.rs
@@ -1,0 +1,200 @@
+use std::collections::HashMap;
+
+use agent_sdk::{Constraints, ModelConfig, OutputSchema, SkillManifest};
+use skill_loader::{validate, AllToolsExist, SkillError, ToolExists};
+
+fn valid_manifest() -> SkillManifest {
+    SkillManifest {
+        name: "test-skill".to_string(),
+        version: "1.0".to_string(),
+        description: "A test skill".to_string(),
+        model: ModelConfig {
+            provider: "anthropic".to_string(),
+            name: "claude-3-haiku".to_string(),
+            temperature: 0.5,
+        },
+        preamble: "You are a test assistant.".to_string(),
+        tools: vec!["web_search".to_string()],
+        constraints: Constraints {
+            max_turns: 5,
+            confidence_threshold: 0.8,
+            escalate_to: None,
+            allowed_actions: vec!["search".to_string()],
+        },
+        output: OutputSchema {
+            format: "json".to_string(),
+            schema: HashMap::from([("result".to_string(), "string".to_string())]),
+        },
+    }
+}
+
+struct RejectTools {
+    rejected: Vec<String>,
+}
+
+impl ToolExists for RejectTools {
+    fn tool_exists(&self, name: &str) -> bool {
+        !self.rejected.iter().any(|r| r == name)
+    }
+}
+
+fn expect_validation_error(result: Result<(), SkillError>) -> Vec<String> {
+    match result {
+        Ok(()) => panic!("expected ValidationError, got Ok(())"),
+        Err(SkillError::ValidationError { reasons, .. }) => reasons,
+        Err(other) => panic!("expected ValidationError, got: {:?}", other),
+    }
+}
+
+#[test]
+fn valid_manifest_passes() {
+    let m = valid_manifest();
+    assert!(validate(&m, &AllToolsExist).is_ok());
+}
+
+#[test]
+fn confidence_threshold_above_one_fails() {
+    let mut m = valid_manifest();
+    m.constraints.confidence_threshold = 1.5;
+    let reasons = expect_validation_error(validate(&m, &AllToolsExist));
+    assert!(reasons.iter().any(|r| r.contains("confidence_threshold")));
+}
+
+#[test]
+fn confidence_threshold_negative_fails() {
+    let mut m = valid_manifest();
+    m.constraints.confidence_threshold = -0.1;
+    let reasons = expect_validation_error(validate(&m, &AllToolsExist));
+    assert!(reasons.iter().any(|r| r.contains("confidence_threshold")));
+}
+
+#[test]
+fn confidence_threshold_boundary_zero_passes() {
+    let mut m = valid_manifest();
+    m.constraints.confidence_threshold = 0.0;
+    assert!(validate(&m, &AllToolsExist).is_ok());
+}
+
+#[test]
+fn confidence_threshold_boundary_one_passes() {
+    let mut m = valid_manifest();
+    m.constraints.confidence_threshold = 1.0;
+    assert!(validate(&m, &AllToolsExist).is_ok());
+}
+
+#[test]
+fn max_turns_zero_fails() {
+    let mut m = valid_manifest();
+    m.constraints.max_turns = 0;
+    let reasons = expect_validation_error(validate(&m, &AllToolsExist));
+    assert!(reasons.iter().any(|r| r.contains("max_turns")));
+}
+
+#[test]
+fn max_turns_one_passes() {
+    let mut m = valid_manifest();
+    m.constraints.max_turns = 1;
+    assert!(validate(&m, &AllToolsExist).is_ok());
+}
+
+#[test]
+fn unknown_tool_name_fails() {
+    let mut m = valid_manifest();
+    m.tools.push("nonexistent_tool".to_string());
+    let checker = RejectTools {
+        rejected: vec!["nonexistent_tool".to_string()],
+    };
+    let reasons = expect_validation_error(validate(&m, &checker));
+    assert!(reasons.iter().any(|r| r.contains("nonexistent_tool")));
+}
+
+#[test]
+fn empty_name_fails() {
+    let mut m = valid_manifest();
+    m.name = "".to_string();
+    let reasons = expect_validation_error(validate(&m, &AllToolsExist));
+    assert!(reasons.iter().any(|r| r.contains("name")));
+}
+
+#[test]
+fn empty_version_fails() {
+    let mut m = valid_manifest();
+    m.version = "".to_string();
+    let reasons = expect_validation_error(validate(&m, &AllToolsExist));
+    assert!(reasons.iter().any(|r| r.contains("version")));
+}
+
+#[test]
+fn empty_preamble_fails() {
+    let mut m = valid_manifest();
+    m.preamble = "".to_string();
+    let reasons = expect_validation_error(validate(&m, &AllToolsExist));
+    assert!(reasons.iter().any(|r| r.contains("preamble")));
+}
+
+#[test]
+fn empty_model_provider_fails() {
+    let mut m = valid_manifest();
+    m.model.provider = "".to_string();
+    let reasons = expect_validation_error(validate(&m, &AllToolsExist));
+    assert!(reasons.iter().any(|r| r.contains("provider")));
+}
+
+#[test]
+fn empty_model_name_fails() {
+    let mut m = valid_manifest();
+    m.model.name = "".to_string();
+    let reasons = expect_validation_error(validate(&m, &AllToolsExist));
+    assert!(reasons.iter().any(|r| r.contains("model.name")));
+}
+
+#[test]
+fn unrecognized_output_format_fails() {
+    let mut m = valid_manifest();
+    m.output.format = "raw".to_string();
+    let reasons = expect_validation_error(validate(&m, &AllToolsExist));
+    assert!(reasons.iter().any(|r| r.contains("format")));
+}
+
+#[test]
+fn recognized_output_formats_pass() {
+    for fmt in &["json", "structured_json", "text"] {
+        let mut m = valid_manifest();
+        m.output.format = fmt.to_string();
+        assert!(
+            validate(&m, &AllToolsExist).is_ok(),
+            "expected format '{fmt}' to pass validation"
+        );
+    }
+}
+
+#[test]
+fn multiple_violations_collected() {
+    let mut m = valid_manifest();
+    m.name = "".to_string();
+    m.constraints.confidence_threshold = 2.0;
+    let reasons = expect_validation_error(validate(&m, &AllToolsExist));
+    assert!(
+        reasons.len() >= 2,
+        "expected at least 2 reasons, got {}: {:?}",
+        reasons.len(),
+        reasons
+    );
+    assert!(reasons.iter().any(|r| r.contains("name")));
+    assert!(reasons.iter().any(|r| r.contains("confidence")));
+}
+
+#[test]
+fn escalate_to_empty_string_fails() {
+    let mut m = valid_manifest();
+    m.constraints.escalate_to = Some("".to_string());
+    let reasons = expect_validation_error(validate(&m, &AllToolsExist));
+    assert!(reasons.iter().any(|r| r.contains("escalate_to")));
+}
+
+#[test]
+fn escalate_to_none_passes() {
+    let mut m = valid_manifest();
+    m.constraints.escalate_to = None;
+    assert!(validate(&m, &AllToolsExist).is_ok());
+}


### PR DESCRIPTION
## Summary

- Change `escalate_to` from `String` to `Option<String>` in `Constraints` so validators can distinguish "no escalation" from "empty string"
- Add `ALLOWED_OUTPUT_FORMATS` constant (`json`, `structured_json`, `text`) to `agent-sdk`
- Define `ToolExists` trait and `AllToolsExist` stub for pluggable tool-name checking
- Implement `validate()` function with 7 checks: required fields non-empty, preamble non-empty, confidence threshold in [0.0, 1.0], max_turns > 0, tool existence, output format recognition, escalate_to non-empty when provided
- Integrate validation into `SkillLoader::load()` so invalid skills fail at startup
- Add 18 unit tests and 7 integration tests covering all validation rules

Closes #6

## Test plan

- [x] `cargo check` — all crates compile cleanly
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all 74 tests pass (18 validation unit + 7 validation integration + 49 existing)