### PR TITLE
feat(docker): create minimal Dockerfile for static binary deployment (#14)

### DIFF
--- a/.claude/specs/issue-13/add-action-disallowed-variant-to-agent-error.md
+++ b/.claude/specs/issue-13/add-action-disallowed-variant-to-agent-error.md
@@ -1,0 +1,86 @@
+# Spec: Add `ActionDisallowed` variant to `AgentError`
+
+> From: .claude/tasks/issue-13.md
+
+## Objective
+
+Introduce an `ActionDisallowed` error variant so that the constraint enforcement system can report when a tool's action type is not in the agent's allowed actions list. This gives downstream consumers (HTTP callers, orchestrators) a structured, typed signal that a permission boundary was hit, distinct from general failures. The HTTP layer must map this to `403 Forbidden` so clients can distinguish authorization-style rejections from other errors.
+
+## Current State
+
+**`crates/agent-sdk/src/agent_error.rs`** defines `AgentError` as a four-variant enum:
+
+- `ToolCallFailed { tool: String, reason: String }`
+- `ConfidenceTooLow { confidence: f32, threshold: f32 }`
+- `MaxTurnsExceeded { turns: u32 }`
+- `Internal(String)`
+
+The enum derives `Debug, Clone, PartialEq, Serialize, Deserialize` and has a manual `Display` impl with a match arm per variant, plus a blanket `impl std::error::Error`.
+
+**`crates/agent-runtime/src/http.rs`** defines `AppError(pub AgentError)` which implements `IntoResponse`. The `into_response()` method maps each `AgentError` variant to an HTTP status code:
+
+- `ToolCallFailed` -> `502 Bad Gateway`
+- `ConfidenceTooLow` -> `200 OK`
+- `MaxTurnsExceeded` -> `422 Unprocessable Entity`
+- `Internal` -> `500 Internal Server Error`
+
+The response body is the JSON-serialized `AgentError`. The test suite in the same file has one test per variant verifying both the status code and the round-tripped JSON body.
+
+## Requirements
+
+1. Add a new variant `AgentError::ActionDisallowed { action: String, allowed: Vec<String> }` to the `AgentError` enum.
+2. The new variant must participate in all existing derives (`Debug, Clone, PartialEq, Serialize, Deserialize`) without additional manual impls — `Vec<String>` supports all of them.
+3. Implement `Display` for the new variant with the format: `"Action '<action>' is not in allowed actions: [<comma-separated allowed>]"`. For example, `"Action 'write' is not in allowed actions: [read, query]"`.
+4. In `AppError::into_response()`, map `AgentError::ActionDisallowed { .. }` to `StatusCode::FORBIDDEN` (403).
+5. Add a test in `crates/agent-runtime/src/http.rs` (in the existing `mod tests` block) that constructs an `ActionDisallowed` error, converts it through `AppError::into_response()`, asserts the status is `403 Forbidden`, and round-trips the JSON body back to `AgentError` for equality.
+6. All existing tests must continue to pass unchanged.
+
+## Implementation Details
+
+### File: `crates/agent-sdk/src/agent_error.rs`
+
+- Add variant to the `AgentError` enum:
+  ```
+  ActionDisallowed { action: String, allowed: Vec<String> }
+  ```
+- Add a match arm in the `Display` impl:
+  ```
+  AgentError::ActionDisallowed { action, allowed } => {
+      write!(f, "Action '{}' is not in allowed actions: [{}]", action, allowed.join(", "))
+  }
+  ```
+
+### File: `crates/agent-runtime/src/http.rs`
+
+- Add a match arm in `IntoResponse for AppError`:
+  ```
+  AgentError::ActionDisallowed { .. } => StatusCode::FORBIDDEN,
+  ```
+- Add a test following the exact pattern of existing tests (e.g., `internal_returns_500`):
+  - Construct `AgentError::ActionDisallowed { action: "write".into(), allowed: vec!["read".into(), "query".into()] }`
+  - Assert status is `StatusCode::FORBIDDEN`
+  - Deserialize body and assert equality with the original error
+
+### No new files are created.
+
+### No new dependencies are required.
+
+## Dependencies
+
+- Blocked by: none
+- Blocking: "Filter tools by `allowed_actions` in tool resolution"
+
+## Risks & Edge Cases
+
+- **Exhaustive match breakage**: Adding a variant to `AgentError` will cause compile errors in any `match` on `AgentError` that lacks a wildcard arm. The only known match sites are `Display` in `agent_error.rs` and `into_response` in `http.rs` — both are modified in this task. Verify with `cargo check` that no other crates have exhaustive matches on `AgentError`.
+- **Serde backwards compatibility**: The new variant uses serde's default externally-tagged enum encoding, producing `{"ActionDisallowed":{"action":"...","allowed":[...]}}`. Existing JSON with only the four original variants will continue to deserialize correctly. Older consumers that receive the new variant will fail to deserialize it — this is acceptable for a pre-1.0 project.
+- **Empty `allowed` list**: The `Display` format handles an empty `allowed` list gracefully, producing `"Action 'write' is not in allowed actions: []"`. No special-casing needed.
+
+## Verification
+
+1. `cargo check --workspace` compiles with no errors.
+2. `cargo clippy --workspace` produces no warnings related to the changed files.
+3. `cargo test --workspace` passes all tests, including:
+   - The new `action_disallowed_returns_403` test (or similar name) in `crates/agent-runtime/src/http.rs`.
+   - All four existing `AppError` status code tests remain green.
+4. Manually confirm the `Display` output matches the specified format by inspecting the test or adding a unit test in `agent_error.rs` that calls `.to_string()` on an `ActionDisallowed` value and asserts the string.

--- a/.claude/specs/issue-13/add-escalate-to-field-to-agent-response.md
+++ b/.claude/specs/issue-13/add-escalate-to-field-to-agent-response.md
@@ -1,0 +1,91 @@
+# Spec: Add `escalate_to` field to `AgentResponse`
+
+> From: .claude/tasks/issue-13.md
+
+## Objective
+
+Add an `escalate_to: Option<String>` field to `AgentResponse` so that when a ConstraintEnforcer (Group 3) detects low confidence, it can stamp the response with the name of the agent or entity to escalate to. This is the first prerequisite for runtime constraint enforcement: the response struct must be able to carry escalation metadata before the enforcer can populate it.
+
+## Current State
+
+`AgentResponse` in `crates/agent-sdk/src/agent_response.rs` has five fields:
+
+```rust
+pub struct AgentResponse {
+    pub id: Uuid,
+    pub output: Value,
+    pub confidence: f32,
+    pub escalated: bool,
+    pub tool_calls: Vec<ToolCallRecord>,
+}
+```
+
+The `success()` constructor initializes `escalated: false` and does not reference any escalation target.
+
+The `Constraints` struct already carries `escalate_to: Option<String>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`, which is the pattern to follow.
+
+Two test files construct `AgentResponse` using struct literals (not the `success()` constructor):
+
+- `crates/agent-sdk/tests/micro_agent_test.rs` (line 58-64): builds `AgentResponse` inside `MockAgent::invoke()`.
+- `crates/agent-runtime/tests/http_test.rs` (line 69-75): builds `AgentResponse` inside `MockAgent::invoke()`.
+
+Both will fail to compile after adding the new field unless they are updated.
+
+## Requirements
+
+1. Add `pub escalate_to: Option<String>` to the `AgentResponse` struct.
+2. Annotate it with `#[serde(default, skip_serializing_if = "Option::is_none")]` so that:
+   - Deserializing JSON that omits `escalate_to` produces `None` (backward-compatible reads).
+   - Serializing a response where `escalate_to` is `None` omits the key entirely (backward-compatible writes).
+3. The `AgentResponse::success()` constructor must initialize `escalate_to: None`.
+4. The `AgentResponse` struct must continue to derive `JsonSchema` (the `Option<String>` field is natively supported by schemars).
+5. All struct-literal constructions of `AgentResponse` in test files must include `escalate_to: None` to compile.
+6. Existing tests must continue to pass with no behavioral change.
+7. `cargo check`, `cargo clippy`, and `cargo test` must all succeed after the change.
+
+## Implementation Details
+
+### Files to modify
+
+1. **`crates/agent-sdk/src/agent_response.rs`**
+   - Add the field after `escalated`:
+     ```rust
+     #[serde(default, skip_serializing_if = "Option::is_none")]
+     pub escalate_to: Option<String>,
+     ```
+   - Update `success()` to include `escalate_to: None`.
+
+2. **`crates/agent-sdk/tests/micro_agent_test.rs`**
+   - In the `MockAgent::invoke()` impl (around line 58-64), add `escalate_to: None` to the `AgentResponse` struct literal.
+
+3. **`crates/agent-runtime/tests/http_test.rs`**
+   - In the `MockAgent::invoke()` impl (around line 69-75), add `escalate_to: None` to the `AgentResponse` struct literal.
+
+### No new types or functions
+
+This task adds a single field and updates existing sites. No new modules, traits, or functions are introduced.
+
+### Integration points
+
+- The `ConstraintEnforcer` (Group 3, next task) will read `manifest.constraints.escalate_to` and write it into `response.escalate_to` when confidence is below threshold.
+- The HTTP layer serializes `AgentResponse` via serde; the `skip_serializing_if` annotation ensures the new field is invisible to existing consumers unless populated.
+
+## Dependencies
+
+- Blocked by: none
+- Blocking: "Implement ConstraintEnforcer struct with confidence and escalation checks"
+
+## Risks & Edge Cases
+
+- **Forgotten construction sites**: If any other file constructs `AgentResponse` via struct literal (not `success()`), it will fail to compile. A workspace-wide `cargo check` will catch this. The two known sites are listed above.
+- **Schema generation**: Adding `Option<String>` to a `JsonSchema`-derived struct produces a nullable string in the generated schema. This is the correct representation and should not break any schema consumers.
+- **Field ordering in JSON**: serde serializes fields in declaration order. Placing `escalate_to` immediately after `escalated` keeps related fields adjacent and produces a natural JSON layout. Existing consumers that parse by key name (not position) are unaffected.
+- **f32 vs f64 mismatch**: Not directly relevant to this task, but worth noting that `AgentResponse.confidence` is `f32` while `Constraints.confidence_threshold` is `f64`. The ConstraintEnforcer (downstream) must cast appropriately. No action needed here.
+
+## Verification
+
+1. `cargo check --workspace` compiles with zero errors.
+2. `cargo clippy --workspace` produces no warnings.
+3. `cargo test --workspace` passes all existing tests with no regressions.
+4. Manually confirm that serializing an `AgentResponse` with `escalate_to: None` omits the key from JSON output (can be verified with an assertion in an existing or ad-hoc test).
+5. Manually confirm that deserializing JSON without an `escalate_to` key produces `AgentResponse { escalate_to: None, .. }`.

--- a/.claude/specs/issue-13/filter-tools-by-allowed-actions.md
+++ b/.claude/specs/issue-13/filter-tools-by-allowed-actions.md
@@ -1,0 +1,152 @@
+# Spec: Filter tools by `allowed_actions` in tool resolution
+
+> From: .claude/tasks/issue-13.md
+
+## Objective
+
+Enforce skill-level `allowed_actions` constraints by filtering MCP tools at resolution time, before they are ever presented to the LLM. Tools that carry an `action_type` not listed in the skill's `allowed_actions` are excluded from the resolved tool set. This is structural enforcement: the LLM cannot call a disallowed tool because it never sees it.
+
+## Current State
+
+### `ToolEntry` (`crates/tool-registry/src/tool_entry.rs`)
+
+The `ToolEntry` struct has four fields: `name`, `version`, `endpoint`, and `handle`. There is no field to classify a tool by action category. The manual `Clone` impl copies all fields except `handle` (set to `None`), and the `PartialEq` impl compares `name`, `version`, and `endpoint`.
+
+### `resolve_mcp_tools()` (`crates/agent-runtime/src/tool_bridge.rs`)
+
+Takes `&ToolRegistry` and `&SkillManifest`. Calls `registry.resolve_for_skill(manifest)` to get entries matching the manifest's `tools` list, then queries each entry's MCP handle to list available tools. Returns a flat `Vec<McpTool>` with no filtering beyond what the manifest names.
+
+### `Constraints` (`crates/agent-sdk/src/constraints.rs`)
+
+Already defines `allowed_actions: Vec<String>` on the `Constraints` struct, which is accessible via `manifest.constraints.allowed_actions`.
+
+### `main.rs` (`crates/agent-runtime/src/main.rs`)
+
+Constructs `ToolEntry` values from `TOOL_ENDPOINTS` env var with `name`, `version`, `endpoint`, and `handle: None`. The `resolve_tools()` helper in `provider.rs` calls `tool_bridge::resolve_mcp_tools(registry, manifest)` and currently does not pass `allowed_actions`.
+
+### `provider.rs` (`crates/agent-runtime/src/provider.rs`)
+
+The `resolve_tools()` helper calls `tool_bridge::resolve_mcp_tools(registry, manifest)`. The `build_agent()` function passes the full manifest so `allowed_actions` is available at this call site.
+
+## Requirements
+
+1. **New field on `ToolEntry`**: Add `action_type: Option<String>` to `ToolEntry`. When `None`, the tool is unrestricted (included regardless of `allowed_actions`). When `Some(t)`, the tool is categorized as action type `t` and subject to filtering.
+
+2. **Serde annotation**: The new field must have `#[serde(default, skip_serializing_if = "Option::is_none")]` so existing serialized entries without the field deserialize correctly and the field is omitted from JSON when `None`.
+
+3. **Updated `Clone` impl**: The manual `Clone` implementation must copy `action_type`.
+
+4. **Updated `PartialEq` impl**: The manual `PartialEq` implementation must compare `action_type`.
+
+5. **Signature change on `resolve_mcp_tools()`**: Accept an additional parameter `allowed_actions: &[String]` representing the skill's allowed action types.
+
+6. **Filtering logic**: After `registry.resolve_for_skill(manifest)` returns entries but before querying MCP handles, filter entries by action type:
+   - If `allowed_actions` is empty, include all entries (no restriction).
+   - If `allowed_actions` is non-empty:
+     - Include entries where `action_type` is `None` (unrestricted tools always pass).
+     - Include entries where `action_type` is `Some(t)` and `t` is in `allowed_actions`.
+     - Exclude entries where `action_type` is `Some(t)` and `t` is not in `allowed_actions`.
+
+7. **Updated call sites**: All callers of `resolve_mcp_tools()` must pass the allowed actions slice. Currently the only caller is `resolve_tools()` in `provider.rs`, which must pass `&manifest.constraints.allowed_actions`.
+
+8. **Updated `ToolEntry` construction in `main.rs`**: The `register_tool_endpoints()` function must include `action_type: None` in the `ToolEntry` struct literal. Optionally, extend the `TOOL_ENDPOINTS` env var format to support action types (e.g., `name=endpoint:action_type`), but this is not required for this task — `None` is a safe default since unrestricted tools always pass the filter.
+
+## Implementation Details
+
+### File: `crates/tool-registry/src/tool_entry.rs`
+
+- Add field to the struct:
+  ```rust
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub action_type: Option<String>,
+  ```
+- Update `Clone` impl to include `action_type: self.action_type.clone()`.
+- Update `PartialEq` impl to include `&& self.action_type == other.action_type`.
+
+### File: `crates/agent-runtime/src/tool_bridge.rs`
+
+- Change `resolve_mcp_tools()` signature:
+  ```rust
+  pub async fn resolve_mcp_tools(
+      registry: &ToolRegistry,
+      manifest: &SkillManifest,
+      allowed_actions: &[String],
+  ) -> Result<Vec<McpTool>, RegistryError>
+  ```
+- After `let entries = registry.resolve_for_skill(manifest)?;`, add a filtering step:
+  ```rust
+  let entries: Vec<ToolEntry> = if allowed_actions.is_empty() {
+      entries
+  } else {
+      entries
+          .into_iter()
+          .filter(|entry| match &entry.action_type {
+              None => true,
+              Some(t) => allowed_actions.iter().any(|a| a == t),
+          })
+          .collect()
+  };
+  ```
+- The rest of the function (MCP handle querying, McpTool creation) remains unchanged.
+
+### File: `crates/agent-runtime/src/provider.rs`
+
+- Update `resolve_tools()` to pass `allowed_actions`:
+  ```rust
+  async fn resolve_tools(
+      registry: &ToolRegistry,
+      manifest: &SkillManifest,
+  ) -> Result<Vec<rig::tool::rmcp::McpTool>, ProviderError> {
+      tool_bridge::resolve_mcp_tools(registry, manifest, &manifest.constraints.allowed_actions)
+          .await
+          .map_err(|e| ProviderError::ClientBuild(e.to_string()))
+  }
+  ```
+
+### File: `crates/agent-runtime/src/main.rs`
+
+- Update the `ToolEntry` construction in `register_tool_endpoints()` to include `action_type: None`.
+
+### File: `crates/tool-registry/src/tool_registry.rs`
+
+- Update `resolve_for_skill()` to include `action_type` in the cloned `ToolEntry`:
+  ```rust
+  .map(|entry| ToolEntry {
+      name: entry.name.clone(),
+      version: entry.version.clone(),
+      endpoint: entry.endpoint.clone(),
+      handle: entry.handle.clone(),
+      action_type: entry.action_type.clone(),
+  })
+  ```
+
+### Files that construct `ToolEntry` in tests
+
+- Any test file that constructs `ToolEntry` directly (e.g., `crates/tool-registry/tests/tool_registry_test.rs`) must be updated to include `action_type: None` (or a specific value for filter-testing purposes).
+
+## Dependencies
+
+- **Blocked by**: "Add `ActionDisallowed` variant to `AgentError`" — The `ActionDisallowed` variant must exist on `AgentError` before this task lands. Although this task's filtering logic does not raise `ActionDisallowed` directly (it silently excludes tools), the variant establishes the broader pattern and the HTTP status mapping (403 Forbidden) that downstream tasks depend on. Both tasks ship together in Group 2.
+- **Blocking**: "Write tests for allowed_actions filtering" — Tests will exercise the filtering logic added here, verifying inclusion/exclusion behavior for various `action_type` and `allowed_actions` combinations.
+
+## Risks & Edge Cases
+
+1. **All tools filtered out**: If `allowed_actions` is non-empty and every resolved tool has an `action_type` that is not in the list, `resolve_mcp_tools()` returns an empty `Vec<McpTool>`. The agent will have no tools and can only respond with text. This is correct behavior (the skill author intentionally restricted actions), but downstream callers should handle a toolless agent gracefully. No code change is needed here — rig-core supports agents with zero tools.
+
+2. **Case sensitivity**: `action_type` matching is case-sensitive string comparison. The skill manifest's `allowed_actions` and the tool entry's `action_type` must use the same casing. Document this as a convention (e.g., lowercase: `"read"`, `"write"`, `"query"`).
+
+3. **Backward compatibility of `ToolEntry` serialization**: The `#[serde(default, skip_serializing_if = "Option::is_none")]` annotation ensures existing JSON without `action_type` deserializes to `None`, and entries with `action_type: None` omit the field from output. No breaking change.
+
+4. **Existing tests that construct `ToolEntry`**: The struct literal gains a new field. All existing test files and production code that construct `ToolEntry` must be updated. The compiler will catch missing fields, so this is a compile-time error, not a runtime risk.
+
+5. **`TOOL_ENDPOINTS` env var format**: This task sets `action_type: None` for all entries parsed from the env var. A future task could extend the format to support `name=endpoint@action_type`, but that is out of scope here.
+
+6. **Performance**: The filter is applied to a small in-memory `Vec<ToolEntry>` (typically single digits). No performance concern.
+
+## Verification
+
+1. **Compilation**: `cargo check` succeeds across the entire workspace with no errors.
+2. **Lint**: `cargo clippy` passes with no warnings.
+3. **Existing tests**: `cargo test` passes — all existing tests still work after updating `ToolEntry` construction sites.
+4. **Manual inspection**: Confirm that `resolve_mcp_tools()` accepts the new `allowed_actions` parameter and that the filtering logic matches the specification (empty = no filter, `None` action_type = always included, `Some(t)` = included only if `t` is in `allowed_actions`).
+5. **Downstream readiness**: The signature change is reflected in `provider.rs` and the `ToolEntry` struct literal in `main.rs` includes `action_type: None`.

--- a/.claude/specs/issue-13/implement-constraint-enforcer.md
+++ b/.claude/specs/issue-13/implement-constraint-enforcer.md
@@ -1,0 +1,156 @@
+# Spec: Implement ConstraintEnforcer struct with confidence and escalation checks
+
+> From: .claude/tasks/issue-13.md
+
+## Objective
+
+Create a decorator (wrapper) struct `ConstraintEnforcer` that sits between the HTTP layer and the inner `RuntimeAgent`, intercepting every `invoke()` response to enforce the confidence-threshold constraint declared in the agent's skill manifest. When the agent's self-reported confidence falls below the threshold, the enforcer marks the response as escalated (with optional target) rather than returning an error. This keeps low-confidence results visible to the caller while signaling that a more capable agent should handle the request.
+
+## Current State
+
+### MicroAgent trait (`crates/agent-sdk/src/micro_agent.rs`)
+
+The `MicroAgent` trait is async-trait-based and dyn-compatible. It has three methods:
+
+- `fn manifest(&self) -> &SkillManifest` -- returns the agent's manifest by reference
+- `async fn invoke(&self, request: AgentRequest) -> Result<AgentResponse, AgentError>` -- processes a request
+- `async fn health(&self) -> HealthStatus` -- returns current health
+
+### AgentResponse (`crates/agent-sdk/src/agent_response.rs`)
+
+Currently has fields: `id: Uuid`, `output: Value`, `confidence: f32`, `escalated: bool`, `tool_calls: Vec<ToolCallRecord>`. The `success()` constructor sets `confidence: 1.0` and `escalated: false`.
+
+**Note:** This task is blocked by the addition of `escalate_to: Option<String>` to `AgentResponse`. The spec assumes that field will exist when implementation begins.
+
+### Constraints (`crates/agent-sdk/src/constraints.rs`)
+
+```rust
+pub struct Constraints {
+    pub max_turns: u32,
+    pub confidence_threshold: f64,     // f64, not f32
+    pub escalate_to: Option<String>,   // target agent name
+    pub allowed_actions: Vec<String>,
+}
+```
+
+Key detail: `confidence_threshold` is `f64` while `AgentResponse.confidence` is `f32`. The comparison requires casting `response.confidence as f64`.
+
+### SkillManifest (`crates/agent-sdk/src/skill_manifest.rs`)
+
+Contains a `constraints: Constraints` field, accessible via `manifest().constraints`.
+
+### RuntimeAgent (`crates/agent-runtime/src/runtime_agent.rs`)
+
+The existing `MicroAgent` implementor. It holds a `SkillManifest`, a `BuiltAgent` (LLM backend), and a `ToolRegistry`. Its `manifest()` returns `&self.manifest` by reference.
+
+### Current module registration (`crates/agent-runtime/src/lib.rs`)
+
+```rust
+pub mod config;
+pub mod http;
+pub mod provider;
+pub mod runtime_agent;
+pub mod tool_bridge;
+```
+
+### Wiring in main.rs (`crates/agent-runtime/src/main.rs`)
+
+Currently wraps `RuntimeAgent` directly into `Arc<dyn MicroAgent>`:
+```rust
+let runtime_agent = RuntimeAgent::new(manifest, agent, registry.clone());
+let micro_agent: Arc<dyn MicroAgent> = Arc::new(runtime_agent);
+```
+The future "Wire ConstraintEnforcer into main.rs" task will insert the enforcer between these two lines.
+
+## Requirements
+
+1. **Create `ConstraintEnforcer` struct** in a new file `crates/agent-runtime/src/constraint_enforcer.rs` that wraps an `Arc<dyn MicroAgent>`.
+
+2. **Implement `MicroAgent` for `ConstraintEnforcer`** using `#[async_trait]`:
+   - `manifest()` delegates to `self.inner.manifest()`.
+   - `health()` delegates to `self.inner.health().await`.
+   - `invoke()` delegates to `self.inner.invoke(request).await`, then performs a post-invocation confidence check on the `Ok` response.
+
+3. **Confidence check logic in `invoke()`**: After receiving a successful response from the inner agent:
+   - Read `self.inner.manifest().constraints.confidence_threshold` (f64).
+   - Cast `response.confidence` (f32) to f64 for comparison.
+   - If `(response.confidence as f64) < confidence_threshold`:
+     - Set `response.escalated = true`.
+     - Set `response.escalate_to = manifest.constraints.escalate_to.clone()`.
+   - Return the (possibly mutated) response as `Ok(response)`. This is not an error path.
+
+4. **Error passthrough**: If the inner agent returns `Err(...)`, the enforcer must propagate it unchanged without any confidence check.
+
+5. **Constructor**: Provide `ConstraintEnforcer::new(inner: Arc<dyn MicroAgent>) -> Self`.
+
+6. **Module registration**: Add `pub mod constraint_enforcer;` to `crates/agent-runtime/src/lib.rs`.
+
+7. **No new dependencies**: The implementation uses only `std::sync::Arc`, `agent_sdk` types, and `async_trait` -- all already available in `agent-runtime`.
+
+## Implementation Details
+
+### Files to create
+
+**`crates/agent-runtime/src/constraint_enforcer.rs`**
+
+- Define `ConstraintEnforcer` with a single field `inner: Arc<dyn MicroAgent>`.
+- Implement `ConstraintEnforcer::new(inner: Arc<dyn MicroAgent>) -> Self`.
+- Implement `MicroAgent` for `ConstraintEnforcer` via `#[async_trait]`:
+  - `manifest()` returns `self.inner.manifest()` (direct delegation, same lifetime).
+  - `health()` returns `self.inner.health().await` (direct delegation).
+  - `invoke()`:
+    1. Call `let mut response = self.inner.invoke(request).await?;` -- the `?` propagates errors immediately.
+    2. Read `let manifest = self.inner.manifest();`
+    3. Read `let threshold = manifest.constraints.confidence_threshold;`
+    4. Compare: `if (response.confidence as f64) < threshold`
+    5. If true: set `response.escalated = true;` and `response.escalate_to = manifest.constraints.escalate_to.clone();`
+    6. Return `Ok(response)`.
+
+### Files to modify
+
+**`crates/agent-runtime/src/lib.rs`**
+
+- Add `pub mod constraint_enforcer;` to the module list.
+
+### Key types and interfaces
+
+| Type | Role |
+|------|------|
+| `ConstraintEnforcer` | Decorator struct wrapping `Arc<dyn MicroAgent>` |
+| `ConstraintEnforcer::new()` | Constructor taking the inner agent |
+| `MicroAgent` impl | Delegates manifest/health, intercepts invoke for confidence check |
+
+### Integration points
+
+- **Downstream (blocked by)**: Requires `AgentResponse.escalate_to: Option<String>` to exist.
+- **Upstream (blocking)**: The "Wire ConstraintEnforcer into main.rs" task will wrap `RuntimeAgent` with this enforcer before passing to the HTTP layer.
+- **The decorator pattern** preserves the `Arc<dyn MicroAgent>` contract so no changes are needed to `http.rs`, `AppState`, or any handler code.
+
+## Dependencies
+
+- **Blocked by**: "Add `escalate_to` field to `AgentResponse`" -- the `response.escalate_to` field must exist before this code can compile.
+- **Blocking**: "Wire ConstraintEnforcer into main.rs" -- that task inserts `ConstraintEnforcer::new(Arc::new(runtime_agent))` between agent construction and HTTP server startup.
+
+## Risks & Edge Cases
+
+1. **Type mismatch (f32 vs f64)**: `confidence` is `f32`, `confidence_threshold` is `f64`. The cast `response.confidence as f64` is lossless (f32 fits in f64) but could introduce subtle floating-point comparison issues. For example, `0.85_f32 as f64` becomes `0.8500000238418579_f64`, which is strictly greater than `0.85_f64`. This means a response with `confidence: 0.85_f32` would NOT be escalated against a `confidence_threshold: 0.85_f64`. This is arguably correct (threshold is "below", not "at or below"), but the implementer should be aware of it. The task description specifies strict `<` comparison, so follow that.
+
+2. **`manifest()` lifetime**: `ConstraintEnforcer::manifest()` returns `&SkillManifest`. Since it delegates to `self.inner.manifest()`, the returned reference borrows from `self.inner` (which is behind `Arc`), so the lifetime is tied to `&self`. This works correctly with the trait signature `fn manifest(&self) -> &SkillManifest`.
+
+3. **Confidence at exactly the threshold**: Per the `<` comparison, a response with `confidence` exactly equal to the threshold (after casting) is NOT escalated. This matches the task description.
+
+4. **`escalate_to` is `None` in constraints**: If the manifest has `escalate_to: None`, the enforcer will still set `response.escalated = true` but `response.escalate_to` will be `None`. This is valid -- the caller sees "escalation needed" but must decide the target. The downstream test suite explicitly covers this case.
+
+5. **Thread safety**: `ConstraintEnforcer` holds `Arc<dyn MicroAgent>` where `MicroAgent: Send + Sync`. The struct itself derives neither, but `Arc<dyn MicroAgent>` is `Send + Sync`, so `ConstraintEnforcer` is automatically `Send + Sync`. The `#[async_trait]` macro requires this for `MicroAgent`.
+
+6. **No mutation of inner agent**: The enforcer only mutates the response, never the inner agent's state. This is a pure post-processing decorator.
+
+## Verification
+
+1. **Compiles**: `cargo check -p agent-runtime` succeeds with no errors.
+2. **No warnings**: `cargo clippy -p agent-runtime` produces no warnings.
+3. **Unit tests pass**: `cargo test -p agent-runtime` passes (existing tests unaffected).
+4. **Full workspace**: `cargo test` passes across all crates.
+5. **Module is public**: `constraint_enforcer` appears in `crates/agent-runtime/src/lib.rs` and `ConstraintEnforcer` is importable as `agent_runtime::constraint_enforcer::ConstraintEnforcer`.
+6. **Manual review**: Confirm that `invoke()` returns `Ok(response)` with `escalated: true` when confidence is below threshold (not `Err`). Confirm that errors from the inner agent pass through without modification.
+7. **Function size**: All functions remain under 50 lines per project rules.

--- a/.claude/specs/issue-13/map-max-turns-error.md
+++ b/.claude/specs/issue-13/map-max-turns-error.md
@@ -1,0 +1,233 @@
+# Spec: Map rig-core MaxTurnsError to AgentError::MaxTurnsExceeded
+
+> From: .claude/tasks/issue-13.md
+
+## Objective
+
+Translate rig-core's `PromptError::MaxTurnsError` into the domain-specific `AgentError::MaxTurnsExceeded { turns }` so that HTTP consumers receive a semantically meaningful 422 response (via the existing `AppError` mapping) instead of a generic 500 Internal Server Error. This requires improving the error pipeline in `BuiltAgent::prompt()` and `RuntimeAgent::invoke()` to distinguish max-turns exhaustion from other prompt failures.
+
+## Current State
+
+### `crates/agent-runtime/src/provider.rs` -- `ProviderError` and `BuiltAgent::prompt()`
+
+`ProviderError` is an enum with four variants:
+
+```rust
+pub enum ProviderError {
+    UnsupportedProvider { provider: String },
+    MissingApiKey { provider: String, env_var: String },
+    ClientBuild(String),
+    Prompt(String),
+}
+```
+
+`BuiltAgent::prompt()` calls rig-core's `Agent::prompt()` (which returns `Result<String, PromptError>`) and maps all errors uniformly to `ProviderError::Prompt(e.to_string())`:
+
+```rust
+pub async fn prompt(&self, input: &str) -> Result<String, ProviderError> {
+    match self {
+        Self::OpenAi(agent) => agent
+            .prompt(input)
+            .await
+            .map_err(|e| ProviderError::Prompt(e.to_string())),
+        Self::Anthropic(agent) => agent
+            .prompt(input)
+            .await
+            .map_err(|e| ProviderError::Prompt(e.to_string())),
+    }
+}
+```
+
+This erases the typed `PromptError` enum, making it impossible for callers to distinguish `MaxTurnsError` from other prompt failures without inspecting the stringified message.
+
+### Rig-core `PromptError` (v0.32)
+
+In `rig-core-0.32.0/src/completion/request.rs`:
+
+```rust
+#[derive(Debug, Error)]
+pub enum PromptError {
+    #[error("CompletionError: {0}")]
+    CompletionError(#[from] CompletionError),
+    #[error("ToolCallError: {0}")]
+    ToolError(#[from] ToolSetError),
+    #[error("ToolServerError: {0}")]
+    ToolServerError(#[from] ToolServerError),
+    #[error("MaxTurnError: (reached max turn limit: {max_turns})")]
+    MaxTurnsError {
+        max_turns: usize,
+        chat_history: Box<Vec<Message>>,
+        prompt: Box<Message>,
+    },
+    #[error("PromptCancelled: {reason}")]
+    PromptCancelled {
+        chat_history: Box<Vec<Message>>,
+        reason: String,
+    },
+}
+```
+
+The `#[error]` attribute produces the display string `"MaxTurnError: (reached max turn limit: N)"`. Note: the display text uses `MaxTurnError` (singular), not `MaxTurnsError`.
+
+### `crates/agent-runtime/src/runtime_agent.rs` -- `RuntimeAgent::invoke()`
+
+```rust
+async fn invoke(&self, request: AgentRequest) -> Result<AgentResponse, AgentError> {
+    let output = self
+        .agent
+        .prompt(&request.input)
+        .await
+        .map_err(|e| AgentError::Internal(e.to_string()))?;
+    Ok(AgentResponse::success(request.id, Value::String(output)))
+}
+```
+
+All `ProviderError` variants are collapsed into `AgentError::Internal(String)`, losing the ability to surface `MaxTurnsExceeded` as a distinct error to the HTTP layer.
+
+### `crates/agent-sdk/src/agent_error.rs` -- `AgentError`
+
+```rust
+pub enum AgentError {
+    ToolCallFailed { tool: String, reason: String },
+    ConfidenceTooLow { confidence: f32, threshold: f32 },
+    MaxTurnsExceeded { turns: u32 },
+    Internal(String),
+}
+```
+
+The `MaxTurnsExceeded` variant already exists and is mapped to HTTP 422 in `crates/agent-runtime/src/http.rs`.
+
+### `crates/agent-sdk/src/constraints.rs` -- `Constraints`
+
+```rust
+pub struct Constraints {
+    pub max_turns: u32,
+    // ...
+}
+```
+
+`max_turns` is a `u32`, matching the `turns` field on `AgentError::MaxTurnsExceeded`.
+
+## Requirements
+
+1. `ProviderError` must gain a new variant `MaxTurnsExceeded { max_turns: u32 }` to carry typed max-turns errors out of `BuiltAgent::prompt()` without relying on string matching.
+2. `BuiltAgent::prompt()` must pattern-match on `PromptError::MaxTurnsError` and map it to `ProviderError::MaxTurnsExceeded { max_turns: e.max_turns as u32 }`. All other `PromptError` variants continue to map to `ProviderError::Prompt(e.to_string())`.
+3. `RuntimeAgent::invoke()` must match `ProviderError::MaxTurnsExceeded` and produce `AgentError::MaxTurnsExceeded { turns: manifest.constraints.max_turns }` instead of `AgentError::Internal(...)`.
+4. All other `ProviderError` variants must continue to map to `AgentError::Internal(e.to_string())` in `invoke()`.
+5. `ProviderError::MaxTurnsExceeded` must implement `Display` with a message like `"max turns exceeded: {max_turns} turns"`.
+6. No new crate dependencies may be added.
+7. `cargo check --workspace`, `cargo clippy --workspace`, and `cargo test --workspace` must all pass.
+
+## Implementation Details
+
+### Files to modify
+
+1. **`crates/agent-runtime/src/provider.rs`**
+
+   - **Add `MaxTurnsExceeded` variant to `ProviderError`**:
+     ```rust
+     pub enum ProviderError {
+         UnsupportedProvider { provider: String },
+         MissingApiKey { provider: String, env_var: String },
+         ClientBuild(String),
+         Prompt(String),
+         MaxTurnsExceeded { max_turns: u32 },
+     }
+     ```
+
+   - **Add `Display` arm** for the new variant in the existing `impl fmt::Display for ProviderError`:
+     ```rust
+     Self::MaxTurnsExceeded { max_turns } => {
+         write!(f, "max turns exceeded: {max_turns} turns")
+     }
+     ```
+
+   - **Import `PromptError`** at the top of the file. Based on rig-core source, the correct import is `rig::completion::PromptError`.
+
+   - **Extract a private helper** to avoid duplicating the error-mapping closure across both `BuiltAgent` arms:
+     ```rust
+     fn map_prompt_error(e: PromptError) -> ProviderError {
+         match e {
+             PromptError::MaxTurnsError { max_turns, .. } => {
+                 ProviderError::MaxTurnsExceeded { max_turns: max_turns as u32 }
+             }
+             other => ProviderError::Prompt(other.to_string()),
+         }
+     }
+     ```
+
+   - **Update `BuiltAgent::prompt()`** to use the helper in both `OpenAi` and `Anthropic` arms:
+     ```rust
+     Self::OpenAi(agent) => agent.prompt(input).await.map_err(map_prompt_error),
+     Self::Anthropic(agent) => agent.prompt(input).await.map_err(map_prompt_error),
+     ```
+
+   - **Add a unit test** in the existing `#[cfg(test)] mod tests` block:
+     ```rust
+     #[test]
+     fn max_turns_exceeded_displays_count() {
+         let err = ProviderError::MaxTurnsExceeded { max_turns: 5 };
+         assert!(err.to_string().contains("5"));
+     }
+     ```
+
+2. **`crates/agent-runtime/src/runtime_agent.rs`**
+
+   - **Import `ProviderError`** from `crate::provider::ProviderError`.
+
+   - **Update `invoke()` error mapping** to distinguish `MaxTurnsExceeded` from other errors. Replace the single `.map_err(|e| AgentError::Internal(e.to_string()))` with a match:
+     ```rust
+     .map_err(|e| match e {
+         ProviderError::MaxTurnsExceeded { .. } => AgentError::MaxTurnsExceeded {
+             turns: self.manifest.constraints.max_turns,
+         },
+         other => AgentError::Internal(other.to_string()),
+     })
+     ```
+
+### Key design decision: typed variant vs. string matching
+
+The task breakdown mentions two approaches: (a) check for the `"MaxTurnError"` substring in the stringified error, or (b) improve `ProviderError` to carry a typed variant. This spec chooses approach (b) -- adding `ProviderError::MaxTurnsExceeded` -- for the following reasons:
+
+- **Reliability**: String matching is fragile; if rig-core changes the error message format, the detection breaks silently. A typed match produces a compile-time error if the upstream enum changes.
+- **Consistency**: The codebase already uses typed error enums (`AgentError`, `ProviderError`). Adding a variant follows the established pattern.
+- **Minimal cost**: Adding one enum variant, one `Display` arm, and one helper function is low effort and does not introduce new dependencies.
+
+### Why `manifest.constraints.max_turns` instead of `PromptError::MaxTurnsError::max_turns`
+
+`PromptError::MaxTurnsError::max_turns` is `usize` and reflects the rig-core turn limit (which may differ from the manifest value due to the `as usize` cast, though in practice they are identical on 64-bit platforms). Using `manifest.constraints.max_turns` is preferred because:
+
+- It is the authoritative source of the constraint as declared in the skill file.
+- It avoids a `usize` to `u32` downcast (which would need a `try_from` or silent narrowing).
+- The `AgentError::MaxTurnsExceeded { turns }` field semantically means "the configured limit", not "the internal loop counter".
+
+## Dependencies
+
+- Blocked by: "Set `default_max_turns` from constraints at agent build time" -- without `default_max_turns` being wired into the agent builder, rig-core will never produce `PromptError::MaxTurnsError`, making this mapping dead code.
+- Blocking: "Wire ConstraintEnforcer into main.rs" -- the constraint enforcer needs the max-turns error to be properly surfaced so that the full enforcement pipeline is functional.
+
+## Risks & Edge Cases
+
+1. **`PromptError` may not be re-exported from `rig::completion`**: The import path must be verified. Based on the rig-core source (`src/completion/request.rs` defines `PromptError`, and `src/completion/mod.rs` re-exports it), the correct import is `rig::completion::PromptError`. If this is not publicly accessible, the implementation must use the full path or fall back to string matching.
+
+2. **`usize` to `u32` narrowing in `map_prompt_error`**: `PromptError::MaxTurnsError::max_turns` is `usize`. Casting to `u32` could narrow on 64-bit if the value exceeds `u32::MAX` (~4 billion turns). This is unrealistic in practice since skill manifests are validated with `max_turns` being greater than 0 and practical limits are single digits. A `u32::try_from(...).unwrap_or(u32::MAX)` guard is acceptable but not strictly necessary.
+
+3. **Exhaustive match on `ProviderError` in `invoke()`**: Other code that matches on `ProviderError` (currently only `invoke()`) must handle the new variant. Since the match uses an `other` wildcard for the fallthrough, this is automatically covered, but the implementer should verify no other call sites exist.
+
+4. **`PromptError` variants may grow**: Future rig-core versions may add new `PromptError` variants. The `other` catch-all arm mapping to `ProviderError::Prompt(other.to_string())` in `map_prompt_error` handles this gracefully.
+
+5. **Thread safety**: `RuntimeAgent::invoke()` accesses `self.manifest.constraints.max_turns` which is immutable after construction. No synchronization concerns.
+
+## Verification
+
+1. `cargo check --workspace` compiles without errors, confirming that `PromptError::MaxTurnsError` can be pattern-matched in `BuiltAgent::prompt()`.
+2. `cargo clippy --workspace` produces no new warnings.
+3. `cargo test --workspace` passes all existing tests with no regressions, including:
+   - `ProviderError` display tests in `crates/agent-runtime/src/provider.rs`.
+   - `RuntimeAgent` tests in `crates/agent-runtime/tests/runtime_agent_test.rs`.
+   - HTTP handler tests in `crates/agent-runtime/tests/http_test.rs`.
+4. The new `max_turns_exceeded_displays_count` test in `provider.rs` passes.
+5. Manual code review confirms:
+   - `BuiltAgent::prompt()` matches on `PromptError::MaxTurnsError` and produces `ProviderError::MaxTurnsExceeded`.
+   - `RuntimeAgent::invoke()` matches on `ProviderError::MaxTurnsExceeded` and produces `AgentError::MaxTurnsExceeded { turns: self.manifest.constraints.max_turns }`.
+   - All other error variants fall through to their previous behavior.

--- a/.claude/specs/issue-13/run-verification-suite.md
+++ b/.claude/specs/issue-13/run-verification-suite.md
@@ -1,0 +1,160 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-13.md
+
+## Objective
+
+Execute the full Cargo quality-gate sequence (`cargo check`, `cargo clippy`, `cargo test`) across the entire workspace to confirm that all issue-13 constraint-enforcement changes compile cleanly, produce no clippy warnings, and pass all tests. This is the final task in the issue-13 series and produces no source files. It is a gate that either confirms the work is done or surfaces failures that must be fixed in predecessor tasks.
+
+## Current State
+
+### Workspace layout
+
+The workspace root `Cargo.toml` lists six members:
+- `crates/agent-sdk`
+- `crates/skill-loader`
+- `crates/tool-registry`
+- `crates/agent-runtime`
+- `crates/orchestrator`
+- `tools/echo-tool`
+
+### Changes made by predecessor tasks (issue-13)
+
+By the time this verification task runs, all preceding issue-13 tasks will have been applied:
+
+1. **`AgentResponse`** (`crates/agent-sdk/src/agent_response.rs`) -- new `escalate_to: Option<String>` field with `#[serde(default, skip_serializing_if = "Option::is_none")]`. `AgentResponse::success()` initializes it as `None`.
+2. **`AgentError`** (`crates/agent-sdk/src/agent_error.rs`) -- new `ActionDisallowed { action: String, allowed: Vec<String> }` variant with `Display` impl and HTTP 403 mapping.
+3. **`AppError`** (`crates/agent-runtime/src/http.rs`) -- `into_response()` updated with `ActionDisallowed` mapping to `403 Forbidden`.
+4. **`ToolEntry`** (`crates/tool-registry/src/tool_entry.rs`) -- new `action_type: Option<String>` field.
+5. **`tool_bridge.rs`** (`crates/agent-runtime/src/tool_bridge.rs`) -- `build_agent_with_tools()` accepts `max_turns` and calls `.default_max_turns()`. `resolve_mcp_tools()` accepts `allowed_actions` and filters tools by `action_type`.
+6. **`provider.rs`** (`crates/agent-runtime/src/provider.rs`) -- passes constraints through to `build_agent_with_tools`.
+7. **`constraint_enforcer.rs`** (`crates/agent-runtime/src/constraint_enforcer.rs`) -- new module wrapping `Arc<dyn MicroAgent>` with post-invocation confidence and escalation checks.
+8. **`runtime_agent.rs`** (`crates/agent-runtime/src/runtime_agent.rs`) -- maps `MaxTurnsError` substring to `AgentError::MaxTurnsExceeded`.
+9. **`lib.rs`** (`crates/agent-runtime/src/lib.rs`) -- `pub mod constraint_enforcer;` added.
+10. **`main.rs`** (`crates/agent-runtime/src/main.rs`) -- `RuntimeAgent` wrapped with `ConstraintEnforcer` before HTTP layer.
+11. **New test files**:
+    - `crates/agent-runtime/tests/constraint_enforcer_test.rs` (5 tests for confidence/escalation logic)
+    - `crates/agent-runtime/tests/runtime_agent_test.rs` or equivalent (max_turns mapping test)
+    - `crates/tool-registry/tests/tool_registry_test.rs` or `crates/agent-runtime/tests/tool_bridge_test.rs` (allowed_actions filtering tests)
+12. **Updated test files** (to include `escalate_to` field in `AgentResponse` struct literals):
+    - `crates/agent-sdk/tests/micro_agent_test.rs`
+    - `crates/agent-runtime/tests/http_test.rs`
+
+### Regression-sensitive test files
+
+These existing test files construct `AgentResponse` directly with struct literals and will fail to compile if `escalate_to` is not included:
+
+- `crates/agent-runtime/tests/http_test.rs` -- 6 integration tests (lines 69-75 construct `AgentResponse` without `escalate_to`; predecessor task must have added the field)
+- `crates/agent-sdk/tests/micro_agent_test.rs` -- 7 tests (lines 58-64 construct `AgentResponse` without `escalate_to`; predecessor task must have added the field)
+
+Additionally, `crates/agent-runtime/src/http.rs` has 5 unit tests in a `#[cfg(test)]` block that exercise `AppError::into_response()` for each `AgentError` variant. The new `ActionDisallowed` variant must have a corresponding test, or at minimum must not cause an exhaustive-match compile error.
+
+## Requirements
+
+1. `cargo check` (workspace-wide) exits with code 0 -- all six workspace members compile, including all test targets.
+2. `cargo clippy -- -D warnings` (workspace-wide) exits with code 0 and produces zero warnings. The `-D warnings` flag converts warnings to errors.
+3. `cargo test` (workspace-wide) exits with code 0 and all tests pass with 0 failures across all crates.
+4. No regressions in the pre-existing tests from issue-12:
+   - `crates/agent-runtime/tests/http_test.rs`: all 6 tests pass (`invoke_valid_request_returns_200`, `invoke_internal_error_returns_500`, `invoke_tool_call_failed_returns_502`, `invoke_invalid_json_returns_422`, `health_returns_200_with_healthy_status`, `health_returns_200_with_degraded_status`).
+   - `crates/agent-sdk/tests/micro_agent_test.rs`: all 7 tests pass (`mock_agent_implements_trait`, `trait_object_is_dyn_compatible`, `invoke_returns_ok`, `invoke_returns_err`, `health_status_healthy`, `health_status_degraded`, `health_status_unhealthy`).
+5. All new issue-13 tests pass:
+   - Constraint enforcer tests (confidence above/below threshold, escalation with/without `escalate_to`, delegation of `manifest`/`health`, error propagation).
+   - Allowed-actions filtering tests (tools excluded by `action_type`, tools included when `action_type` matches, tools included when `action_type` is `None`, empty `allowed_actions` passes all tools).
+   - Max-turns enforcement test (`MaxTurnsError` substring mapped to `AgentError::MaxTurnsExceeded`).
+
+## Implementation Details
+
+### Files to create or modify
+
+None. This task runs only command-line tools and inspects their output.
+
+### Commands to run, in order
+
+Run each command from the workspace root (`/workspaces/spore`):
+
+1. **Type-check full workspace**
+   ```
+   cargo check
+   ```
+   Validates: all six workspace members compile, including the new `constraint_enforcer` module, updated `AgentResponse` with `escalate_to`, new `ActionDisallowed` variant, updated `ToolEntry` with `action_type`, and all test targets. Catches missing imports, signature mismatches, exhaustive-match failures from new enum variants, and struct literal completeness.
+
+2. **Lint full workspace**
+   ```
+   cargo clippy -- -D warnings
+   ```
+   Validates: no clippy warnings across any crate. Catches dead code from unused new fields, redundant clones, missing `#[serde(default)]` attributes that should be present, unused imports in new modules, and type casting issues (e.g., `f32` to `f64` confidence comparison).
+
+3. **Test `agent-runtime` crate**
+   ```
+   cargo test -p agent-runtime
+   ```
+   Validates: all integration tests in `tests/http_test.rs` (6 pre-existing), `tests/constraint_enforcer_test.rs` (new, ~5 tests), and any max-turns tests pass. Also runs unit tests inside `src/http.rs` (5 pre-existing + any new `ActionDisallowed` test). This is the crate most affected by issue-13 changes.
+
+4. **Test `agent-sdk` crate**
+   ```
+   cargo test -p agent-sdk
+   ```
+   Validates: the 7 pre-existing tests in `tests/micro_agent_test.rs` still pass with the updated `AgentResponse` struct. Also validates any new tests for `AgentError::ActionDisallowed` display formatting.
+
+5. **Test `tool-registry` crate**
+   ```
+   cargo test -p tool-registry
+   ```
+   Validates: pre-existing tests in `tests/tool_entry_test.rs` and `tests/tool_registry_test.rs` pass with the updated `ToolEntry` struct. Also validates any new allowed-actions filtering tests if they live here.
+
+6. **Test full workspace**
+   ```
+   cargo test
+   ```
+   Validates: all tests across all six crates pass, confirming no transitive regressions in `skill-loader`, `orchestrator`, or `tools/echo-tool`.
+
+### Expected output indicators
+
+- Each `cargo check` call ends with `Finished` and no `error[E...]` lines.
+- `cargo clippy -- -D warnings` ends with `Finished` and no `warning:` or `error:` lines.
+- `cargo test -p agent-runtime` shows `test result: ok` with at minimum 11 passing tests (6 http_test + 5 http unit tests + constraint_enforcer tests + max_turns tests) and 0 failures.
+- `cargo test -p agent-sdk` shows `test result: ok` with at minimum 7 passing tests and 0 failures.
+- `cargo test` (workspace) shows `test result: ok` for every crate with tests.
+
+### What to do if a command fails
+
+- **Struct literal missing `escalate_to`**: A predecessor task ("Add `escalate_to` field to `AgentResponse`") was supposed to update `http_test.rs` and `micro_agent_test.rs`. Fix by adding `escalate_to: None` to every `AgentResponse { ... }` struct literal in those files.
+- **Exhaustive match on `AgentError`**: The new `ActionDisallowed` variant must be handled in `AppError::into_response()` in `crates/agent-runtime/src/http.rs`. Add the `ActionDisallowed` arm mapping to `StatusCode::FORBIDDEN`.
+- **Clippy warning on `action_type` field**: If `action_type` is declared but never read, clippy will flag dead code. Confirm the filtering logic in `resolve_mcp_tools()` actually reads the field.
+- **Type mismatch in confidence comparison**: `Constraints.confidence_threshold` is `f64`, `AgentResponse.confidence` is `f32`. The enforcer must cast with `response.confidence as f64` before comparing. A type error here means the cast is missing.
+- **`MaxTurnsError` detection fails**: If `BuiltAgent::prompt()` returns an error string that does not contain `"MaxTurnsError"` or `"MaxTurnError"`, the mapping will silently fall through to `AgentError::Internal`. Verify the substring match is correct by checking rig-core's error message format.
+- **Regression in another crate**: Run `cargo test -p <crate>` in isolation to confirm the failure is related to issue-13 changes vs. pre-existing. Check `cargo tree -p <crate>` for dependency version conflicts introduced by new dependencies.
+
+## Dependencies
+
+- Blocked by: "Write tests for ConstraintEnforcer", "Write tests for allowed_actions filtering", "Write tests for max_turns enforcement"
+- Blocking: none (this is the final task in the issue-13 series)
+
+## Risks & Edge Cases
+
+- **`AgentResponse` struct literal completeness**: Both `http_test.rs` (line 69-75) and `micro_agent_test.rs` (line 58-64) construct `AgentResponse` using struct literal syntax without `..Default::default()`. Adding the `escalate_to` field to the struct will cause a compile error in both files unless the predecessor task updated them. This is the single most likely regression.
+
+- **Exhaustive match breakage from `ActionDisallowed`**: The `AppError::into_response()` match and the `AgentError::Display` match must both handle the new variant. If either match is missing an arm, `cargo check` will fail. The `http.rs` unit tests also use `match` or explicit variant construction that must cover the new variant.
+
+- **Serde compatibility of new fields**: The `escalate_to` field on `AgentResponse` and `action_type` field on `ToolEntry` both use `#[serde(default, skip_serializing_if = "Option::is_none")]`. If these attributes are missing, existing JSON payloads that lack these fields will fail to deserialize, breaking tests that parse JSON responses.
+
+- **`f32`/`f64` precision in confidence comparison**: The `ConstraintEnforcer` compares `response.confidence` (`f32`) against `constraints.confidence_threshold` (`f64`). Floating-point promotion from `f32` to `f64` can introduce rounding artifacts. For example, `0.85_f32 as f64` is `0.8500000238418579`, not `0.85`. Tests must account for this by choosing threshold values that are exact in both precisions, or by using inequality comparisons with appropriate margins.
+
+- **Clippy false positives on test code**: Clippy lints like `clippy::too_many_arguments` or `clippy::needless_pass_by_value` may fire on test helper functions. If a lint is genuinely inapplicable, suppress it with a targeted `#[allow(...)]` on the specific item, not a crate-wide allow.
+
+- **`cargo test` hanging from `start_server`**: If any new test accidentally calls `start_server` (which binds a TCP listener and blocks on `axum::serve()`), the test binary will hang. All tests must use `build_router` + `oneshot()` or direct function calls, never `start_server`.
+
+- **New `ActionDisallowed` variant in `AgentError` may affect `PartialEq`-based assertions**: Existing tests assert `AgentError` equality (e.g., `micro_agent_test.rs` line 127). The new variant does not break `PartialEq` derive, but any test that does exhaustive matching on `AgentError` values must be updated.
+
+## Verification
+
+This task is complete when all of the following conditions are simultaneously true:
+
+1. `cargo check` (workspace) exits 0 with no error lines.
+2. `cargo clippy -- -D warnings` (workspace) exits 0 with no warning or error lines.
+3. `cargo test -p agent-runtime` exits 0 with 0 failures. All pre-existing http_test.rs tests pass. All new constraint_enforcer and max_turns tests pass.
+4. `cargo test -p agent-sdk` exits 0 with 0 failures. All 7 pre-existing micro_agent_test.rs tests pass.
+5. `cargo test -p tool-registry` exits 0 with 0 failures. All pre-existing and new allowed_actions tests pass.
+6. `cargo test` (workspace) exits 0 with no failing tests in any crate.
+
+Record the final output of each command (the `Finished` / `test result` lines) as evidence that the verification gate passed before closing the issue-13 branch.

--- a/.claude/specs/issue-13/set-default-max-turns-from-constraints.md
+++ b/.claude/specs/issue-13/set-default-max-turns-from-constraints.md
@@ -1,0 +1,132 @@
+# Spec: Set `default_max_turns` from constraints at agent build time
+
+> From: .claude/tasks/issue-13.md
+
+## Objective
+
+Wire the `max_turns` value from a skill manifest's `Constraints` into rig-core's `AgentBuilder::default_max_turns()` so that the built agent natively enforces a turn limit during its `PromptRequest` loop. This is the foundational step for max-turns enforcement: once the builder receives the limit, rig-core will automatically return `PromptError::MaxTurnsError` when the agent exceeds it, and downstream code (the "Map rig-core MaxTurnsError to AgentError::MaxTurnsExceeded" task) can translate that into a domain-specific error.
+
+## Current State
+
+### `crates/agent-runtime/src/tool_bridge.rs`
+
+`build_agent_with_tools()` is a generic helper that attaches MCP tools to a rig-core `AgentBuilder` and calls `.build()`:
+
+```rust
+pub fn build_agent_with_tools<M, P>(
+    builder: AgentBuilder<M, P, NoToolConfig>,
+    tools: Vec<McpTool>,
+) -> Agent<M, P>
+where
+    M: CompletionModel,
+    P: PromptHook<M>,
+{
+    let boxed: Vec<Box<dyn ToolDyn>> = tools
+        .into_iter()
+        .map(|t| Box::new(t) as Box<dyn ToolDyn>)
+        .collect();
+    builder.tools(boxed).build()
+}
+```
+
+The builder transitions from `NoToolConfig` to a tools-configured state via `.tools(boxed)`, then `.build()` finalizes it. There is no call to `.default_max_turns()`. The function has no knowledge of constraints.
+
+### `crates/agent-runtime/src/provider.rs`
+
+Two internal helpers call `build_agent_with_tools`:
+
+- `build_openai_agent(model_name, preamble, temperature, tools)` -- constructs an OpenAI `AgentBuilder`, sets preamble and temperature, then delegates to `tool_bridge::build_agent_with_tools(builder, tools)`.
+- `build_anthropic_agent(model_name, preamble, temperature, tools)` -- same pattern for Anthropic.
+
+The top-level `build_agent()` function receives the full `&SkillManifest` (which contains `manifest.constraints.max_turns: u32`) but only extracts `provider`, `model_name`, `preamble`, and `temperature` before dispatching to the helpers. `constraints` is not passed through.
+
+### `crates/agent-sdk/src/constraints.rs`
+
+```rust
+pub struct Constraints {
+    pub max_turns: u32,
+    pub confidence_threshold: f64,
+    pub escalate_to: Option<String>,
+    pub allowed_actions: Vec<String>,
+}
+```
+
+`max_turns` is a `u32`. The rig-core `AgentBuilder::default_max_turns()` accepts `usize`.
+
+### Builder method ordering
+
+Per the task breakdown notes, `.default_max_turns()` is available on any `ToolState` of `AgentBuilder`. The chain must be `.default_max_turns(n).tools(t).build()` -- i.e., `default_max_turns` is called on the `NoToolConfig` builder before `.tools()` transitions it to the tools-configured state.
+
+## Requirements
+
+1. `build_agent_with_tools()` must accept a `max_turns: u32` parameter in addition to its existing `builder` and `tools` parameters.
+2. `build_agent_with_tools()` must call `builder.default_max_turns(max_turns as usize)` before calling `.tools(boxed).build()`.
+3. `build_openai_agent()` and `build_anthropic_agent()` must accept a `max_turns: u32` parameter and forward it to `build_agent_with_tools()`.
+4. `build_agent()` must extract `manifest.constraints.max_turns` and pass it to the provider-specific helpers.
+5. No new crate dependencies may be added.
+6. The function signatures in `tool_bridge.rs` must remain generic over `M: CompletionModel` and `P: PromptHook<M>`.
+7. `cargo check --workspace`, `cargo clippy --workspace`, and `cargo test --workspace` must all pass after the change.
+
+## Implementation Details
+
+### Files to modify
+
+1. **`crates/agent-runtime/src/tool_bridge.rs`**
+   - Add `max_turns: u32` as the third parameter to `build_agent_with_tools()`:
+     ```rust
+     pub fn build_agent_with_tools<M, P>(
+         builder: AgentBuilder<M, P, NoToolConfig>,
+         tools: Vec<McpTool>,
+         max_turns: u32,
+     ) -> Agent<M, P>
+     ```
+   - Insert `.default_max_turns(max_turns as usize)` on the builder before `.tools(boxed)`:
+     ```rust
+     builder
+         .default_max_turns(max_turns as usize)
+         .tools(boxed)
+         .build()
+     ```
+   - Update the doc comment to mention that `max_turns` configures rig-core's native turn enforcement.
+
+2. **`crates/agent-runtime/src/provider.rs`**
+   - Add `max_turns: u32` as a parameter to both `build_openai_agent()` and `build_anthropic_agent()`.
+   - Forward `max_turns` to `tool_bridge::build_agent_with_tools(builder, tools, max_turns)` in both helpers.
+   - In `build_agent()`, extract `manifest.constraints.max_turns` and pass it to the match arms:
+     ```rust
+     let max_turns = manifest.constraints.max_turns;
+     match provider {
+         "openai" => build_openai_agent(model_name, preamble, temperature, tools, max_turns),
+         "anthropic" => build_anthropic_agent(model_name, preamble, temperature, tools, max_turns),
+         ...
+     }
+     ```
+
+### No new types or modules
+
+This task only modifies function signatures and adds a single builder method call. No new structs, enums, traits, or modules are introduced.
+
+### Integration points
+
+- **Downstream consumer**: The "Map rig-core MaxTurnsError to AgentError::MaxTurnsExceeded" task depends on this change. Once `default_max_turns` is set, rig-core's `PromptRequest` loop will produce `PromptError::MaxTurnsError` when the limit is hit. That error flows through `BuiltAgent::prompt()` as `ProviderError::Prompt(String)`, which the downstream task will inspect and map to `AgentError::MaxTurnsExceeded`.
+- **No impact on HTTP layer**: The HTTP handler calls `MicroAgent::invoke()`, which calls `BuiltAgent::prompt()`. The max-turns limit is enforced inside the rig-core prompt loop, transparent to the HTTP layer.
+
+## Dependencies
+
+- Blocked by: none
+- Blocking: "Map rig-core MaxTurnsError to AgentError::MaxTurnsExceeded"
+
+## Risks & Edge Cases
+
+- **`max_turns: 0` in manifest**: If a skill file sets `max_turns: 0`, this would be passed as `default_max_turns(0)`. Depending on rig-core's implementation, this could either mean "no limit" or "zero turns allowed" (immediate error). The `Constraints` validation in `skill-loader` should already reject `max_turns: 0` as invalid, but the implementer should verify this. If rig-core treats `0` as "unlimited", there is no issue; if it treats `0` as "zero turns", the validation layer is the correct place to guard against it.
+- **Type cast overflow**: `max_turns` is `u32` and `default_max_turns` takes `usize`. On all supported platforms (64-bit), `u32` fits in `usize` without truncation. On a hypothetical 16-bit platform, `u32 as usize` would truncate, but this is not a realistic deployment target.
+- **No runtime tests in this task**: This task is purely a build-time wiring change. Verifying that rig-core actually enforces the limit requires an integration test with a real (or mocked) LLM that triggers multiple tool-call turns, which is out of scope here and covered by the "Write tests for max_turns enforcement" task in Group 5.
+- **Builder method availability**: The task breakdown notes state `.default_max_turns()` is available on `AgentBuilder` in the `NoToolConfig` state. If the rig-core 0.32 API differs (e.g., the method is on a different state or has a different name), compilation will fail immediately, making the issue easy to diagnose.
+
+## Verification
+
+1. `cargo check --workspace` compiles with zero errors, confirming that `AgentBuilder::default_max_turns()` exists and accepts `usize`.
+2. `cargo clippy --workspace` produces no new warnings.
+3. `cargo test --workspace` passes all existing tests with no regressions. (Existing tests do not exercise `default_max_turns` behavior, but they must not break from the signature changes.)
+4. Read the modified `build_agent_with_tools()` and confirm `.default_max_turns(max_turns as usize)` is called before `.tools(boxed).build()`.
+5. Read the modified `build_agent()` and confirm `manifest.constraints.max_turns` is extracted and threaded through to both provider helpers.

--- a/.claude/specs/issue-13/wire-constraint-enforcer-into-main.md
+++ b/.claude/specs/issue-13/wire-constraint-enforcer-into-main.md
@@ -1,0 +1,100 @@
+# Spec: Wire ConstraintEnforcer into main.rs
+
+> From: .claude/tasks/issue-13.md
+
+## Objective
+
+Insert a `ConstraintEnforcer` decorator between the `RuntimeAgent` and the HTTP layer in the agent-runtime startup sequence. This is the integration step that activates post-invocation constraint enforcement (confidence threshold checks and escalation metadata) for every request flowing through the HTTP API. Without this wiring, the `ConstraintEnforcer` struct (built in a prior task) would exist but never be used.
+
+## Current State
+
+`crates/agent-runtime/src/main.rs` defines a 7-step async `main()` function:
+
+1. Load configuration (`RuntimeConfig::from_env()`)
+2. Register tool endpoints into a `ToolRegistry`
+3. Connect all tool servers
+4. Load skill manifest via `SkillLoader`
+5. Build a provider-backed agent
+6. Create runtime agent -- constructs a `RuntimeAgent` and immediately wraps it as `Arc<dyn MicroAgent>`
+7. Start HTTP server -- passes `micro_agent` and `config.bind_addr` to `http::start_server()`
+
+At step 6 (lines 66-68), the code is:
+```rust
+// Step 6: Wrap as MicroAgent
+tracing::info!("[6/7] Creating runtime agent");
+let runtime_agent = RuntimeAgent::new(manifest, agent, registry.clone());
+let micro_agent: Arc<dyn MicroAgent> = Arc::new(runtime_agent);
+```
+
+The `runtime_agent` is wrapped directly in an `Arc` and assigned to `micro_agent`, which is then passed to the HTTP server. There is no intermediate enforcement layer.
+
+`crates/agent-runtime/src/lib.rs` declares five public modules: `config`, `http`, `provider`, `runtime_agent`, and `tool_bridge`. The `constraint_enforcer` module does not exist yet -- it will be added by the "Implement ConstraintEnforcer struct" task.
+
+The `ConstraintEnforcer` struct (to be created in `crates/agent-runtime/src/constraint_enforcer.rs`) will implement `MicroAgent` and wrap an `Arc<dyn MicroAgent>`. Its constructor is expected to be `ConstraintEnforcer::new(inner: Arc<dyn MicroAgent>)`.
+
+`http::start_server` accepts `AppState` (which is `Arc<dyn MicroAgent>`) and a `SocketAddr`. Since `ConstraintEnforcer` implements `MicroAgent`, wrapping it in `Arc` produces a valid `AppState`.
+
+## Requirements
+
+- The `RuntimeAgent` must be wrapped in an `Arc` and passed to `ConstraintEnforcer::new()` before being assigned to `micro_agent`.
+- The final `micro_agent: Arc<dyn MicroAgent>` must hold an `Arc<ConstraintEnforcer>`, not an `Arc<RuntimeAgent>`.
+- A new log line `tracing::info!("[6.5/7] Applying constraint enforcement")` must appear between the step 6 log and the step 7 log, confirming the enforcer is applied.
+- A `use` import for `agent_runtime::constraint_enforcer::ConstraintEnforcer` (or equivalent path) must be added to `main.rs`.
+- The existing step numbering (1-7) must not change. The new step is labeled `[6.5/7]` to indicate it is a sub-step inserted between steps 6 and 7.
+- The `http::start_server` call must continue to receive the same type (`Arc<dyn MicroAgent>`) -- the change is purely in what concrete type is behind the trait object.
+- No new dependencies are added to `Cargo.toml`.
+
+## Implementation Details
+
+- **File to modify**: `crates/agent-runtime/src/main.rs`
+
+  1. **Add import**: Add `use agent_runtime::constraint_enforcer::ConstraintEnforcer;` to the import block at the top of the file, alongside the existing `use agent_runtime::runtime_agent::RuntimeAgent;`.
+
+  2. **Modify step 6 block**: Replace the current lines 66-68:
+     ```rust
+     // Step 6: Wrap as MicroAgent
+     tracing::info!("[6/7] Creating runtime agent");
+     let runtime_agent = RuntimeAgent::new(manifest, agent, registry.clone());
+     let micro_agent: Arc<dyn MicroAgent> = Arc::new(runtime_agent);
+     ```
+     with:
+     ```rust
+     // Step 6: Wrap as MicroAgent
+     tracing::info!("[6/7] Creating runtime agent");
+     let runtime_agent = RuntimeAgent::new(manifest, agent, registry.clone());
+
+     // Step 6.5: Apply constraint enforcement
+     tracing::info!("[6.5/7] Applying constraint enforcement");
+     let enforced = ConstraintEnforcer::new(Arc::new(runtime_agent));
+     let micro_agent: Arc<dyn MicroAgent> = Arc::new(enforced);
+     ```
+
+  3. **No changes to step 7**: The `http::start_server(micro_agent, config.bind_addr)` call remains identical since the `micro_agent` variable retains the same type (`Arc<dyn MicroAgent>`).
+
+- **No other files are created or modified** in this task. The `constraint_enforcer` module registration in `lib.rs` and the module itself are handled by the "Implement ConstraintEnforcer struct" task.
+
+## Dependencies
+
+- Blocked by: "Implement ConstraintEnforcer struct with confidence and escalation checks" (provides `ConstraintEnforcer` and registers the `constraint_enforcer` module in `lib.rs`)
+- Blocked by: "Map rig-core MaxTurnsError to AgentError::MaxTurnsExceeded" (ensures the error type that `ConstraintEnforcer` may encounter from the inner agent is properly typed)
+- Blocking: "Write tests for ConstraintEnforcer" (integration tests need the full wired-up server path to verify end-to-end enforcement)
+
+## Risks & Edge Cases
+
+1. **`ConstraintEnforcer::new` signature may differ**: The exact constructor signature depends on the "Implement ConstraintEnforcer struct" task. If the constructor takes additional parameters (e.g., explicit `Constraints` or `SkillManifest`), the wiring code must be adjusted. However, the task description specifies the enforcer reads constraints from the inner agent's `manifest()`, so `new(Arc<dyn MicroAgent>)` is the expected signature.
+
+2. **Double `Arc` wrapping**: The `RuntimeAgent` is first wrapped in `Arc::new(runtime_agent)` to pass to `ConstraintEnforcer::new`, then the enforcer is wrapped in another `Arc::new(enforced)`. This double-Arc is intentional and necessary: `ConstraintEnforcer` holds an `Arc<dyn MicroAgent>` internally (not a bare value), and the HTTP layer requires `Arc<dyn MicroAgent>` for shared ownership. The overhead of two `Arc` reference counts is negligible.
+
+3. **Trait object compatibility**: `ConstraintEnforcer` must implement `MicroAgent + Send + Sync` to be stored as `Arc<dyn MicroAgent>`. This is guaranteed by the "Implement ConstraintEnforcer struct" task, which uses `#[async_trait]` (adding `Send` bounds) and holds only `Send + Sync` fields.
+
+4. **No behavioral change when constraints are permissive**: If `confidence_threshold` is `0.0` and `escalate_to` is `None`, the enforcer is a pass-through. The wiring is unconditional -- there is no feature flag or config option to bypass it. This is the intended design: the enforcer is always in the chain, and permissive constraints simply result in no-op checks.
+
+5. **Module not yet registered**: If this task is attempted before `pub mod constraint_enforcer;` is added to `lib.rs`, the `use agent_runtime::constraint_enforcer::ConstraintEnforcer;` import will fail to compile. The dependency chain prevents this in practice.
+
+## Verification
+
+1. `cargo check -p agent-runtime` compiles without errors (assumes the `constraint_enforcer` module from the blocking task is present).
+2. `cargo clippy -p agent-runtime` produces no warnings -- in particular, no unused import warnings for `ConstraintEnforcer`.
+3. `cargo test` across the workspace passes with no regressions in existing tests.
+4. The startup log output shows the new `[6.5/7] Applying constraint enforcement` line between `[6/7] Creating runtime agent` and `[7/7] Starting HTTP server`.
+5. A manual integration test: start the runtime with a skill whose `confidence_threshold` is set high (e.g., `0.99`), send a request via `curl`, and verify the response includes `escalated: true` when the LLM returns a confidence below the threshold.

--- a/.claude/specs/issue-13/write-tests-for-allowed-actions-filtering.md
+++ b/.claude/specs/issue-13/write-tests-for-allowed-actions-filtering.md
@@ -1,0 +1,126 @@
+# Spec: Write tests for allowed_actions filtering
+
+> From: .claude/tasks/issue-13.md
+
+## Objective
+
+Add tests that verify the `allowed_actions` filtering logic introduced by the "Filter tools by `allowed_actions` in tool resolution" task. The filtering happens in `resolve_mcp_tools()` (in `tool_bridge.rs`), which accepts `allowed_actions` and excludes `ToolEntry` instances whose `action_type` is not in the allowed list. These tests ensure that:
+
+1. Tools with a matching `action_type` are included.
+2. Tools with a non-matching `action_type` are excluded.
+3. Tools with `action_type: None` are always included (no restriction).
+4. When `allowed_actions` is empty, all tools pass through regardless of `action_type`.
+
+## Current State
+
+### `crates/tool-registry/src/tool_entry.rs`
+
+`ToolEntry` currently has three fields: `name`, `version`, `endpoint`, plus a `handle: Option<McpHandle>` (skipped in serde). The "Filter tools by `allowed_actions`" task will add `action_type: Option<String>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`.
+
+### `crates/agent-runtime/src/tool_bridge.rs`
+
+`resolve_mcp_tools()` currently takes `&ToolRegistry` and `&SkillManifest`, calls `registry.resolve_for_skill(manifest)` to get entries, then iterates entries with MCP handles to list and wrap tools. The "Filter tools by `allowed_actions`" task will modify this function to also accept `&[String]` for allowed_actions and filter entries before querying MCP handles.
+
+### `crates/tool-registry/tests/tool_registry_test.rs`
+
+Contains synchronous tests for `ToolRegistry` operations: register, get, assert_exists, resolve_for_skill, duplicate detection, and the `ToolExists` trait. Uses helper functions `make_entry(name)` and `make_manifest(tools)` to construct test fixtures. The `make_manifest` function builds a `SkillManifest` with `allowed_actions: vec![]`.
+
+### `crates/tool-registry/tests/mcp_connection_test.rs`
+
+Contains async tests using a `MockServer` (implementing `ServerHandler`) that starts a real TCP/Unix MCP server. Provides helpers `start_tcp_server`, `make_registry_with_entry`, and `json_object_schema`. Tests verify connect, list_tools, and call_tool through live MCP connections.
+
+### Test strategy decision
+
+The `allowed_actions` filtering has two layers:
+
+1. **Entry-level filtering** (in `tool_bridge.rs`): filtering `Vec<ToolEntry>` by `action_type` against `allowed_actions`. This is the core logic being tested.
+2. **MCP tool resolution** (in `tool_bridge.rs`): the filtered entries are then used to query MCP handles for actual `McpTool` objects.
+
+Testing layer 1 in isolation is the most valuable and reliable approach. Since the filtering modifies the entries before MCP handle queries, we can test it by:
+- Placing pure filtering tests in `crates/tool-registry/tests/tool_registry_test.rs` if the filtering is exposed as a registry method, OR
+- Placing integration tests in `crates/agent-runtime/tests/tool_bridge_test.rs` using the MockServer pattern from `mcp_connection_test.rs`.
+
+The task description says the file is `crates/tool-registry/tests/tool_registry_test.rs` **or** `crates/agent-runtime/tests/tool_bridge_test.rs`. Choose based on where the filtering logic lands:
+
+- If `resolve_mcp_tools()` performs the filtering inline, tests go in `crates/agent-runtime/tests/tool_bridge_test.rs` using the mock MCP server pattern.
+- If the filtering is factored into a method on `ToolRegistry` (e.g., `resolve_for_skill_filtered`), pure synchronous tests can go in `crates/tool-registry/tests/tool_registry_test.rs`.
+
+Either way, the test cases are the same. The implementation below covers both locations.
+
+## Requirements
+
+1. **Test: non-matching `action_type` is excluded** -- Register three tools: `reader` with `action_type: Some("read")`, `writer` with `action_type: Some("write")`, `querier` with `action_type: Some("query")`. Call the filtering logic with `allowed_actions: ["read", "query"]`. Assert that `writer` is excluded and `reader` and `querier` are included.
+
+2. **Test: matching `action_type` is included** -- Covered by requirement 1 (reader and querier should be present in results).
+
+3. **Test: `action_type: None` is always included** -- Register a tool with `action_type: None` alongside tools with `action_type: Some("write")`. Call with `allowed_actions: ["read"]`. Assert the `None`-typed tool is included and the write-typed tool is excluded.
+
+4. **Test: empty `allowed_actions` passes all tools** -- Register tools with `action_type: Some("read")`, `Some("write")`, and `None`. Call with `allowed_actions: []` (empty). Assert all three tools are included.
+
+5. **Test: all tools excluded when none match** -- Register tools with `action_type: Some("write")` and `Some("admin")`. Call with `allowed_actions: ["read"]`. Assert zero tools are returned (only tools whose `action_type` is `Some` and not in the list are excluded; but here all have `Some` types that don't match).
+
+6. All existing tests continue to pass (the new `action_type` field defaults to `None`, so existing `ToolEntry` constructions remain valid).
+
+## Implementation Details
+
+### Option A: `crates/tool-registry/tests/tool_registry_test.rs` (preferred if filtering is on the registry)
+
+**Modify `make_entry` helper** to optionally accept `action_type`:
+
+- Add a `make_entry_with_action(name: &str, action_type: Option<&str>) -> ToolEntry` helper that constructs a `ToolEntry` with the `action_type` field set.
+- The existing `make_entry(name)` helper should continue to work (producing `action_type: None`), either by keeping it as-is or delegating to the new helper.
+
+**Modify `make_manifest` helper** to accept `allowed_actions`:
+
+- Add a `make_manifest_with_actions(tools: Vec<String>, allowed_actions: Vec<String>) -> SkillManifest` helper, or modify the existing `make_manifest` to accept an optional `allowed_actions` parameter.
+
+**Add test functions:**
+
+- `fn allowed_actions_excludes_non_matching_action_type()` -- Tests requirement 1.
+- `fn allowed_actions_includes_tools_with_no_action_type()` -- Tests requirement 3.
+- `fn empty_allowed_actions_passes_all_tools()` -- Tests requirement 4.
+- `fn allowed_actions_excludes_all_when_none_match()` -- Tests requirement 5.
+
+Each test follows the existing pattern: construct a `ToolRegistry`, register entries, build a manifest, call the filtering function, and assert on the returned `Vec<ToolEntry>`.
+
+### Option B: `crates/agent-runtime/tests/tool_bridge_test.rs` (if filtering is inline in `resolve_mcp_tools`)
+
+This requires the MockServer pattern from `mcp_connection_test.rs` since `resolve_mcp_tools` queries MCP handles. Tests would:
+
+1. Start mock MCP servers advertising tools with various names.
+2. Register `ToolEntry` instances with different `action_type` values.
+3. Connect to the mock servers.
+4. Call `resolve_mcp_tools()` with a manifest containing the appropriate `allowed_actions`.
+5. Assert on the resulting `Vec<McpTool>` (checking tool names via the `ToolDyn` trait's `definition().name`).
+
+These are `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]` tests, following the pattern in `mcp_connection_test.rs`.
+
+### Key types and interfaces (post-prerequisite task)
+
+- `ToolEntry` gains: `pub action_type: Option<String>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`
+- `resolve_mcp_tools()` signature changes to accept allowed_actions (either as a separate parameter or via the manifest's `constraints.allowed_actions`)
+- Filtering logic: if `allowed_actions` is non-empty, exclude entries where `entry.action_type` is `Some(t)` and `t` is not in `allowed_actions`. If `action_type` is `None`, include the entry.
+
+### No new dependencies required.
+
+## Dependencies
+
+- Blocked by: "Filter tools by `allowed_actions` in tool resolution" (the filtering logic and `action_type` field must exist before tests can be written)
+- Blocking: "Run verification suite"
+
+## Risks & Edge Cases
+
+- **`action_type` field missing from existing `ToolEntry` constructions**: The new field uses `#[serde(default)]` and `Option<String>`, so existing code constructing `ToolEntry` with struct literal syntax will get a compile error unless the field is added. All test helpers (`make_entry`, `make_registry_with_entry`) must be updated to include `action_type: None`. This is a straightforward mechanical change.
+- **Case sensitivity of `action_type` matching**: The spec assumes exact string matching (e.g., `"read"` matches `"read"`, not `"Read"`). Tests should use consistent casing. If the implementation normalizes case, tests should verify that behavior explicitly.
+- **Mock MCP server tool names vs. ToolEntry names**: In the integration test approach (Option B), the MockServer advertises tool names at the MCP protocol level, while `ToolEntry.name` is the registry-level name. These are different namespaces. The filtering applies to `ToolEntry.action_type`, not to individual MCP tool names. Tests must be careful to assert on the correct layer.
+- **Empty results**: When all tools are filtered out, `resolve_mcp_tools` should return `Ok(vec![])`, not an error. The "all excluded" test case verifies this.
+- **Interaction with `resolve_for_skill`**: The existing `resolve_for_skill` checks that all tools in the manifest exist in the registry and errors on missing tools. The `allowed_actions` filter runs after this check, so it cannot cause `ToolNotFound` errors. Tests should not conflate these two concerns.
+
+## Verification
+
+1. `cargo check --workspace` compiles cleanly after the prerequisite task and this test task are both complete.
+2. `cargo test --workspace` passes all tests, including:
+   - All four (or more) new `allowed_actions` filtering tests.
+   - All existing tests in `tool_registry_test.rs`, `tool_entry_test.rs`, and `mcp_connection_test.rs`.
+3. `cargo clippy --workspace` produces no new warnings.
+4. Each test case exercises a distinct filtering scenario (matching, non-matching, None, empty allowed_actions) so that a regression in any single filtering branch is caught.

--- a/.claude/specs/issue-13/write-tests-for-constraint-enforcer.md
+++ b/.claude/specs/issue-13/write-tests-for-constraint-enforcer.md
@@ -1,0 +1,157 @@
+# Spec: Write tests for ConstraintEnforcer
+
+> From: .claude/tasks/issue-13.md
+
+## Objective
+
+Create an integration test file that verifies the `ConstraintEnforcer` decorator correctly enforces confidence-threshold escalation, delegates `manifest()` and `health()` to the inner agent, and propagates errors without modification. These tests validate that the runtime constraint enforcement layer (Group 3) works as specified before the full verification suite runs.
+
+## Current State
+
+### ConstraintEnforcer (not yet implemented, specified in task breakdown)
+
+`ConstraintEnforcer` will be a struct in `crates/agent-runtime/src/constraint_enforcer.rs` that:
+- Wraps an `Arc<dyn MicroAgent>` as its inner agent.
+- Implements `MicroAgent` itself (decorator pattern).
+- Delegates `manifest()` and `health()` directly to the inner agent.
+- In `invoke()`, calls the inner agent's `invoke()`, then performs a post-invocation check: if `(response.confidence as f64) < manifest.constraints.confidence_threshold`, it sets `response.escalated = true` and `response.escalate_to = manifest.constraints.escalate_to.clone()`.
+- Low confidence produces a successful response with escalation metadata, not an error.
+- The module will be registered in `crates/agent-runtime/src/lib.rs` as `pub mod constraint_enforcer;`.
+
+### Key types involved
+
+- **`AgentResponse`** (`crates/agent-sdk/src/agent_response.rs`): Has fields `id: Uuid`, `output: Value`, `confidence: f32`, `escalated: bool`, `tool_calls: Vec<ToolCallRecord>`. After the "Add `escalate_to` field" task completes, it will also have `escalate_to: Option<String>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`.
+- **`Constraints`** (`crates/agent-sdk/src/constraints.rs`): Has `max_turns: u32`, `confidence_threshold: f64`, `escalate_to: Option<String>`, `allowed_actions: Vec<String>`.
+- **`MicroAgent` trait** (`crates/agent-sdk/src/micro_agent.rs`): `fn manifest(&self) -> &SkillManifest`, `async fn invoke(&self, request: AgentRequest) -> Result<AgentResponse, AgentError>`, `async fn health(&self) -> HealthStatus`.
+- **`AgentError`** (`crates/agent-sdk/src/agent_error.rs`): Enum with `ToolCallFailed`, `ConfidenceTooLow`, `MaxTurnsExceeded`, `Internal` variants.
+
+### Existing test patterns
+
+The project uses a `MockAgent` pattern in integration tests:
+- `crates/agent-sdk/tests/micro_agent_test.rs`: Defines a `MockAgent` struct with `manifest`, `should_fail`, `health_status` fields. Uses `make_manifest()` and `make_mock()` helpers. Implements `MicroAgent` via `#[async_trait]`. Returns a fixed `AgentResponse` with `confidence: 0.95` or an `AgentError::Internal` when `should_fail` is true.
+- `crates/agent-runtime/tests/http_test.rs`: Similar `MockAgent` but uses an `ErrorMode` enum for more granular error control. Wraps the mock in `Arc<dyn MicroAgent>` for passing to the HTTP router.
+
+Both test files use `#[tokio::test]` and import from `agent_sdk` via its public API.
+
+### Crate dependencies
+
+`crates/agent-runtime/Cargo.toml` already has `agent-sdk` as a dependency and `tokio` with `features = ["full"]`. No additional dependencies are needed for these tests.
+
+## Requirements
+
+1. **Confidence above threshold passes through unchanged**: When the inner agent returns a response with `confidence` >= `confidence_threshold`, the `ConstraintEnforcer` must return the response with `escalated: false` and `escalate_to: None`, and the `output`, `id`, `confidence`, and `tool_calls` fields must be identical to the inner agent's response.
+
+2. **Confidence below threshold with `escalate_to` configured triggers escalation**: When the inner agent returns a response with `confidence` < `confidence_threshold` and `constraints.escalate_to` is `Some("fallback-agent")`, the response must have `escalated: true` and `escalate_to: Some("fallback-agent")`. The `output`, `id`, `confidence`, and `tool_calls` fields must remain unchanged (only escalation metadata is stamped).
+
+3. **Confidence below threshold without `escalate_to` configured**: When the inner agent returns a response with `confidence` < `confidence_threshold` and `constraints.escalate_to` is `None`, the response must have `escalated: true` and `escalate_to: None`. This verifies escalation flagging works even when no target is specified.
+
+4. **Manifest and health delegate correctly**: Calling `manifest()` on the `ConstraintEnforcer` must return the same `SkillManifest` as the inner agent. Calling `health()` must return the same `HealthStatus` as the inner agent (test with at least `Healthy` and `Degraded` variants).
+
+5. **Error propagation**: When the inner agent returns an `Err(AgentError::Internal(...))`, the `ConstraintEnforcer` must propagate that exact error without modification. The confidence check must not run on error paths.
+
+## Implementation Details
+
+### File to create
+
+**`crates/agent-runtime/tests/constraint_enforcer_test.rs`**
+
+### MockAgent design
+
+Define a `MockAgent` struct tailored for constraint enforcer testing. Unlike the SDK's mock (which uses a boolean `should_fail`) or the HTTP test mock (which uses `ErrorMode`), this mock needs a configurable `confidence` value on its responses so tests can set it above or below the threshold:
+
+```rust
+struct MockAgent {
+    manifest: SkillManifest,
+    response_confidence: f32,
+    error_mode: Option<AgentError>,
+    health_status: HealthStatus,
+}
+```
+
+The `invoke()` implementation should:
+- If `error_mode` is `Some(err)`, return `Err(err.clone())`.
+- Otherwise, return `Ok(AgentResponse { id: request.id, output: json!({"result": "ok"}), confidence: self.response_confidence, escalated: false, escalate_to: None, tool_calls: vec![] })`.
+
+### Helper functions
+
+- `make_manifest_with_threshold(threshold: f64, escalate_to: Option<String>) -> SkillManifest`: Creates a `SkillManifest` with the given `confidence_threshold` and `escalate_to` in its constraints. Other fields use sensible defaults (name: `"test-agent"`, version: `"1.0.0"`, etc.), following the pattern from existing test helpers.
+- `make_mock(confidence: f32, threshold: f64, escalate_to: Option<String>, error_mode: Option<AgentError>, health_status: HealthStatus) -> MockAgent`: Convenience constructor combining manifest creation and mock setup.
+
+### Test cases
+
+1. **`confidence_above_threshold_passes_through_unchanged`**
+   - Create a mock with `response_confidence: 0.95`, `confidence_threshold: 0.85`, `escalate_to: Some("fallback-agent")`.
+   - Wrap in `ConstraintEnforcer::new(Arc::new(mock))`.
+   - Call `enforcer.invoke(AgentRequest::new("hello"))`.
+   - Assert: `response.escalated == false`, `response.escalate_to == None`, `response.confidence == 0.95`, `response.output == json!({"result": "ok"})`, `response.id == request.id`.
+
+2. **`confidence_below_threshold_triggers_escalation`**
+   - Create a mock with `response_confidence: 0.50`, `confidence_threshold: 0.85`, `escalate_to: Some("fallback-agent")`.
+   - Wrap in `ConstraintEnforcer`.
+   - Call `enforcer.invoke(...)`.
+   - Assert: `response.escalated == true`, `response.escalate_to == Some("fallback-agent")`, `response.confidence == 0.50` (unchanged), `response.output == json!({"result": "ok"})` (unchanged).
+
+3. **`confidence_below_threshold_without_escalate_to`**
+   - Create a mock with `response_confidence: 0.50`, `confidence_threshold: 0.85`, `escalate_to: None`.
+   - Wrap in `ConstraintEnforcer`.
+   - Call `enforcer.invoke(...)`.
+   - Assert: `response.escalated == true`, `response.escalate_to == None`.
+
+4. **`manifest_delegates_to_inner_agent`**
+   - Create a mock and wrap in `ConstraintEnforcer`.
+   - Call `enforcer.manifest()`.
+   - Assert: `manifest.name == "test-agent"`, `manifest.version == "1.0.0"`, `manifest.constraints.confidence_threshold == 0.85`.
+
+5. **`health_delegates_to_inner_agent`**
+   - Create a mock with `health_status: HealthStatus::Healthy`, wrap in `ConstraintEnforcer`, assert `health().await == HealthStatus::Healthy`.
+   - Create a mock with `health_status: HealthStatus::Degraded("slow")`, wrap in `ConstraintEnforcer`, assert `health().await == HealthStatus::Degraded("slow")`.
+
+6. **`inner_agent_error_propagates_unchanged`**
+   - Create a mock with `error_mode: Some(AgentError::Internal("mock failure"))`.
+   - Wrap in `ConstraintEnforcer`.
+   - Call `enforcer.invoke(...)`.
+   - Assert: result is `Err(AgentError::Internal("mock failure"))`.
+
+### Imports
+
+```rust
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use agent_sdk::{
+    async_trait, AgentError, AgentRequest, AgentResponse, Constraints, HealthStatus, MicroAgent,
+    ModelConfig, OutputSchema, SkillManifest,
+};
+use serde_json::json;
+
+use agent_runtime::constraint_enforcer::ConstraintEnforcer;
+```
+
+### Edge case: confidence exactly equal to threshold
+
+The spec from the task breakdown says `if (response.confidence as f64) < manifest.constraints.confidence_threshold` (strict less-than). When confidence equals the threshold exactly, it should NOT trigger escalation. Consider adding a test for `confidence: 0.85` with `threshold: 0.85` asserting `escalated: false`. This can be included as part of test case 1 or as a separate test.
+
+### Type casting note
+
+`AgentResponse.confidence` is `f32` while `Constraints.confidence_threshold` is `f64`. The `ConstraintEnforcer` casts `response.confidence as f64` before comparing. Tests should exercise values where f32-to-f64 casting does not introduce false positives (use clean values like 0.5, 0.85, 0.95).
+
+## Dependencies
+
+- Blocked by: "Wire ConstraintEnforcer into main.rs" (the `ConstraintEnforcer` struct and its `pub mod` registration must exist for the test file to compile)
+- Blocking: "Run verification suite"
+
+## Risks & Edge Cases
+
+- **`escalate_to` field not yet on `AgentResponse`**: This test file depends on the "Add `escalate_to` field to `AgentResponse`" task completing first. If that field is missing, the mock's `invoke()` and the test assertions will not compile. Since "Wire ConstraintEnforcer into main.rs" already depends on that task transitively, the blocking chain is correct.
+- **`ConstraintEnforcer` API changes**: The tests assume `ConstraintEnforcer::new(Arc<dyn MicroAgent>)` as the constructor. If the implementation uses a different signature (e.g., taking `Box<dyn MicroAgent>` or separate constraint parameters), the test construction will need adjustment. The task breakdown specifies `Arc<dyn MicroAgent>`.
+- **f32 precision in assertions**: Use `(value - expected).abs() < f32::EPSILON` for floating-point comparisons on confidence, following the pattern in `micro_agent_test.rs` (line 114).
+- **Module visibility**: The test imports `agent_runtime::constraint_enforcer::ConstraintEnforcer`. This requires `constraint_enforcer` to be a `pub mod` in `crates/agent-runtime/src/lib.rs` and `ConstraintEnforcer` to be `pub`. The task breakdown specifies both.
+- **`AgentError` clone**: The mock stores an `Option<AgentError>` and must clone it on each `invoke()` call. `AgentError` already derives `Clone`, so this is safe.
+
+## Verification
+
+1. `cargo test --package agent-runtime --test constraint_enforcer_test` runs all six test cases and they pass.
+2. `cargo check --workspace` compiles with zero errors.
+3. `cargo clippy --workspace` produces no warnings.
+4. `cargo test --workspace` shows no regressions in existing tests.
+5. Each test case maps 1:1 to the five requirements listed in the task breakdown (with the boundary case as a bonus).

--- a/.claude/specs/issue-13/write-tests-for-max-turns-enforcement.md
+++ b/.claude/specs/issue-13/write-tests-for-max-turns-enforcement.md
@@ -1,0 +1,169 @@
+# Spec: Write tests for max_turns enforcement
+
+> From: .claude/tasks/issue-13.md
+
+## Objective
+
+Add tests to `crates/agent-runtime/tests/runtime_agent_test.rs` that verify two aspects of max-turns enforcement:
+
+1. When `BuiltAgent::prompt()` returns an error whose string representation contains the rig-core `MaxTurnsError` marker, `RuntimeAgent::invoke()` maps it to `AgentError::MaxTurnsExceeded { turns }` (not `AgentError::Internal`).
+2. The `default_max_turns` value from `manifest.constraints.max_turns` is correctly threaded through `build_agent_with_tools()` into the built rig-core agent.
+
+These tests validate the work done in the two upstream tasks ("Set `default_max_turns` from constraints at agent build time" and "Map rig-core MaxTurnsError to AgentError::MaxTurnsExceeded") and serve as the regression safety net before the final verification suite.
+
+## Current State
+
+### `crates/agent-runtime/src/runtime_agent.rs`
+
+`RuntimeAgent` wraps a `BuiltAgent` and implements `MicroAgent`. The `invoke()` method currently maps all errors from `self.agent.prompt()` to `AgentError::Internal(e.to_string())`:
+
+```rust
+async fn invoke(&self, request: AgentRequest) -> Result<AgentResponse, AgentError> {
+    let output = self
+        .agent
+        .prompt(&request.input)
+        .await
+        .map_err(|e| AgentError::Internal(e.to_string()))?;
+    Ok(AgentResponse::success(request.id, Value::String(output)))
+}
+```
+
+After the blocking task "Map rig-core MaxTurnsError to AgentError::MaxTurnsExceeded" is implemented, this method will detect `MaxTurnsError` in the error (either via typed enum matching or substring detection on the stringified `ProviderError::Prompt(String)`) and produce `AgentError::MaxTurnsExceeded { turns: manifest.constraints.max_turns }`.
+
+### `crates/agent-runtime/src/provider.rs`
+
+`BuiltAgent` is an enum with `OpenAi(Agent<OpenAiModel>)` and `Anthropic(Agent<AnthropicModel>)` variants. Its `prompt()` method delegates to the inner rig-core agent and maps errors to `ProviderError::Prompt(String)`, which erases the original `PromptError` type. The `build_agent()` function constructs the agent via `build_agent_with_tools()`.
+
+After the blocking task "Set `default_max_turns` from constraints at agent build time" is implemented, `build_agent()` will pass `manifest.constraints.max_turns` through to `build_agent_with_tools()`, which will call `.default_max_turns(max_turns as usize)` on the builder.
+
+### `crates/agent-runtime/src/tool_bridge.rs`
+
+`build_agent_with_tools()` currently accepts `(builder, tools)` and calls `builder.tools(boxed).build()`. After the upstream task, it will accept an additional `max_turns: u32` parameter and call `builder.default_max_turns(max_turns as usize).tools(boxed).build()`.
+
+### `crates/agent-runtime/tests/runtime_agent_test.rs`
+
+Contains four tests: `test_manifest_returns_correct_values`, `test_health_returns_healthy`, `test_runtime_agent_is_dyn_compatible`, and `test_invoke_with_real_llm` (ignored). Uses a `build_test_runtime_agent()` helper that sets a fake API key and builds a real `RuntimeAgent` via `provider::build_agent()`. None of the existing tests exercise error mapping or max-turns behavior.
+
+### `crates/agent-sdk/src/agent_error.rs`
+
+`AgentError::MaxTurnsExceeded { turns: u32 }` already exists with `Display`, `Debug`, `Clone`, `PartialEq`, `Serialize`, and `Deserialize` implementations.
+
+### Test architecture constraint
+
+`RuntimeAgent::new()` requires a `BuiltAgent`, which is an enum wrapping concrete rig-core `Agent` types. There is no way to inject a mock `BuiltAgent` since it is a closed enum, not a trait. This constrains testing approaches:
+
+- **MaxTurnsError mapping test**: Cannot unit-test `invoke()` in isolation with a mock agent because `BuiltAgent` cannot be mocked. Two viable approaches: (a) add a test variant to `BuiltAgent` (e.g., `#[cfg(test)] Mock(...)`) that can return arbitrary errors, or (b) test the error-mapping logic by extracting it into a standalone function that takes a `Result<String, ProviderError>` and returns `Result<String, AgentError>`, then unit-test that function directly.
+- **`default_max_turns` passthrough test**: The built `Agent<M>` struct in rig-core has a `default_max_turns` field. After building an agent via the test helper (which uses `provider::build_agent()`), the test can access the `BuiltAgent` enum, match on the variant, and inspect the inner agent's `default_max_turns` field to verify it equals `manifest.constraints.max_turns as usize`. This requires either: (a) the `Agent` struct's field is `pub`, or (b) there is a getter method. If the field is not accessible, an alternative is to verify indirectly through behavior (prompt a real LLM, which is impractical), or to trust the builder call and test only the wiring.
+
+## Requirements
+
+1. **Test: MaxTurnsError maps to AgentError::MaxTurnsExceeded** -- When `RuntimeAgent::invoke()` encounters a `MaxTurnsError`-pattern error from the underlying agent, it must return `Err(AgentError::MaxTurnsExceeded { turns })` where `turns` equals `manifest.constraints.max_turns`. The test must assert:
+   - The result is `Err`, not `Ok`.
+   - The error variant is `AgentError::MaxTurnsExceeded`.
+   - The `turns` field matches the manifest's `constraints.max_turns`.
+
+2. **Test: non-MaxTurns errors still map to AgentError::Internal** -- When `RuntimeAgent::invoke()` encounters a non-MaxTurns error, it must return `Err(AgentError::Internal(_))` (the existing behavior is preserved).
+
+3. **Test: `default_max_turns` is set on the built agent** -- After building an agent via `provider::build_agent()` with a manifest that has `constraints.max_turns = N`, the resulting rig-core agent's `default_max_turns` field must equal `Some(N as usize)`. The test must verify this by inspecting the built agent.
+
+4. All new tests must be in `crates/agent-runtime/tests/runtime_agent_test.rs`.
+
+5. Tests must not require a valid API key or network access (no `#[ignore]` attribute).
+
+6. Tests must compile and pass with `cargo test -p agent-runtime`.
+
+## Implementation Details
+
+### Files to modify
+
+**`crates/agent-runtime/tests/runtime_agent_test.rs`** -- Add the following tests.
+
+#### Test 1: `test_max_turns_error_maps_to_max_turns_exceeded`
+
+This test verifies the error-mapping logic in `RuntimeAgent::invoke()`. The approach depends on how the blocking task implements the mapping:
+
+- **Option A (extracted function)**: If the blocking task extracts the error-mapping logic into a public helper function (e.g., `pub fn map_prompt_error(err: ProviderError, max_turns: u32) -> AgentError`), the test calls that function directly with a `ProviderError::Prompt(...)` whose string contains the `MaxTurnsError` marker and asserts it returns `AgentError::MaxTurnsExceeded { turns: max_turns }`.
+
+- **Option B (test variant on BuiltAgent)**: If `BuiltAgent` gains a `#[cfg(test)]` mock variant that can return controlled errors, construct a `RuntimeAgent` with that variant, invoke it, and assert the error mapping.
+
+- **Option C (integration-style with substring)**: Build a `RuntimeAgent` via the existing test helper. Since we cannot trigger a real `MaxTurnsError` without an LLM, construct a `ProviderError::Prompt(String)` that contains the rig-core `MaxTurnsError` signature string, and test the mapping function in isolation.
+
+The implementer should choose whichever approach the blocking task's design makes feasible, preferring the approach that provides the most direct test coverage without adding unnecessary complexity.
+
+Regardless of approach, assert:
+```rust
+assert!(matches!(result, Err(AgentError::MaxTurnsExceeded { turns }) if turns == expected_max_turns));
+```
+
+#### Test 2: `test_non_max_turns_error_maps_to_internal`
+
+Same setup as Test 1, but with a generic error string (e.g., `"connection timeout"`) that does not contain the `MaxTurnsError` marker. Assert:
+```rust
+assert!(matches!(result, Err(AgentError::Internal(_))));
+```
+
+#### Test 3: `test_default_max_turns_set_on_built_agent`
+
+Build an agent using the existing `build_test_runtime_agent()` helper (which uses `test_manifest()` with `constraints.max_turns = 1`). Access the inner `BuiltAgent` from `RuntimeAgent` and match on the enum variant to inspect the inner rig-core `Agent`'s `default_max_turns` field.
+
+This requires either:
+- A public getter on `RuntimeAgent` that exposes the inner `BuiltAgent` (e.g., `pub fn agent(&self) -> &BuiltAgent`), or
+- Making `RuntimeAgent.agent` field `pub(crate)` or `pub`, or
+- Testing through `build_agent_with_tools()` directly by calling it from the test and inspecting the returned `Agent`.
+
+If accessing the `Agent`'s `default_max_turns` field directly is not possible (it may be private in rig-core), alternative verification:
+- Build two agents with different `max_turns` values and verify both build successfully (compile-time + runtime wiring check) and rely on the error-mapping tests to validate the behavioral effect.
+- Or call `build_agent_with_tools()` directly from the test, which is a public function, and check the returned agent.
+
+Assert:
+```rust
+// If direct field access is available:
+assert_eq!(agent.default_max_turns, Some(1));
+
+// If only build verification is possible:
+// assert that building with max_turns = N succeeds and the agent is usable
+```
+
+#### Test 4: `test_default_max_turns_varies_with_manifest`
+
+Build two agents with different `max_turns` values (e.g., 1 and 10) and verify each has the correct `default_max_turns` set. This confirms the value is threaded from the manifest rather than hardcoded.
+
+### Key functions/types involved
+
+- `RuntimeAgent::invoke()` -- the method under test for error mapping
+- `BuiltAgent::prompt()` -- returns `Result<String, ProviderError>`
+- `ProviderError::Prompt(String)` -- the error type that wraps the stringified rig-core error
+- `AgentError::MaxTurnsExceeded { turns: u32 }` -- the expected mapped error
+- `tool_bridge::build_agent_with_tools(builder, tools, max_turns)` -- the function that sets `default_max_turns` (after upstream task)
+- `provider::build_agent(manifest, registry)` -- top-level builder that threads `max_turns`
+
+### Integration points with existing code
+
+- Tests import from `agent_runtime::provider`, `agent_runtime::runtime_agent::RuntimeAgent`, `agent_sdk::AgentError`, and `agent_sdk::AgentRequest`.
+- Reuse the existing `test_manifest()` and `build_test_runtime_agent()` helpers where possible.
+- May need to add a variant of `test_manifest()` that accepts a custom `max_turns` value (e.g., `test_manifest_with_max_turns(max_turns: u32) -> SkillManifest`).
+
+## Dependencies
+
+- Blocked by: "Map rig-core MaxTurnsError to AgentError::MaxTurnsExceeded" -- the error-mapping logic must exist before tests can verify it. Also transitively blocked by "Set `default_max_turns` from constraints at agent build time" since the mapping task depends on it.
+- Blocking: "Run verification suite" -- these tests must pass before the final suite run.
+
+## Risks & Edge Cases
+
+1. **`BuiltAgent` is not mockable.** It is a closed enum with concrete provider-specific variants, not a trait. If the blocking task does not expose a test seam (extracted function, test variant, or public error-mapping helper), the error-mapping tests may need to be restructured as unit tests on an extracted helper rather than integration tests on `RuntimeAgent::invoke()`. The implementer of the blocking task should be aware of this testing need.
+
+2. **rig-core `Agent.default_max_turns` field visibility.** If this field is private in rig-core 0.32, the `test_default_max_turns_set_on_built_agent` test cannot directly assert its value. In that case, fall back to verifying the build succeeds with different `max_turns` values (compile-time + runtime wiring check) and rely on the error-mapping tests to validate the behavioral effect.
+
+3. **`MaxTurnsError` string format.** The blocking task maps errors by detecting a `MaxTurnsError` substring (or similar marker) in the stringified `ProviderError::Prompt(String)`. If rig-core changes its error `Display` format in a future version, the substring check and thus the tests may break. Tests should use the same marker string that the production code checks for, ensuring consistency.
+
+4. **Fake API key and agent construction.** The existing test helper sets `OPENAI_API_KEY` to a fake value via `set_var`, which is `unsafe` due to potential data races. Tests are serialized by tokio's single-threaded runtime, mitigating this, but adding more tests that call `build_test_runtime_agent()` increases the surface area. No new risk is introduced as long as all tests use the same pattern.
+
+5. **Test isolation.** If `test_default_max_turns_varies_with_manifest` constructs agents with different manifest values, ensure the `OPENAI_API_KEY` env var is set before each build call (the existing helper already does this).
+
+## Verification
+
+1. `cargo test -p agent-runtime -- runtime_agent_test` runs all new tests and they pass.
+2. `cargo test -p agent-runtime` passes with no regressions to existing tests.
+3. `cargo clippy -p agent-runtime` produces no warnings in the test file.
+4. The `test_max_turns_error_maps_to_max_turns_exceeded` test fails if the error-mapping logic is removed (i.e., it would catch a regression to the old blanket `Internal` mapping).
+5. The `test_default_max_turns_set_on_built_agent` test fails if the `default_max_turns()` call is removed from `build_agent_with_tools()`.

--- a/.claude/specs/issue-14/add-build-and-run-documentation.md
+++ b/.claude/specs/issue-14/add-build-and-run-documentation.md
@@ -1,0 +1,151 @@
+# Spec: Add build and run documentation
+
+> From: .claude/tasks/issue-14.md
+
+## Objective
+
+Add a "Docker" section to the project `README.md` that documents how to build, run, inspect, and debug Spore agent containers. This is the user-facing documentation for the Dockerfile created by the "Create multi-stage Dockerfile" task. Without this section, users would need to reverse-engineer the Dockerfile and source code to understand the build arguments, environment variables, and `FROM scratch` limitations.
+
+## Current State
+
+### README structure (`README.md`)
+
+The README currently has these top-level sections in order:
+
+1. **Why** (line 5) — motivation for the microservices approach
+2. **How It Works** (line 11) — runtime + skill file explanation with example
+3. **Architecture** (line 72) — directory tree, crate descriptions, agent tiers
+4. **Self-Bootstrapping Factory** (line 109) — seed agents table
+5. **Tech Stack** (line 122) — dependency table
+6. **Key Properties** (line 131) — bullet points about design qualities
+7. **Analogy** (line 142) — "serverless for agents" framing
+8. **License** (line 147) — TBD placeholder
+
+There is no Docker, deployment, or "getting started" section. The README mentions Docker images in several places (line 15: "Ships as a 1-5MB Docker image"; line 95: "The Docker image is `FROM scratch` + the binary + the skill file"; line 135: "1-5MB Docker images vs. gigabyte-scale typical AI containers") but never explains how to actually build or run one.
+
+### Environment variables consumed by the runtime
+
+From `crates/agent-runtime/src/config.rs` and `crates/agent-runtime/src/main.rs`:
+
+| Variable | Required | Default | Source |
+|---|---|---|---|
+| `SKILL_NAME` | Yes | (none — errors if missing) | `config.rs` line 48, `read_required_var` |
+| `SKILL_DIR` | No | `./skills` | `config.rs` line 49, `read_optional_var_or` |
+| `BIND_ADDR` | No | `0.0.0.0:8080` | `config.rs` line 74-86, `parse_bind_addr` |
+| `TOOL_ENDPOINTS` | No | `echo-tool=mcp://localhost:7001` | `main.rs` line 89-90, `register_tool_endpoints` |
+| `ANTHROPIC_API_KEY` | Yes (if provider is `anthropic`) | (none — errors if missing) | `provider.rs` line 188, `read_api_key` |
+| `OPENAI_API_KEY` | Yes (if provider is `openai`) | (none — errors if missing) | `provider.rs` line 166, `read_api_key` |
+| `RUST_LOG` | No | (tracing default: INFO) | `main.rs` line 25-28, `EnvFilter::from_default_env` |
+
+### HTTP endpoints
+
+From `crates/agent-runtime/src/http.rs`:
+
+- `POST /invoke` — sends a request to the agent (accepts `AgentRequest` JSON)
+- `GET /health` — returns agent name, version, and health status
+
+### Dockerfile (not yet created)
+
+The Dockerfile is being created by the prerequisite task "Create multi-stage Dockerfile". Per the task description in `.claude/tasks/issue-14.md` (lines 23-33), it will:
+
+- Accept `SKILL_NAME` as a build arg to select which skill file to copy
+- Use `FROM scratch` for the runtime stage
+- Set `SKILL_NAME` and `SKILL_DIR` as default ENV values
+- Expose port 8080
+- Set entrypoint to `/agent-runtime`
+
+## Requirements
+
+- Add a `## Docker` section to `README.md` positioned between "Tech Stack" (line 129) and "Key Properties" (line 131). This placement groups all technical/operational content together before the higher-level "Key Properties" and "Analogy" sections.
+- The Docker section must include exactly five subsections documented below. Each subsection must use `###` heading level.
+- **Build the image** (`### Build`): Show the `docker build` command with `--build-arg SKILL_NAME=echo -t spore-echo .`. Explain that `SKILL_NAME` selects which skill file from the `skills/` directory gets baked into the image.
+- **Run the container** (`### Run`): Show the `docker run` command with `-p 8080:8080 -e ANTHROPIC_API_KEY=... spore-echo`. Include a curl example hitting `GET /health` to verify the container is running. Mention that the port maps to the default `BIND_ADDR` of `0.0.0.0:8080`.
+- **Check image size** (`### Image Size`): Show `docker images spore-echo` and note the expected size range (realistically 5-10 MB, aspirationally under 5 MB). Frame the size as a key advantage over typical AI containers.
+- **Environment variables** (`### Environment Variables`): Document all seven environment variables in a markdown table with columns: Variable, Required, Default, Description. Include `SKILL_NAME`, `SKILL_DIR`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `TOOL_ENDPOINTS`, `BIND_ADDR`, and `RUST_LOG`. Mark `SKILL_NAME` as set at build time (baked into the image as a default) but overridable at runtime. Mark the API key variables as conditionally required based on the provider specified in the skill file.
+- **`FROM scratch` limitations** (`### Debugging`): Explain that `FROM scratch` images contain no shell, no package manager, and no debugging utilities. Document two workarounds: (1) `docker cp <container>:/agent-runtime ./agent-runtime` to extract the binary for local inspection, and (2) temporarily switching the Dockerfile's `FROM scratch` to `FROM alpine` to get a shell for interactive debugging. Note that `docker exec` will not work with `FROM scratch`.
+- All code examples must use fenced code blocks with the `sh` or `bash` language identifier.
+- Do not modify any existing sections of the README. Only insert the new Docker section.
+- The documentation must be accurate relative to the actual source code (environment variable names, defaults, and behavior as documented in "Current State" above).
+
+## Implementation Details
+
+### Insertion point
+
+Insert the new `## Docker` section after the "Tech Stack" table (after line 129, which is the last row of the tech stack table) and before `## Key Properties` (currently line 131). Add a blank line before and after the new section.
+
+### Section content outline
+
+```
+## Docker
+
+### Build
+
+<paragraph explaining build args>
+<code block: docker build command>
+
+### Run
+
+<paragraph explaining runtime config>
+<code block: docker run command>
+<code block: curl health check>
+
+### Image Size
+
+<code block: docker images command>
+<paragraph about expected size>
+
+### Environment Variables
+
+<table with all 7 variables>
+
+### Debugging
+
+<paragraph about FROM scratch limitations>
+<code block: docker cp workaround>
+<paragraph about alpine workaround>
+```
+
+### Variable table format
+
+Use this exact column layout for consistency with the existing "Tech Stack" table style:
+
+```
+| Variable | Required | Default | Description |
+|---|---|---|---|
+```
+
+### Command examples
+
+- Build: `docker build --build-arg SKILL_NAME=echo -t spore-echo .`
+- Run: `docker run -p 8080:8080 -e ANTHROPIC_API_KEY=sk-... spore-echo`
+- Health check: `curl http://localhost:8080/health`
+- Image size: `docker images spore-echo`
+- Copy binary out: `docker cp <container_id>:/agent-runtime ./agent-runtime`
+
+## Dependencies
+
+- Blocked by: "Create multi-stage Dockerfile" — the Docker section documents the Dockerfile, so the Dockerfile must exist first to ensure the documentation is accurate (build arg names, exposed ports, entrypoint, default ENV values).
+- Blocking: None
+
+## Risks & Edge Cases
+
+- **Dockerfile not yet finalized**: Since this task is blocked by the Dockerfile creation task, the exact build arg names, default ENV values, and exposed ports documented here are based on the task description in `.claude/tasks/issue-14.md`. If the Dockerfile implementation deviates from the task description, this documentation must be updated to match. Mitigation: the spec captures the source-of-truth environment variables from the actual Rust source code, which will not change.
+- **API key in command examples**: The `docker run` example includes `-e ANTHROPIC_API_KEY=...`. Using a placeholder like `sk-...` or `your-key-here` avoids accidentally encouraging users to paste real keys into shell history. The example must use a clearly-fake placeholder value.
+- **Image size claims**: The README already claims "1-5MB Docker images" in multiple places (lines 15, 135). The realistic size with the full dependency tree (`tokio`, `axum`, `rig-core`, `reqwest`, `rustls`, `aws-lc-rs`) is 5-10 MB per the task file's implementation notes. The Docker section should state the realistic range and avoid contradicting the existing claims by framing it as "typically under 10 MB" rather than making a specific promise.
+- **Provider-conditional API keys**: `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are only required when the skill file specifies the corresponding provider. The documentation must make this conditionality clear to avoid confusion (e.g., a user running an Anthropic-backed skill should not think `OPENAI_API_KEY` is also needed).
+- **`TOOL_ENDPOINTS` format**: The format is `name=endpoint,name=endpoint` (comma-separated key=value pairs). This non-obvious format must be documented with an example value to prevent user confusion.
+
+## Verification
+
+- The `## Docker` section appears in `README.md` between `## Tech Stack` and `## Key Properties`.
+- The section contains exactly five subsections: Build, Run, Image Size, Environment Variables, Debugging.
+- All seven environment variables (`SKILL_NAME`, `SKILL_DIR`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `TOOL_ENDPOINTS`, `BIND_ADDR`, `RUST_LOG`) are documented in the table.
+- Variable names, defaults, and required/optional status match the source code in `config.rs`, `main.rs`, and `provider.rs`.
+- All code examples use fenced code blocks with a language identifier.
+- The `docker build` command includes `--build-arg SKILL_NAME=echo -t spore-echo .`.
+- The `docker run` command includes `-p 8080:8080 -e ANTHROPIC_API_KEY=...`.
+- The `docker images` command is present for size checking.
+- The `FROM scratch` limitation is explained with both workarounds (`docker cp` and `FROM alpine`).
+- No existing README sections are modified or removed.
+- API key placeholders use clearly-fake values (not real key patterns).
+- `cargo test` still passes (no code changes, but ensures nothing is broken by stale state).

--- a/.claude/specs/issue-14/add-release-profile-optimizations.md
+++ b/.claude/specs/issue-14/add-release-profile-optimizations.md
@@ -1,0 +1,101 @@
+# Spec: Add release profile optimizations to workspace `Cargo.toml`
+
+> From: .claude/tasks/issue-14.md
+
+## Objective
+
+Add a `[profile.release]` section to the workspace-level `Cargo.toml` with binary-size-optimizing settings. These settings are critical for achieving the 1-5 MB Docker image size target defined in issue #14. Without them, the `agent-runtime` binary (which pulls in `tokio`, `axum`, `serde`, `rig-core`, `reqwest`, `rustls`, and `aws-lc-rs`) will be 10-20 MB. With these optimizations, the stripped binary should be in the 5-8 MB range.
+
+## Current State
+
+The workspace `Cargo.toml` at `/workspaces/spore/Cargo.toml` contains only workspace membership configuration and has no profile sections:
+
+```toml
+[workspace]
+resolver = "2"
+members = [
+    "crates/agent-sdk",
+    "crates/skill-loader",
+    "crates/tool-registry",
+    "crates/agent-runtime",
+    "crates/orchestrator",
+    "tools/echo-tool",
+]
+```
+
+None of the six member crate `Cargo.toml` files contain any `[profile.*]` sections. There are no existing release profile settings anywhere in the workspace.
+
+## Requirements
+
+- The workspace-level `Cargo.toml` must contain a `[profile.release]` section with exactly these settings:
+  - `lto = true` -- enables full link-time optimization across all crates, allowing the linker to eliminate dead code across crate boundaries
+  - `opt-level = "z"` -- optimizes aggressively for binary size over speed (more aggressive than `"s"`)
+  - `codegen-units = 1` -- compiles each crate as a single codegen unit, enabling maximum optimization at the cost of compilation parallelism
+  - `strip = true` -- strips debug symbols and symbol tables from the final binary
+  - `panic = "abort"` -- uses abort-on-panic instead of unwinding, removing the unwinding infrastructure from the binary
+- The settings must apply to all workspace members via workspace-level inheritance (no per-crate profile overrides)
+- The existing `[workspace]` section and its contents must remain unchanged
+- `cargo build --release` must complete without errors after the change
+- `cargo test` must still pass (Cargo automatically ignores `panic = "abort"` for test builds and uses `unwind` instead, so tests are unaffected)
+
+## Implementation Details
+
+**File to modify:** `Cargo.toml` (workspace root, `/workspaces/spore/Cargo.toml`)
+
+Append the following section after the existing `[workspace]` block:
+
+```toml
+[profile.release]
+lto = true
+opt-level = "z"
+codegen-units = 1
+strip = true
+panic = "abort"
+```
+
+### Effect of each setting
+
+| Setting | Default | New Value | Effect on binary size |
+|---------|---------|-----------|----------------------|
+| `lto` | `false` (thin) | `true` (fat) | Enables cross-crate dead-code elimination; 20-40% size reduction |
+| `opt-level` | `3` (speed) | `"z"` (size) | Prioritizes size over speed; 10-30% size reduction |
+| `codegen-units` | `16` | `1` | Allows LLVM to optimize across the entire crate as one unit; 5-15% size reduction |
+| `strip` | `false` | `true` | Removes symbol tables and debug info; 30-60% size reduction |
+| `panic` | `"unwind"` | `"abort"` | Removes stack unwinding infrastructure; 5-10% size reduction |
+
+### No other files need modification
+
+Profile sections in Cargo are only valid at the workspace root level. Individual member crate `Cargo.toml` files do not need changes and cannot override `[profile.release]`.
+
+## Dependencies
+
+- Blocked by: None
+- Blocking: "Create multi-stage Dockerfile" (the Dockerfile's `cargo build --release` depends on these settings to produce a small binary)
+
+## Risks & Edge Cases
+
+1. **`panic = "abort"` and tests:** Cargo automatically overrides `panic = "abort"` with `panic = "unwind"` when running `cargo test`, because the test harness requires unwinding to catch panics. Therefore, `cargo test` will continue to work correctly. However, any integration tests that rely on `std::panic::catch_unwind` in the release binary itself (not in test mode) would not be able to catch panics. Currently no code in this workspace uses `catch_unwind`, so this is not a concern.
+
+2. **`panic = "abort"` and runtime behavior:** In production, any panic will immediately terminate the process rather than unwinding the stack. This is appropriate for a server binary that will be restarted by a container orchestrator (Docker, Kubernetes). It means destructors (`Drop` impls) will not run on panic. Review the codebase for any `Drop` impls that perform critical cleanup (e.g., flushing data to disk). Currently the codebase has no such critical `Drop` implementations.
+
+3. **LTO increases compile times significantly:** Full LTO (`lto = true`) can increase release build times by 2-5x compared to the default thin LTO. This only affects `cargo build --release`; debug builds and `cargo test` are unaffected. For CI, this means release builds will be slower, but this is an acceptable tradeoff for the Docker image size target. If build times become problematic, `lto = "thin"` is a middle ground (smaller size improvement but faster builds).
+
+4. **`opt-level = "z"` and performance:** Optimizing for size (`"z"`) may result in slightly slower runtime performance compared to the default `opt-level = 3`. For an AI agent runtime that is primarily I/O-bound (waiting on LLM API calls), this performance difference is negligible.
+
+5. **`codegen-units = 1` and compile times:** Single codegen unit prevents parallel code generation within a crate, increasing compile times. Combined with full LTO, release builds will be noticeably slower. This is acceptable since release builds are infrequent (Docker image builds, CI releases).
+
+6. **No impact on `cargo build` (debug):** All settings are under `[profile.release]` and do not affect debug builds. Developer iteration speed with `cargo build` / `cargo run` is unchanged.
+
+## Verification
+
+1. **Syntax check:** Run `cargo check` to confirm the workspace `Cargo.toml` parses correctly with the new profile section.
+
+2. **Release build succeeds:** Run `cargo build --release` and confirm it completes without errors.
+
+3. **Tests pass:** Run `cargo test` and confirm all tests pass (verifying `panic = "abort"` does not break the test harness).
+
+4. **Binary size comparison (informational):** Compare the size of `target/release/agent-runtime` before and after the change. Expected reduction is 50-70% (e.g., from ~15 MB to ~5-8 MB). This can be checked with `ls -lh target/release/agent-runtime`.
+
+5. **Lint check:** Run `cargo clippy` to confirm no new warnings are introduced.
+
+6. **Settings are applied:** Run `cargo build --release -v 2>&1 | grep -E '(lto|codegen-units|opt-level)'` to confirm the compiler flags reflect the new settings.

--- a/.claude/specs/issue-14/create-dockerignore-file.md
+++ b/.claude/specs/issue-14/create-dockerignore-file.md
@@ -1,0 +1,137 @@
+# Spec: Create `.dockerignore` file
+
+> From: .claude/tasks/issue-14.md
+
+## Objective
+
+Create a `.dockerignore` file at the project root to minimize the Docker build context size. Without this file, `docker build` sends the entire working directory to the Docker daemon, including the `target/` directory (which can be several gigabytes of compiled artifacts), the `.git/` history, worktree clones, and other files irrelevant to the image build. A well-crafted `.dockerignore` reduces context transfer from gigabytes to kilobytes, making builds faster and avoiding accidental inclusion of secrets or large binaries.
+
+## Current State
+
+- No `.dockerignore` file exists in the project.
+- No `Dockerfile` exists yet either (that is a separate downstream task in the same issue).
+- The project root contains these directories and files relevant to exclusion decisions:
+  - `target/` -- Rust build artifacts (multi-GB)
+  - `.git/` -- Git history
+  - `.worktrees/` -- Git worktree checkouts
+  - `.claude/` -- Claude Code configuration, logs, specs, tasks
+  - `README.md`, `CLAUDE.md` -- Markdown files at the root
+  - `.DS_Store` -- macOS metadata
+  - `.gitignore` -- Git ignore rules (useful reference but not needed in image)
+  - `Cargo.lock`, `Cargo.toml` -- needed for the build (must NOT be excluded)
+  - `crates/` -- Rust source code (must NOT be excluded)
+  - `tools/` -- Rust tool source code (must NOT be excluded)
+  - `skills/` -- Skill definition markdown files (must NOT be excluded; these are copied into the final Docker image)
+- The existing `.gitignore` excludes: `target/`, `debug/`, `*.pdb`, `*.swp`, `*.swo`, `*~`, `.vscode/`, `.idea/`, `.DS_Store`, `Thumbs.db`, `.env`, `.env.*`, `CLAUDE.local.md`, and various `.claude/` subdirectories.
+- Three skill files exist at `skills/echo.md`, `skills/cogs-analyst.md`, and `skills/skill-writer.md`.
+
+## Requirements
+
+1. **File location:** `.dockerignore` at the project root.
+
+2. **Exclude build artifacts:** `target/` must be excluded. This is the single largest contributor to context size.
+
+3. **Exclude version control:** `.git/` must be excluded. Git history is not needed inside the image and can be hundreds of megabytes.
+
+4. **Exclude worktrees:** `.worktrees/` must be excluded. These are full repository clones used for parallel development.
+
+5. **Exclude Claude Code configuration:** `.claude/` must be excluded. This contains logs, specs, tasks, agent configs, and other development tooling not needed at runtime.
+
+6. **Exclude markdown files globally, then re-include `skills/`:** Use `*.md` to exclude all markdown files (README.md, CLAUDE.md, etc.), then use the negation pattern `!skills/` and `!skills/*.md` to re-include the skill definition files. The skill files (`skills/echo.md`, `skills/cogs-analyst.md`, `skills/skill-writer.md`) are required at runtime because the Dockerfile copies them into the final image for the agent to load.
+
+7. **Exclude editor/IDE files:** `.vscode/`, `.idea/`, `*.swp`, `*.swo`, `*~` -- consistent with what `.gitignore` already excludes.
+
+8. **Exclude OS metadata files:** `.DS_Store`, `Thumbs.db`.
+
+9. **Exclude environment files:** `.env`, `.env.*` -- these may contain API keys and must never be sent to the Docker daemon.
+
+10. **Exclude Cargo debug artifacts:** `*.pdb`, `debug/` -- consistent with `.gitignore`.
+
+11. **Do NOT exclude:** `Cargo.toml`, `Cargo.lock`, `crates/`, `tools/`, `skills/`, `src/` -- these are all required for the Docker build.
+
+## Implementation Details
+
+**File to create:** `.dockerignore`
+
+The file should be organized into clearly commented sections for maintainability. The key Docker-specific behavior to leverage:
+
+- Lines starting with `#` are comments.
+- Lines starting with `!` are negation patterns (re-include previously excluded paths).
+- Patterns are evaluated top-to-bottom; later rules override earlier ones.
+- `.dockerignore` uses Go's `filepath.Match` rules plus a `**` wildcard for directory matching.
+
+**Recommended structure:**
+
+```
+# Build artifacts
+target/
+debug/
+*.pdb
+
+# Version control
+.git/
+
+# Worktrees
+.worktrees/
+
+# Claude Code
+.claude/
+
+# Documentation (skill files re-included below)
+*.md
+
+# Re-include skill files needed at runtime
+!skills/
+!skills/*.md
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Environment / secrets
+.env
+.env.*
+
+# Docker (not needed inside build context)
+Dockerfile
+.dockerignore
+```
+
+**Critical ordering note:** The `*.md` exclusion must appear BEFORE the `!skills/` and `!skills/*.md` negation patterns. Docker processes `.dockerignore` rules sequentially, and negation patterns only work if the path was previously excluded by an earlier rule.
+
+**Dockerfile and .dockerignore self-exclusion:** Including `Dockerfile` and `.dockerignore` themselves is a common best practice -- they are not needed inside the build context since Docker reads them before sending the context.
+
+## Dependencies
+
+- Blocked by: None
+- Blocking: None (the downstream "Create multi-stage Dockerfile" task does not strictly depend on this file existing first, but having it in place ensures the Dockerfile build is efficient from the start)
+
+## Risks & Edge Cases
+
+1. **Negation pattern ordering:** If `!skills/*.md` is placed before `*.md`, the negation has no effect because there is nothing to negate yet. The exclusion of `*.md` must come first. This is the most common mistake with `.dockerignore` negation patterns.
+
+2. **Nested markdown files in crates:** Files like `crates/*/README.md` will be excluded by the `*.md` glob. This is acceptable because no Rust crate in this project uses markdown files at build time. If a crate ever adds a `build.rs` that reads a markdown file, the `.dockerignore` would need updating.
+
+3. **New skill files in subdirectories:** If skill files are added in subdirectories of `skills/` (e.g., `skills/advanced/my-skill.md`), the pattern `!skills/*.md` would not match them. The pattern would need to be changed to `!skills/**/*.md`. For now, all three skill files are at the top level of `skills/`, so `!skills/*.md` is sufficient. The implementer should add a comment noting this limitation.
+
+4. **`Cargo.lock` must not be excluded:** Some `.dockerignore` templates exclude `*.lock` files. This would break reproducible builds. The spec explicitly requires `Cargo.lock` to remain included.
+
+5. **`.env` files and secrets:** Excluding `.env` and `.env.*` is a security measure. Even though `.gitignore` excludes them from version control, they could still exist on disk and be sent to the Docker daemon without a `.dockerignore` entry. The Docker daemon context is not encrypted and could be exposed in CI logs.
+
+6. **No `**` prefix needed for top-level patterns:** In `.dockerignore`, patterns like `target/` are anchored to the build context root by default. Since `target/` only exists at the project root, `target/` is correct (not `**/target/`).
+
+## Verification
+
+1. **File exists at the project root:** Confirm `.dockerignore` exists at the repository root.
+2. **Context size is small:** Run `docker build --no-cache -f /dev/null .` (or equivalent) and verify the context size is under 1 MB, not several GB.
+3. **Skill files are included:** After creating the Dockerfile (downstream task), verify that `docker build` can `COPY skills/ /skills/` successfully -- meaning the skill `.md` files are present in the build context despite the `*.md` exclusion.
+4. **No secrets in context:** Verify that `.env` patterns are excluded by creating a dummy `.env` file and confirming it is not sent to the daemon.
+5. **Syntax is valid:** The file should contain no trailing whitespace on pattern lines, no blank negation patterns, and no Windows-style line endings (use LF, not CRLF).
+6. **Consistency with `.gitignore`:** Visually confirm that all editor/IDE and OS patterns from `.gitignore` are also present in `.dockerignore`. The `.dockerignore` should be a superset of `.gitignore` for build-irrelevant files.

--- a/.claude/specs/issue-14/create-multi-stage-dockerfile.md
+++ b/.claude/specs/issue-14/create-multi-stage-dockerfile.md
@@ -1,0 +1,227 @@
+# Spec: Create multi-stage Dockerfile
+
+> From: .claude/tasks/issue-14.md
+
+## Objective
+
+Create a multi-stage Dockerfile that compiles the `agent-runtime` binary as a fully static musl-linked binary and packages it in a minimal `FROM scratch` image alongside the skill file(s) and CA certificates. The goal is to produce a production-ready container image in the 5-15 MB range that can serve the HTTP API on port 8080 and make outbound HTTPS calls to LLM provider APIs.
+
+## Current State
+
+### Workspace structure
+
+The project is a Cargo workspace with 6 members:
+
+| Member | Path | Type | Has `lib.rs` | Has `main.rs` |
+|--------|------|------|-------------|---------------|
+| `agent-sdk` | `crates/agent-sdk` | library | yes | no |
+| `skill-loader` | `crates/skill-loader` | library | yes | no |
+| `tool-registry` | `crates/tool-registry` | library | yes | no |
+| `agent-runtime` | `crates/agent-runtime` | binary + library | yes | yes |
+| `orchestrator` | `crates/orchestrator` | binary | no | yes |
+| `echo-tool` | `tools/echo-tool` | binary | no | yes (with `mod echo`) |
+
+The workspace `Cargo.toml` at the root defines only `[workspace]` with `resolver = "2"` and the members list. A `[profile.release]` section with size optimizations (`lto = true`, `opt-level = "z"`, `codegen-units = 1`, `strip = true`, `panic = "abort"`) is expected to be added by the prerequisite task before this Dockerfile is implemented.
+
+### Dependency tree (TLS/crypto path)
+
+The TLS chain is: `rig-core` -> `reqwest` -> `hyper-rustls` -> `rustls` -> `aws-lc-rs` -> `aws-lc-sys`. The `aws-lc-sys` crate (v0.38.0) has build-time dependencies on `cc`, `cmake`, `dunce`, and `fs_extra`. This means `cmake` must be installed in the builder stage. There is **no** dependency on `openssl` or `openssl-sys`, making a fully static musl build viable.
+
+### Binary entry point
+
+`agent-runtime` is the target binary. Its `main.rs` reads configuration via `RuntimeConfig::from_env()`, which requires:
+- `SKILL_NAME` (required) -- name of the skill to load
+- `SKILL_DIR` (optional, defaults to `./skills`) -- directory containing skill `.md` files
+- `BIND_ADDR` (optional, defaults to `0.0.0.0:8080`) -- socket address to bind the HTTP server
+
+### Skills directory
+
+Skills live in `skills/` as Markdown files with YAML frontmatter:
+- `echo.md`
+- `cogs-analyst.md`
+- `skill-writer.md`
+
+### echo-tool module structure
+
+The `echo-tool` binary has a non-trivial source layout: `src/main.rs` declares `mod echo;` and imports from `src/echo.rs`. The dependency-caching stub must account for this by creating both `src/main.rs` and `src/echo.rs` stubs.
+
+## Requirements
+
+1. The Dockerfile MUST be placed at the project root (`Dockerfile`).
+2. The Dockerfile MUST use exactly two stages: a `builder` stage and a `runtime` stage.
+3. The builder stage MUST use `rust:latest` as the base image.
+4. The builder stage MUST install `musl-tools` and `cmake` via `apt-get`.
+5. The builder stage MUST add the `x86_64-unknown-linux-musl` target via `rustup target add`.
+6. The builder stage MUST implement the dependency-caching pattern: copy manifest files and create stub sources first, build to cache dependencies, then copy real sources and rebuild.
+7. The dependency-caching pattern MUST create stub files for all 6 workspace members with the correct source file types (lib.rs for libraries, main.rs for binaries, plus echo.rs for echo-tool).
+8. The builder stage MUST accept `SKILL_NAME` as a Docker `ARG` with a sensible default (e.g., `echo`).
+9. The builder stage MUST build only the `agent-runtime` binary (not all workspace members) in release mode targeting `x86_64-unknown-linux-musl`.
+10. The builder stage MUST verify the binary is statically linked using the `file` command (via `RUN file ... | grep -q 'statically linked'`).
+11. The runtime stage MUST use `FROM scratch`.
+12. The runtime stage MUST copy the compiled `agent-runtime` binary to `/agent-runtime`.
+13. The runtime stage MUST copy the entire `skills/` directory from the build context (for flexibility at runtime).
+14. The runtime stage MUST copy CA certificates from the builder stage (`/etc/ssl/certs/ca-certificates.crt`) to the same path.
+15. The runtime stage MUST set `ENV SKILL_NAME` to the value of the build arg and `ENV SKILL_DIR` to `/skills`.
+16. The runtime stage MUST set `ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt` so that `rustls` can locate the CA bundle.
+17. The runtime stage MUST `EXPOSE 8080`.
+18. The runtime stage MUST set `ENTRYPOINT ["/agent-runtime"]`.
+19. The Dockerfile MUST NOT install `openssl` or `libssl-dev` -- TLS is handled entirely by `rustls`/`aws-lc-rs`.
+
+## Implementation Details
+
+### Stage 1: builder
+
+```
+FROM rust:latest AS builder
+```
+
+**System dependencies:**
+
+```
+RUN apt-get update && apt-get install -y musl-tools cmake \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+- `musl-tools`: provides `musl-gcc`, the linker wrapper needed for `x86_64-unknown-linux-musl`.
+- `cmake`: required by `aws-lc-sys` (which builds the aws-lc C library from source).
+
+**Rust target:**
+
+```
+RUN rustup target add x86_64-unknown-linux-musl
+```
+
+**Build arg:**
+
+```
+ARG SKILL_NAME=echo
+```
+
+**Dependency-caching pattern:**
+
+The key insight is that `cargo build` caches compiled dependencies as long as the `Cargo.toml`/`Cargo.lock` files have not changed. By first copying only manifests and creating minimal stub source files, the expensive dependency compilation is cached in a Docker layer. Subsequent builds that only change application source code skip dependency compilation entirely.
+
+Step 1 -- Create directory structure and copy workspace manifests:
+```
+WORKDIR /app
+
+RUN mkdir -p crates/agent-sdk/src \
+             crates/skill-loader/src \
+             crates/tool-registry/src \
+             crates/agent-runtime/src \
+             crates/orchestrator/src \
+             tools/echo-tool/src
+
+COPY Cargo.toml Cargo.lock ./
+COPY crates/agent-sdk/Cargo.toml crates/agent-sdk/Cargo.toml
+COPY crates/skill-loader/Cargo.toml crates/skill-loader/Cargo.toml
+COPY crates/tool-registry/Cargo.toml crates/tool-registry/Cargo.toml
+COPY crates/agent-runtime/Cargo.toml crates/agent-runtime/Cargo.toml
+COPY crates/orchestrator/Cargo.toml crates/orchestrator/Cargo.toml
+COPY tools/echo-tool/Cargo.toml tools/echo-tool/Cargo.toml
+```
+
+Step 2 -- Create stub source files:
+
+For **library** crates (`agent-sdk`, `skill-loader`, `tool-registry`), create an empty `src/lib.rs`. For **binary** crates (`orchestrator`, `echo-tool`), create a `src/main.rs` with `fn main() {}`. For `echo-tool`, also create a stub `src/echo.rs` (because the real `main.rs` contains `mod echo;`). For `agent-runtime` (both lib and bin), create both files:
+
+```
+RUN echo "" > crates/agent-sdk/src/lib.rs && \
+    echo "" > crates/skill-loader/src/lib.rs && \
+    echo "" > crates/tool-registry/src/lib.rs && \
+    echo "" > crates/agent-runtime/src/lib.rs && \
+    echo "fn main() {}" > crates/agent-runtime/src/main.rs && \
+    echo "fn main() {}" > crates/orchestrator/src/main.rs && \
+    echo "fn main() {}" > tools/echo-tool/src/main.rs && \
+    touch tools/echo-tool/src/echo.rs
+```
+
+Step 3 -- Build dependencies only:
+```
+RUN cargo build --release --target x86_64-unknown-linux-musl -p agent-runtime
+```
+
+Step 4 -- Copy real source and rebuild:
+```
+COPY crates/ crates/
+COPY tools/ tools/
+RUN cargo build --release --target x86_64-unknown-linux-musl -p agent-runtime
+```
+
+**Static-link verification:**
+
+```
+RUN file target/x86_64-unknown-linux-musl/release/agent-runtime | grep -q 'statically linked'
+```
+
+### Stage 2: runtime
+
+```
+FROM scratch
+```
+
+**Copy binary:**
+```
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/agent-runtime /agent-runtime
+```
+
+**Copy skills (entire directory for runtime flexibility):**
+```
+COPY skills/ /skills/
+```
+
+**Copy CA certificates:**
+```
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+```
+
+**Environment and entrypoint:**
+```
+ARG SKILL_NAME=echo
+ENV SKILL_NAME=${SKILL_NAME}
+ENV SKILL_DIR=/skills
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+EXPOSE 8080
+
+ENTRYPOINT ["/agent-runtime"]
+```
+
+The `ARG` must be re-declared in the runtime stage because Docker ARGs do not cross stage boundaries. The `SSL_CERT_FILE` environment variable is the standard way to tell `rustls-native-certs` / `openssl-probe` where to find the CA bundle.
+
+## Dependencies
+
+- **Blocked by:** "Add release profile optimizations to workspace `Cargo.toml`" -- The `[profile.release]` with `lto = true`, `opt-level = "z"`, `codegen-units = 1`, `strip = true`, `panic = "abort"` must be present in the workspace `Cargo.toml` before building the Dockerfile, otherwise the binary will be 10-20 MB instead of 5-10 MB.
+- **Blocking:** "Add build and run documentation" (needs to document `docker build` / `docker run` commands), "Verify image builds and meets size target" (needs the Dockerfile to exist).
+
+## Risks & Edge Cases
+
+1. **`aws-lc-sys` + musl build failure:** `aws-lc-sys` builds a C library (`aws-lc`) from source using CMake. Cross-compiling this for musl can fail if the musl toolchain is not properly configured. The `musl-tools` package on Debian provides `musl-gcc` which should work, but the CMake build may need the `CC` environment variable set explicitly to `musl-gcc`, or `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc` may need to be set. If this fails, add these environment variables to the Dockerfile.
+
+2. **Architecture assumption:** The Dockerfile hardcodes `x86_64-unknown-linux-musl`. It will not work on ARM64 hosts without modification. Multi-arch support via `--platform` or `cross` could be a follow-up, but is out of scope.
+
+3. **echo-tool stub compilation:** The `echo-tool` uses `rmcp` v1 while other crates use v0.16. The workspace allows this because they are separate dependencies. However, the stub must create both `src/main.rs` and `src/echo.rs` to satisfy the `mod echo;` declaration in the real source. If any workspace member adds new `mod` declarations in the future, the stubs will need updating.
+
+4. **Cargo workspace resolution with stubs:** The stub `lib.rs` files are empty, which means any inter-crate `use` statements will fail during the stub build. This is expected -- the stub build may produce warnings or partial compilation errors for workspace crates, but the external dependency crates will still be compiled and cached.
+
+5. **CA certificate path:** Different Linux distributions place CA certificates in different locations. `rust:latest` is Debian-based, so `/etc/ssl/certs/ca-certificates.crt` is correct. The `SSL_CERT_FILE` environment variable ensures `rustls-native-certs` and `openssl-probe` find the bundle regardless of compile-time assumptions.
+
+6. **`FROM scratch` debugging limitations:** A scratch image has no shell, no `ls`, no debugging tools. If the binary crashes, the only diagnostic is the container exit code and any logs written to stdout/stderr. Temporarily switching to `FROM alpine` is useful for debugging.
+
+7. **Skills directory vs single file:** The spec copies the entire `skills/` directory rather than just `skills/${SKILL_NAME}.md`. This is a deliberate tradeoff: slightly larger image (~4 KB for all 3 current skill files) in exchange for runtime flexibility (can override `SKILL_NAME` without rebuilding).
+
+8. **Build context size:** Without a `.dockerignore` file, `docker build` will send the entire project directory (including `target/`, `.git/`, etc.) as context, which can be multiple gigabytes. The `.dockerignore` task in Group 1 should be completed first or simultaneously.
+
+9. **Layer ordering for cache efficiency:** The `apt-get` and `rustup` steps should come before any `COPY` commands, since system dependencies change less frequently than Rust dependencies. This maximizes layer cache hits.
+
+## Verification
+
+1. **Build succeeds:** `docker build --build-arg SKILL_NAME=echo -t spore-echo .` completes without errors.
+2. **Binary is statically linked:** The `file` command check in the builder stage serves as an in-build assertion.
+3. **Image size is reasonable:** `docker images spore-echo --format '{{.Size}}'` should report under 15 MB. Target is 5-10 MB with release optimizations.
+4. **Skills are present:** Runtime successfully loads the skill (logs `[4/7] Loading skill manifest` before failing on missing API keys).
+5. **CA certificates work:** When run with a valid `ANTHROPIC_API_KEY`, the container can make HTTPS calls without TLS certificate errors.
+6. **Environment variables are set:** `docker inspect spore-echo --format '{{.Config.Env}}'` should show `SKILL_NAME=echo`, `SKILL_DIR=/skills`, and `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`.
+7. **Port is exposed:** `docker inspect spore-echo --format '{{.Config.ExposedPorts}}'` should show `8080/tcp`.
+8. **Entrypoint is correct:** `docker inspect spore-echo --format '{{.Config.Entrypoint}}'` should show `[/agent-runtime]`.
+9. **Dependency caching works:** Run `docker build` twice with only a source file change. The second build should skip the dependency compilation layer and complete significantly faster.

--- a/.claude/specs/issue-14/verify-image-builds-and-meets-size-target.md
+++ b/.claude/specs/issue-14/verify-image-builds-and-meets-size-target.md
@@ -1,0 +1,147 @@
+# Spec: Verify image builds and meets size target
+
+> From: .claude/tasks/issue-14.md
+
+## Objective
+
+Validate that the multi-stage Dockerfile produces a working, correctly-sized Docker image. This is a verification-only task -- no code is written. The goal is to confirm four properties: (1) the Docker build completes without errors, (2) the final image meets the size target, (3) the container starts and begins its startup sequence, and (4) the binary inside is statically linked. If the image exceeds expectations, document the actual size and identify the contributing dependencies.
+
+## Current State
+
+- **No CI/CD infrastructure**: There are no GitHub Actions workflows or automated Docker build pipelines. All verification is manual.
+- **No Dockerfile yet**: This task is blocked by "Create multi-stage Dockerfile". The Dockerfile does not exist on `main` at this time.
+- **No `.dockerignore` yet**: Also blocked by Group 1 tasks (`.dockerignore` creation and release profile optimizations).
+- **Existing test infrastructure**: `cargo test` runs unit and integration tests across the workspace. There are no Docker-specific tests.
+- **Echo skill available**: `skills/echo.md` exists and uses the `anthropic` provider with `claude-haiku-4-5-20251001`. It has no tools (`tools: []`), making it the simplest skill for testing.
+
+## Requirements
+
+### R1: Docker build completes without errors
+
+- **Command**: `docker build --build-arg SKILL_NAME=echo -t spore-echo .`
+- **Pass criteria**: Exit code 0, no error messages in build output.
+- **Fail criteria**: Any non-zero exit code, or errors during compilation, musl linking, or `COPY` steps.
+
+### R2: Image size is under 15 MB (hard limit), ideally under 5 MB
+
+- **Command**: `docker images spore-echo --format "{{.Size}}"`
+- **Hard pass**: Image size < 15 MB.
+- **Ideal pass**: Image size < 5 MB.
+- **Acceptable**: Image size 5-15 MB. Document the actual size in a comment or PR description.
+- **Fail**: Image size >= 15 MB.
+- **Note**: With `tokio`, `axum`, `serde`, `rig-core`, `reqwest`, `rustls`, and `aws-lc-rs`, a realistic stripped static binary is 5-10 MB. The `[profile.release]` settings (`lto = true`, `opt-level = "z"`, `codegen-units = 1`, `strip = true`, `panic = "abort"`) should bring it toward the lower end. The 1 MB target from the original issue is aspirational and not expected.
+
+### R3: Container starts without crashing
+
+- **Command**: `docker run --rm spore-echo` (with a timeout, since it will block waiting for connections)
+- **Pass criteria**: The container produces log output showing at least the first startup steps before failing. Expected log sequence:
+  1. `[1/7] Loading configuration` -- config loads (`SKILL_NAME=echo` is set via Dockerfile `ENV`)
+  2. `[2/7] Registering tool entries` -- tool endpoints registered (defaults to `echo-tool=mcp://localhost:7001`)
+  3. `[3/7] Connecting to tool servers` -- will attempt MCP connection to `localhost:7001`
+- **Expected failure point**: The container will fail at step 3 (connecting to tool servers) because there is no MCP tool server running at `localhost:7001` inside the container. This is acceptable. Alternatively, if `TOOL_ENDPOINTS` is overridden to empty, it will fail at step 5 when building the agent due to missing `ANTHROPIC_API_KEY`.
+- **Fail criteria**: The container exits immediately with a signal (SIGSEGV, SIGILL, SIGABRT) or produces no output at all, indicating the binary cannot execute (e.g., dynamic linker missing in scratch image).
+- **Verification command**: `timeout 5 docker run --rm spore-echo 2>&1 || true` -- capture stderr (tracing writes to stderr) and allow the non-zero exit.
+- **Alternative for cleaner startup**: `timeout 5 docker run --rm -e TOOL_ENDPOINTS="" spore-echo 2>&1 || true` -- skips tool registration, will fail at step 5 (missing API key) but confirms more startup steps succeed.
+
+### R4: Binary is statically linked
+
+- **Command**: Use a helper container to inspect the binary:
+  ```
+  docker create --name spore-echo-inspect spore-echo
+  docker cp spore-echo-inspect:/agent-runtime /tmp/agent-runtime-check
+  docker rm spore-echo-inspect
+  file /tmp/agent-runtime-check
+  ```
+- **Pass criteria**: `file` output contains `statically linked`.
+- **Fail criteria**: `file` output shows `dynamically linked` or references `ld-linux` / `ld-musl`.
+- **Alternative** (if `file` is not available on the host): Build a small alpine container to inspect:
+  ```
+  docker run --rm -v /tmp/agent-runtime-check:/binary alpine file /binary
+  ```
+
+### R5: Document size breakdown if image exceeds 5 MB
+
+- If the image exceeds 5 MB, the verifier should note:
+  - The actual total image size.
+  - The binary size (from `ls -lh /tmp/agent-runtime-check`).
+  - The skill file size (check on the host: `ls -lh skills/echo.md`).
+  - The CA certificate bundle size (typically ~200 KB, negligible).
+  - A note that the primary contributor is the Rust binary itself, and which dependency families (TLS/crypto via `aws-lc-rs`, HTTP via `hyper`/`reqwest`, async runtime via `tokio`, LLM client via `rig-core`) account for the bulk.
+
+## Implementation Details
+
+The full verification sequence, intended to be run manually by the implementer:
+
+```bash
+# Step 1: Build the image
+docker build --build-arg SKILL_NAME=echo -t spore-echo .
+echo "Build exit code: $?"
+
+# Step 2: Check image size
+docker images spore-echo --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}"
+SIZE_BYTES=$(docker inspect spore-echo --format='{{.Size}}')
+SIZE_MB=$((SIZE_BYTES / 1048576))
+echo "Image size: ${SIZE_MB} MB (${SIZE_BYTES} bytes)"
+
+# Step 3: Run the container (expect failure, but should show startup logs)
+echo "--- Container startup output (expect failure at tool connect or API key) ---"
+timeout 5 docker run --rm -e TOOL_ENDPOINTS="" spore-echo 2>&1 || true
+echo "--- End container output ---"
+
+# Step 4: Check static linking
+docker create --name spore-echo-inspect spore-echo
+docker cp spore-echo-inspect:/agent-runtime /tmp/agent-runtime-check
+docker rm spore-echo-inspect
+file /tmp/agent-runtime-check
+ls -lh /tmp/agent-runtime-check
+rm -f /tmp/agent-runtime-check
+```
+
+### Expected output patterns
+
+- **Build**: Final line should be something like `Successfully tagged spore-echo:latest`.
+- **Image size**: A line showing `spore-echo latest <SIZE>` where SIZE is under 15 MB.
+- **Container logs**: Lines containing `[1/7]`, `[2/7]`, and possibly `[3/7]` or up to `[5/7]` on stderr before an error about missing API key or connection failure.
+- **Static linking**: `file` output should include `ELF 64-bit LSB executable, x86-64, ... statically linked, ... stripped`.
+
+### Pass/fail summary
+
+| Check | Pass | Fail |
+|-------|------|------|
+| Build completes | Exit code 0 | Non-zero exit code |
+| Image size (hard) | < 15 MB | >= 15 MB |
+| Image size (ideal) | < 5 MB | 5-15 MB (acceptable, document) |
+| Container starts | Shows `[1/7]` log line | No output or signal crash |
+| Static linking | `statically linked` in file output | `dynamically linked` in file output |
+
+## Dependencies
+
+- Blocked by: "Create multi-stage Dockerfile" (the Dockerfile must exist before it can be verified)
+- Blocked by (transitively): "Add release profile optimizations to workspace `Cargo.toml`" and "Create `.dockerignore` file" (Group 1 tasks that the Dockerfile task depends on)
+- Blocking: None
+
+## Risks & Edge Cases
+
+1. **Docker not available in the build environment**: The verification requires Docker to be installed and the Docker daemon to be running. In some CI or codespace environments, Docker-in-Docker may not be available or may require special configuration (`--privileged` mode, DinD sidecar).
+
+2. **Architecture mismatch**: The Dockerfile targets `x86_64-unknown-linux-musl`. If the verifier is on an ARM machine (e.g., Apple Silicon Mac), the build will either fail or produce an emulated x86_64 build via QEMU, which will be extremely slow (30+ minutes) and may time out. In that case, use `docker buildx build --platform linux/amd64` explicitly.
+
+3. **Build time**: A clean Docker build with no cache compiles the entire Rust dependency tree for the musl target. With `aws-lc-sys` (which requires cmake and a C compilation step), this can take 10-20 minutes even on a fast machine. Subsequent builds with the dependency cache layer intact should be 1-2 minutes.
+
+4. **`FROM scratch` limitations**: The `FROM scratch` image has no shell, no `ls`, no utilities. You cannot `docker exec` into it for debugging. To inspect the image contents, use `docker create` + `docker cp` (as shown in the verification commands) or temporarily switch the Dockerfile to `FROM alpine` for debugging.
+
+5. **Disk space**: The builder stage image can be large (1-2 GB with Rust toolchain + compiled artifacts). Ensure the Docker host has sufficient disk space. The final image is small, but the build cache is not.
+
+6. **`SKILL_NAME` not set as env var**: The Dockerfile should set `ENV SKILL_NAME=echo` (or whatever the build arg was). If this is not done, the container will fail at step 1 with `missing required environment variable: 'SKILL_NAME'` rather than at step 3 or 5. This would indicate a Dockerfile bug, not a verification failure -- but it should be noted.
+
+7. **Non-deterministic binary size**: The exact binary size may vary slightly between Rust compiler versions, dependency updates, or link-time optimization decisions. The size thresholds should be treated as approximate guidelines, not exact byte counts.
+
+## Verification
+
+To verify that the verification itself is correct:
+
+1. **Positive control**: If the build succeeds and all checks pass, confirm by running `docker run --rm -p 8080:8080 -e ANTHROPIC_API_KEY=test-key -e TOOL_ENDPOINTS="" spore-echo` and sending `curl http://localhost:8080/health` -- the health endpoint should respond (even if the agent cannot actually call the LLM with a fake key, the HTTP server should be listening).
+
+2. **Negative control**: Deliberately break the Dockerfile (e.g., remove the `COPY` for CA certificates) and verify that the build or runtime check catches the regression.
+
+3. **Size regression detection**: Record the exact image size (in bytes) in the PR description. Future PRs that add dependencies can compare against this baseline to detect size regressions.

--- a/.claude/tasks/issue-14.md
+++ b/.claude/tasks/issue-14.md
@@ -1,0 +1,63 @@
+# Task Breakdown: Create minimal Dockerfile for static binary deployment
+
+> Build a multi-stage Dockerfile that compiles `agent-runtime` as a fully static musl binary and packages it in a `FROM scratch` image with just the binary and skill files, targeting 1-5 MB total image size.
+
+## Group 1 — Build configuration
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Create `.dockerignore` file** `[S]`
+      Create a `.dockerignore` at the project root to exclude `target/`, `.git/`, `.worktrees/`, `.claude/`, `*.md` (except skill files in `skills/`), and editor/IDE files from the Docker build context. This keeps the build context small and avoids sending gigabytes of compiled artifacts to the Docker daemon.
+      Files: `.dockerignore`
+      Blocking: None
+
+- [x] **Add release profile optimizations to workspace `Cargo.toml`** `[S]`
+      Add a `[profile.release]` section to the workspace-level `Cargo.toml` with size-optimizing settings: `lto = true`, `opt-level = "z"`, `codegen-units = 1`, `strip = true`, `panic = "abort"`. These are critical for hitting the 1-5 MB image size target. Without these, a Rust binary with `tokio`, `axum`, `serde`, `rig-core`, and `reqwest` will be 10-20 MB. With these settings it should come down to 5-8 MB stripped. The `panic = "abort"` is safe for a server binary and further reduces size by removing unwinding infrastructure.
+      Files: `Cargo.toml`
+      Blocking: "Create multi-stage Dockerfile"
+
+## Group 2 — Dockerfile
+
+_Depends on: Group 1._
+
+- [x] **Create multi-stage Dockerfile** `[M]`
+      Create a `Dockerfile` at the project root with two stages:
+
+      **Stage 1 (builder):** Use `rust:latest` as base. Install `musl-tools` and `cmake` (needed for `aws-lc-sys` which is in the `rustls` dependency tree). Add the `x86_64-unknown-linux-musl` target via `rustup`. Use the dependency-caching pattern: copy all `Cargo.toml` and `Cargo.lock` files first with stub `src/` files, run `cargo build` to cache dependency compilation, then copy actual source and rebuild. Accept `SKILL_NAME` as a `ARG`. Verify the binary is statically linked with `file` command.
+
+      **Stage 2 (runtime):** Use `FROM scratch`. Copy just the compiled binary from the builder stage. Copy `skills/${SKILL_NAME}.md` (or alternatively the entire `skills/` directory for flexibility). Copy CA certificates from the builder stage (`/etc/ssl/certs/ca-certificates.crt`) since the binary needs to make HTTPS calls to LLM provider APIs and `FROM scratch` has no CA bundle. Expose port 8080. Set `SKILL_NAME` and `SKILL_DIR` environment variables. Set entrypoint to `/agent-runtime`.
+
+      The dependency-caching pattern requires creating stub files for all 6 workspace members: `crates/agent-sdk`, `crates/skill-loader`, `crates/tool-registry`, `crates/agent-runtime`, `crates/orchestrator`, and `tools/echo-tool`. This ensures `cargo build` caches dependency compilation separately from application code compilation, making iterative builds much faster.
+      Files: `Dockerfile`
+      Blocked by: "Add release profile optimizations to workspace `Cargo.toml`"
+      Blocking: "Add build and run documentation", "Verify image builds and meets size target"
+
+## Group 3 — Documentation and verification
+
+_Depends on: Group 2._
+
+- [x] **Add build and run documentation** `[S]`
+      Add a "Docker" section to the project `README.md` documenting: (1) how to build the image (`docker build --build-arg SKILL_NAME=echo -t spore-echo .`), (2) how to run the container (`docker run -p 8080:8080 -e ANTHROPIC_API_KEY=... spore-echo`), (3) how to check the image size (`docker images spore-echo`), (4) the key environment variables (`SKILL_NAME`, `SKILL_DIR`, `ANTHROPIC_API_KEY`, `TOOL_ENDPOINTS`, `BIND_ADDR`), (5) a note about the `FROM scratch` limitation (no shell, debugging requires `docker cp` or temporarily switching to `FROM alpine`).
+      Files: `README.md`
+      Blocked by: "Create multi-stage Dockerfile"
+      Blocking: None
+
+- [x] **Verify image builds and meets size target** `[S]`
+      Build the Docker image with `docker build --build-arg SKILL_NAME=echo -t spore-echo .`. Verify: (1) the build completes without errors, (2) `docker images spore-echo` shows the image is under 15 MB (ideally under 5 MB), (3) `docker run --rm spore-echo` starts without crashing (it will fail to connect to LLM APIs without keys, but should at least begin the startup sequence), (4) the binary inside is statically linked. If the image exceeds 5 MB, document the actual size and note which dependencies contribute most.
+      Files: (none — command-line verification only)
+      Blocked by: "Create multi-stage Dockerfile"
+      Blocking: None
+
+## Implementation Notes
+
+1. **TLS via `rustls`, not `openssl`**: The dependency tree uses `rustls` with `aws-lc-rs` as the crypto backend. This avoids linking against `libssl`/`libcrypto` and makes `FROM scratch` viable. However, `aws-lc-sys` requires `cmake` in the builder stage.
+
+2. **CA certificates are required**: Since `rig-core` uses `reqwest` to call LLM APIs over HTTPS, the final image must include CA certificates. Copy `/etc/ssl/certs/ca-certificates.crt` from the builder stage.
+
+3. **`SKILL_NAME` as build arg vs runtime env**: The issue specifies `SKILL_NAME` as a build arg. The recommended approach is to use it as a build arg that selects which skill file to copy into the image, and also set it as a default `ENV` that the runtime reads. This allows the same image to be overridden at runtime with `-e SKILL_NAME=other` if multiple skills are copied.
+
+4. **No CI/CD yet**: There are no GitHub Actions workflows. Docker image CI could be a follow-up issue.
+
+5. **Depends on completed issues #11 and #12**: The HTTP server (issue #12, merged in commit `3bc7d6b`) and skill loading (issue #11) are already implemented. The Dockerfile should produce a working image.
+
+6. **Image size reality check**: With `tokio`, `axum`, `serde`, `rig-core`, `reqwest`, `rustls`, and `aws-lc-rs`, the stripped binary will likely be 5-10 MB. The 1 MB target from the issue is aspirational; 5-10 MB is realistic and still a massive improvement over typical AI container images.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Build artifacts
+target/
+debug/
+*.pdb
+
+# Version control
+.git/
+
+# Worktrees
+.worktrees/
+
+# Claude Code
+.claude/
+
+# Documentation (skill files re-included below)
+*.md
+
+# Re-include skill files needed at runtime
+!skills/
+!skills/*.md
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Environment / secrets
+.env
+.env.*
+
+# Docker (not needed inside build context)
+Dockerfile
+.dockerignore

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,10 @@ members = [
     "crates/orchestrator",
     "tools/echo-tool",
 ]
+
+[profile.release]
+lto = true
+opt-level = "z"
+codegen-units = 1
+strip = true
+panic = "abort"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+FROM rust:latest AS builder
+
+RUN apt-get update && apt-get install -y musl-tools cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+WORKDIR /app
+
+RUN mkdir -p crates/agent-sdk/src \
+             crates/skill-loader/src \
+             crates/tool-registry/src \
+             crates/agent-runtime/src \
+             crates/orchestrator/src \
+             tools/echo-tool/src
+
+COPY Cargo.toml Cargo.lock ./
+COPY crates/agent-sdk/Cargo.toml crates/agent-sdk/Cargo.toml
+COPY crates/skill-loader/Cargo.toml crates/skill-loader/Cargo.toml
+COPY crates/tool-registry/Cargo.toml crates/tool-registry/Cargo.toml
+COPY crates/agent-runtime/Cargo.toml crates/agent-runtime/Cargo.toml
+COPY crates/orchestrator/Cargo.toml crates/orchestrator/Cargo.toml
+COPY tools/echo-tool/Cargo.toml tools/echo-tool/Cargo.toml
+
+RUN echo "" > crates/agent-sdk/src/lib.rs && \
+    echo "" > crates/skill-loader/src/lib.rs && \
+    echo "" > crates/tool-registry/src/lib.rs && \
+    echo "" > crates/agent-runtime/src/lib.rs && \
+    echo "fn main() {}" > crates/agent-runtime/src/main.rs && \
+    echo "fn main() {}" > crates/orchestrator/src/main.rs && \
+    echo "fn main() {}" > tools/echo-tool/src/main.rs && \
+    touch tools/echo-tool/src/echo.rs
+
+RUN cargo build --release --target x86_64-unknown-linux-musl -p agent-runtime
+
+COPY crates/ crates/
+COPY tools/ tools/
+# Touch .rs files to invalidate cargo's mtime-based cache after COPY overwrites stubs
+RUN find crates/ tools/ -name '*.rs' -exec touch {} + && \
+    cargo build --release --target x86_64-unknown-linux-musl -p agent-runtime
+
+RUN file target/x86_64-unknown-linux-musl/release/agent-runtime | grep -qE 'static(-pie)? linked'
+
+FROM scratch
+
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/agent-runtime /agent-runtime
+COPY skills/ /skills/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+ARG SKILL_NAME=echo
+ENV SKILL_NAME=${SKILL_NAME}
+ENV SKILL_DIR=/skills
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+EXPOSE 8080
+
+USER 1000
+
+ENTRYPOINT ["/agent-runtime"]

--- a/README.md
+++ b/README.md
@@ -127,6 +127,62 @@ The third agent they produce together is the **Deploy Agent** (`deploy-agent.md`
 | Async runtime | `tokio` | Standard Rust async runtime |
 | Serialization | `serde` / `schemars` | Skill file parsing and JSON schema generation |
 
+## Docker
+
+### Build
+
+```sh
+docker build --build-arg SKILL_NAME=echo -t spore-echo .
+```
+
+The `SKILL_NAME` build argument sets the default skill the agent loads at startup. All skill files in `skills/` are bundled into the image, so you can override `SKILL_NAME` at runtime with `-e SKILL_NAME=other-skill`.
+
+### Run
+
+```sh
+docker run -p 8080:8080 -e ANTHROPIC_API_KEY=your-key-here spore-echo
+```
+
+Verify the agent is running with a health check:
+
+```sh
+curl http://localhost:8080/health
+```
+
+### Image Size
+
+```sh
+docker images spore-echo
+```
+
+Images are statically compiled Rust binaries on a `scratch` base with no OS layer. Expected size is typically under 10 MB.
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `SKILL_NAME` | Yes (build arg) | `echo` | Name of the skill to load |
+| `SKILL_DIR` | No | `/skills` | Directory containing skill `.md` files |
+| `BIND_ADDR` | No | `0.0.0.0:8080` | Socket address for the HTTP server |
+| `TOOL_ENDPOINTS` | No | `echo-tool=mcp://localhost:7001` | Comma-separated `name=endpoint` pairs for MCP tool servers |
+| `ANTHROPIC_API_KEY` | If provider is `anthropic` | — | API key for Anthropic-backed skills |
+| `OPENAI_API_KEY` | If provider is `openai` | — | API key for OpenAI-backed skills |
+| `RUST_LOG` | No | `info` | Controls tracing verbosity |
+
+### Debugging
+
+The production image uses `FROM scratch`, which means there is no shell, no package manager, and no utilities inside the container. `docker exec` will not work because there is no `/bin/sh` to invoke.
+
+Two workarounds:
+
+1. **Extract the binary with `docker cp`.** Copy the compiled binary out of a stopped container to inspect or run it locally:
+
+```sh
+docker cp <container_id>:/agent-runtime ./agent-runtime
+```
+
+2. **Temporarily switch to `FROM alpine`.** Replace `FROM scratch` with `FROM alpine` in the final stage of the Dockerfile. This adds a shell and common utilities so you can `docker exec -it <container_id> /bin/sh` into the running container for interactive debugging. Remember to switch back to `FROM scratch` for production builds.
+
 ## Key Properties
 
 **Single-responsibility agents.** Each agent does one thing. Debug, test, and version them independently.


### PR DESCRIPTION
## Summary

Add a multi-stage Dockerfile that compiles `agent-runtime` as a fully static musl binary and packages it in a `FROM scratch` image with just the binary and skill files. Includes `.dockerignore`, release profile optimizations for binary size, and build/run documentation in README.

## Changes

### Group 1 — Build configuration
- ✅ Create `.dockerignore` file
- ✅ Add release profile optimizations to workspace `Cargo.toml`

### Group 2 — Dockerfile
- ✅ Create multi-stage Dockerfile

### Group 3 — Documentation and verification
- ✅ Add build and run documentation
- ✅ Verify image builds and meets size target

## Test plan

- `cargo build` — workspace builds cleanly
- `cargo test` — all tests pass
- `cargo clippy` — no lint warnings
- `docker build --build-arg SKILL_NAME=echo -t spore-echo .` — image builds successfully
- `docker images spore-echo` — verify image size is under 15 MB

## Issue

Closes #14