### PR TITLE
feat: implement tool-registry crate with ToolEntry storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,12 @@ dependencies = [
 [[package]]
 name = "tool-registry"
 version = "0.1.0"
+dependencies = [
+ "agent-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/crates/skill-loader/src/lib.rs
+++ b/crates/skill-loader/src/lib.rs
@@ -3,7 +3,8 @@ mod frontmatter;
 pub mod validation;
 
 pub use error::SkillError;
-pub use validation::{AllToolsExist, ToolExists, validate};
+pub use tool_registry::ToolExists;
+pub use validation::{AllToolsExist, validate};
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/skill-loader/src/validation.rs
+++ b/crates/skill-loader/src/validation.rs
@@ -1,14 +1,7 @@
 use agent_sdk::{SkillManifest, ALLOWED_OUTPUT_FORMATS};
+use tool_registry::ToolExists;
 
 use crate::SkillError;
-
-/// Trait for checking whether a tool name is registered.
-///
-/// Used by the `validate` function to verify that all tool names
-/// referenced in a `SkillManifest` actually exist in the runtime.
-pub trait ToolExists {
-    fn tool_exists(&self, name: &str) -> bool;
-}
 
 /// Stub implementation that always returns `true`.
 ///

--- a/crates/skill-loader/tests/example_skills_test.rs
+++ b/crates/skill-loader/tests/example_skills_test.rs
@@ -12,7 +12,7 @@ fn skills_dir() -> std::path::PathBuf {
 }
 
 fn make_loader(dir: &std::path::Path) -> SkillLoader {
-    let registry = Arc::new(ToolRegistry);
+    let registry = Arc::new(ToolRegistry::new());
     SkillLoader::new(dir.to_path_buf(), registry, Box::new(AllToolsExist))
 }
 

--- a/crates/skill-loader/tests/skill_loader_test.rs
+++ b/crates/skill-loader/tests/skill_loader_test.rs
@@ -6,7 +6,7 @@ use tokio::fs;
 use tool_registry::ToolRegistry;
 
 fn make_loader(dir: &std::path::Path) -> SkillLoader {
-    let registry = Arc::new(ToolRegistry);
+    let registry = Arc::new(ToolRegistry::new());
     SkillLoader::new(dir.to_path_buf(), registry, Box::new(AllToolsExist))
 }
 

--- a/crates/skill-loader/tests/validation_integration_test.rs
+++ b/crates/skill-loader/tests/validation_integration_test.rs
@@ -6,7 +6,7 @@ use tokio::fs;
 use tool_registry::ToolRegistry;
 
 fn make_loader(dir: &std::path::Path) -> SkillLoader {
-    let registry = Arc::new(ToolRegistry);
+    let registry = Arc::new(ToolRegistry::new());
     SkillLoader::new(dir.to_path_buf(), registry, Box::new(AllToolsExist))
 }
 

--- a/crates/tool-registry/Cargo.toml
+++ b/crates/tool-registry/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
+schemars = { version = "0.8", features = ["derive", "uuid1"] }
+serde_json = "1"
+agent-sdk = { path = "../agent-sdk" }

--- a/crates/tool-registry/src/lib.rs
+++ b/crates/tool-registry/src/lib.rs
@@ -1,1 +1,15 @@
-pub struct ToolRegistry;
+mod registry_error;
+mod tool_entry;
+mod tool_registry;
+
+pub use registry_error::RegistryError;
+pub use tool_entry::ToolEntry;
+pub use tool_registry::ToolRegistry;
+
+/// Trait for checking whether a tool name is registered.
+///
+/// Used by the `validate` function to verify that all tool names
+/// referenced in a `SkillManifest` actually exist in the runtime.
+pub trait ToolExists {
+    fn tool_exists(&self, name: &str) -> bool;
+}

--- a/crates/tool-registry/src/registry_error.rs
+++ b/crates/tool-registry/src/registry_error.rs
@@ -1,0 +1,26 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RegistryError {
+    ToolNotFound { name: String },
+    DuplicateEntry { name: String },
+    ConnectionFailed { endpoint: String, reason: String },
+}
+
+impl fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RegistryError::ToolNotFound { name } => {
+                write!(f, "tool not found: '{}'", name)
+            }
+            RegistryError::DuplicateEntry { name } => {
+                write!(f, "duplicate tool entry: '{}'", name)
+            }
+            RegistryError::ConnectionFailed { endpoint, reason } => {
+                write!(f, "connection to '{}' failed: {}", endpoint, reason)
+            }
+        }
+    }
+}
+
+impl std::error::Error for RegistryError {}

--- a/crates/tool-registry/src/tool_entry.rs
+++ b/crates/tool-registry/src/tool_entry.rs
@@ -1,0 +1,9 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ToolEntry {
+    pub name: String,
+    pub version: String,
+    pub endpoint: String,
+}

--- a/crates/tool-registry/src/tool_registry.rs
+++ b/crates/tool-registry/src/tool_registry.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use agent_sdk::SkillManifest;
+
+use crate::registry_error::RegistryError;
+use crate::tool_entry::ToolEntry;
+
+pub struct ToolRegistry {
+    entries: Arc<RwLock<HashMap<String, ToolEntry>>>,
+}
+
+impl Default for ToolRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ToolRegistry {
+    pub fn new() -> Self {
+        Self {
+            entries: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn register(&self, entry: ToolEntry) -> Result<(), RegistryError> {
+        let mut map = self.entries.write().unwrap();
+        if map.contains_key(&entry.name) {
+            return Err(RegistryError::DuplicateEntry { name: entry.name });
+        }
+        let name = entry.name.clone();
+        map.insert(name, entry);
+        Ok(())
+    }
+
+    pub fn assert_exists(&self, name: &str) -> Result<(), RegistryError> {
+        let map = self.entries.read().unwrap();
+        if !map.contains_key(name) {
+            return Err(RegistryError::ToolNotFound {
+                name: name.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn resolve_for_skill(
+        &self,
+        manifest: &SkillManifest,
+    ) -> Result<Vec<ToolEntry>, RegistryError> {
+        let map = self.entries.read().unwrap();
+        manifest
+            .tools
+            .iter()
+            .map(|tool_name| {
+                map.get(tool_name)
+                    .cloned()
+                    .ok_or_else(|| RegistryError::ToolNotFound {
+                        name: tool_name.clone(),
+                    })
+            })
+            .collect()
+    }
+
+    pub fn connect(_url: &str) {
+        // TODO: real MCP connection logic in issue #9
+    }
+
+    pub fn get(&self, name: &str) -> Option<ToolEntry> {
+        let map = self.entries.read().unwrap();
+        map.get(name).cloned()
+    }
+}
+
+impl crate::ToolExists for ToolRegistry {
+    fn tool_exists(&self, name: &str) -> bool {
+        self.entries.read().unwrap().contains_key(name)
+    }
+}

--- a/crates/tool-registry/tests/tool_entry_test.rs
+++ b/crates/tool-registry/tests/tool_entry_test.rs
@@ -1,0 +1,137 @@
+use tool_registry::{RegistryError, ToolEntry};
+
+fn make_tool_entry() -> ToolEntry {
+    ToolEntry {
+        name: "my-tool".to_string(),
+        version: "1.0.0".to_string(),
+        endpoint: "http://localhost:8080".to_string(),
+    }
+}
+
+// ── ToolEntry tests ──────────────────────────────────────────────────
+
+#[test]
+fn json_round_trip() {
+    let entry = make_tool_entry();
+    let json = serde_json::to_string(&entry).expect("serialize");
+    let deserialized: ToolEntry = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(entry, deserialized);
+}
+
+#[test]
+fn json_round_trip_unix_socket() {
+    let entry = ToolEntry {
+        name: "unix-tool".to_string(),
+        version: "2.3.1".to_string(),
+        endpoint: "unix:///var/run/tool.sock".to_string(),
+    };
+    let json = serde_json::to_string(&entry).expect("serialize");
+    let deserialized: ToolEntry = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(entry, deserialized);
+}
+
+#[test]
+fn equality() {
+    let a = make_tool_entry();
+    let b = make_tool_entry();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn inequality_by_name() {
+    let a = make_tool_entry();
+    let b = ToolEntry {
+        name: "other-tool".to_string(),
+        ..a.clone()
+    };
+    assert_ne!(a, b);
+}
+
+#[test]
+fn inequality_by_version() {
+    let a = make_tool_entry();
+    let b = ToolEntry {
+        version: "2.0.0".to_string(),
+        ..a.clone()
+    };
+    assert_ne!(a, b);
+}
+
+#[test]
+fn inequality_by_endpoint() {
+    let a = make_tool_entry();
+    let b = ToolEntry {
+        endpoint: "http://localhost:9090".to_string(),
+        ..a.clone()
+    };
+    assert_ne!(a, b);
+}
+
+#[test]
+fn clone_is_equal() {
+    let original = make_tool_entry();
+    let cloned = original.clone();
+    assert_eq!(original, cloned);
+}
+
+// ── RegistryError tests ─────────────────────────────────────────────
+
+#[test]
+fn tool_not_found_display() {
+    let err = RegistryError::ToolNotFound {
+        name: "missing-tool".to_string(),
+    };
+    assert_eq!(err.to_string(), "tool not found: 'missing-tool'");
+}
+
+#[test]
+fn duplicate_entry_display() {
+    let err = RegistryError::DuplicateEntry {
+        name: "dup-tool".to_string(),
+    };
+    assert_eq!(err.to_string(), "duplicate tool entry: 'dup-tool'");
+}
+
+#[test]
+fn connection_failed_display() {
+    let err = RegistryError::ConnectionFailed {
+        endpoint: "http://bad-host:1234".to_string(),
+        reason: "timeout".to_string(),
+    };
+    assert_eq!(
+        err.to_string(),
+        "connection to 'http://bad-host:1234' failed: timeout"
+    );
+}
+
+#[test]
+fn error_trait_impl() {
+    let err = RegistryError::ToolNotFound {
+        name: "some-tool".to_string(),
+    };
+    let dyn_err: &dyn std::error::Error = &err;
+    let msg = dyn_err.to_string();
+    assert!(msg.contains("some-tool"), "expected tool name in: {msg}");
+}
+
+#[test]
+fn registry_error_equality() {
+    let a = RegistryError::ToolNotFound {
+        name: "x".to_string(),
+    };
+    let b = RegistryError::ToolNotFound {
+        name: "x".to_string(),
+    };
+    assert_eq!(a, b);
+}
+
+#[test]
+fn inequality_between_variants() {
+    let a = RegistryError::ToolNotFound {
+        name: "x".to_string(),
+    };
+    let b = RegistryError::DuplicateEntry {
+        name: "x".to_string(),
+    };
+    assert_ne!(a, b);
+}

--- a/crates/tool-registry/tests/tool_registry_test.rs
+++ b/crates/tool-registry/tests/tool_registry_test.rs
@@ -1,0 +1,135 @@
+use std::collections::HashMap;
+
+use agent_sdk::{Constraints, ModelConfig, OutputSchema, SkillManifest};
+use tool_registry::{RegistryError, ToolEntry, ToolExists, ToolRegistry};
+
+fn make_entry(name: &str) -> ToolEntry {
+    ToolEntry {
+        name: name.to_string(),
+        version: "1.0.0".to_string(),
+        endpoint: "http://localhost:8080".to_string(),
+    }
+}
+
+fn make_manifest(tools: Vec<String>) -> SkillManifest {
+    SkillManifest {
+        name: "test-skill".to_string(),
+        version: "0.1.0".to_string(),
+        description: "test".to_string(),
+        model: ModelConfig {
+            provider: "anthropic".to_string(),
+            name: "claude".to_string(),
+            temperature: 0.0,
+        },
+        preamble: String::new(),
+        tools,
+        constraints: Constraints {
+            max_turns: 1,
+            confidence_threshold: 0.5,
+            escalate_to: None,
+            allowed_actions: vec![],
+        },
+        output: OutputSchema {
+            format: "json".to_string(),
+            schema: HashMap::new(),
+        },
+    }
+}
+
+#[test]
+fn register_and_get() {
+    let registry = ToolRegistry::new();
+    let entry = make_entry("web_search");
+
+    registry.register(entry.clone()).unwrap();
+
+    let retrieved = registry.get("web_search");
+    assert_eq!(retrieved, Some(entry));
+}
+
+#[test]
+fn assert_exists_returns_ok_for_registered_tool() {
+    let registry = ToolRegistry::new();
+    registry.register(make_entry("file_read")).unwrap();
+
+    let result = registry.assert_exists("file_read");
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn assert_exists_returns_error_for_missing_tool() {
+    let registry = ToolRegistry::new();
+
+    let result = registry.assert_exists("nonexistent");
+    assert_eq!(
+        result,
+        Err(RegistryError::ToolNotFound {
+            name: "nonexistent".into()
+        })
+    );
+}
+
+#[test]
+fn register_duplicate_returns_error() {
+    let registry = ToolRegistry::new();
+    registry.register(make_entry("web_search")).unwrap();
+
+    let result = registry.register(make_entry("web_search"));
+    assert_eq!(
+        result,
+        Err(RegistryError::DuplicateEntry {
+            name: "web_search".into()
+        })
+    );
+}
+
+#[test]
+fn resolve_for_skill_returns_matching_entries() {
+    let registry = ToolRegistry::new();
+    registry.register(make_entry("web_search")).unwrap();
+    registry.register(make_entry("file_read")).unwrap();
+    registry.register(make_entry("shell_exec")).unwrap();
+
+    let manifest = make_manifest(vec!["web_search".to_string(), "file_read".to_string()]);
+
+    let mut entries = registry.resolve_for_skill(&manifest).unwrap();
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0], make_entry("file_read"));
+    assert_eq!(entries[1], make_entry("web_search"));
+}
+
+#[test]
+fn resolve_for_skill_fails_on_missing_tool() {
+    let registry = ToolRegistry::new();
+    registry.register(make_entry("web_search")).unwrap();
+
+    let manifest = make_manifest(vec!["web_search".to_string(), "missing_tool".to_string()]);
+
+    let result = registry.resolve_for_skill(&manifest);
+    assert_eq!(
+        result,
+        Err(RegistryError::ToolNotFound {
+            name: "missing_tool".into()
+        })
+    );
+}
+
+#[test]
+fn get_returns_none_for_missing_tool() {
+    let registry = ToolRegistry::new();
+
+    let result = registry.get("nonexistent");
+    assert_eq!(result, None);
+}
+
+#[test]
+fn tool_exists_trait_impl() {
+    let registry = ToolRegistry::new();
+    registry.register(make_entry("web_search")).unwrap();
+
+    let checker: &dyn ToolExists = &registry;
+    assert!(checker.tool_exists("web_search"));
+    assert!(!checker.tool_exists("nonexistent"));
+}


### PR DESCRIPTION
## Summary
- Add `tool-registry` crate with thread-safe `ToolRegistry` storing `ToolEntry` mappings (tool name → MCP endpoint)
- Implement registration, lookup, `resolve_for_skill`, and `ToolExists` trait (moved from `skill-loader` with backward-compatible re-export)
- 21 new tests covering serialization, error display, registry operations, trait implementation, and skill manifest resolution

## Test plan
- [x] `cargo check` — zero errors
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — 98 tests pass (77 existing + 21 new), 0 failures