### PR TITLE
feat(orchestrator): implement escalation handling (#17)

### DIFF
--- a/.claude/specs/issue-15/convert-orchestrator-from-binary-to-library-crate.md
+++ b/.claude/specs/issue-15/convert-orchestrator-from-binary-to-library-crate.md
@@ -1,0 +1,128 @@
+# Spec: Convert orchestrator from binary to library crate
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+
+Convert the `orchestrator` crate from a binary crate (with a `main.rs` stub) to a library crate (with a `lib.rs` declaring public modules). The orchestrator is not a standalone binary -- it runs inside `agent-runtime` as a `MicroAgent` -- so it must expose its types through a library interface. This is the foundational scaffolding step that unblocks all subsequent orchestrator implementation work.
+
+## Current State
+
+**`crates/orchestrator/src/main.rs`** -- A 3-line placeholder stub:
+```rust
+fn main() {
+    println!("Hello, world!");
+}
+```
+
+**`crates/orchestrator/Cargo.toml`** -- Minimal package definition with no dependencies:
+```toml
+[package]
+name = "orchestrator"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+```
+
+The Cargo.toml has no `[[bin]]` or `[lib]` section, so Cargo uses its default convention: `src/main.rs` means it is compiled as a binary crate. There is no `src/lib.rs` file. The crate is already a member of the workspace (listed in the root `Cargo.toml`).
+
+No other crate in the workspace currently depends on `orchestrator`.
+
+## Requirements
+
+- Delete `crates/orchestrator/src/main.rs` entirely.
+- Create `crates/orchestrator/src/lib.rs` with exactly four public module declarations:
+  - `pub mod agent_endpoint;`
+  - `pub mod error;`
+  - `pub mod orchestrator;`
+  - `pub mod config;`
+- Create empty placeholder files for each declared module so the crate compiles:
+  - `crates/orchestrator/src/agent_endpoint.rs` (empty)
+  - `crates/orchestrator/src/error.rs` (empty)
+  - `crates/orchestrator/src/orchestrator.rs` (empty)
+  - `crates/orchestrator/src/config.rs` (empty)
+- The `Cargo.toml` does NOT need a `[lib]` section added -- Cargo's default convention will detect `src/lib.rs` automatically and treat the crate as a library.
+- The crate must compile successfully with `cargo check -p orchestrator`.
+- The crate must pass `cargo clippy -p orchestrator` with no warnings.
+- No new dependencies are added in this task (dependencies are handled by the sibling task "Update orchestrator Cargo.toml with dependencies").
+
+## Implementation Details
+
+### Files to delete
+
+- `crates/orchestrator/src/main.rs` -- Remove entirely. This file contains only a `println!` stub and has no code worth preserving.
+
+### Files to create
+
+1. **`crates/orchestrator/src/lib.rs`**
+   - Declare four public modules in this order:
+     ```rust
+     pub mod agent_endpoint;
+     pub mod config;
+     pub mod error;
+     pub mod orchestrator;
+     ```
+   - No other content (no imports, no re-exports, no functions). Keep it minimal -- re-exports and convenience imports will be added in later tasks as the module contents are implemented.
+
+2. **`crates/orchestrator/src/agent_endpoint.rs`** -- Empty file (module placeholder).
+
+3. **`crates/orchestrator/src/config.rs`** -- Empty file (module placeholder).
+
+4. **`crates/orchestrator/src/error.rs`** -- Empty file (module placeholder).
+
+5. **`crates/orchestrator/src/orchestrator.rs`** -- Empty file (module placeholder).
+
+### Files unchanged
+
+- **`crates/orchestrator/Cargo.toml`** -- No modifications needed. The `[dependencies]` section remains empty. Cargo will automatically detect `src/lib.rs` and compile as a library crate. No `[lib]` section is necessary.
+
+- **`Cargo.toml` (workspace root)** -- No modifications needed. The `orchestrator` crate is already listed in `workspace.members`.
+
+### Integration points
+
+- Once this task is complete, other crates can add `orchestrator = { path = "../orchestrator" }` to their dependencies and `use orchestrator::{agent_endpoint, config, error, orchestrator};` to import modules.
+- The `agent-runtime` crate will eventually depend on `orchestrator` and instantiate the `Orchestrator` as a `MicroAgent`, but that wiring is out of scope for this task.
+
+## Dependencies
+
+- **Blocked by:** Nothing -- this is a Group 1 task with no prerequisites.
+- **Blocking:** All Group 2 tasks ("Implement AgentEndpoint struct", "Define registry config format and loader") and all Group 3+ tasks. Every subsequent orchestrator task depends on the library crate structure existing.
+
+## Risks & Edge Cases
+
+- **Module name collision with crate name:** The module `pub mod orchestrator;` shares the same name as the crate itself. This is valid Rust -- the module is accessed as `orchestrator::orchestrator::Orchestrator` from external crates (or `crate::orchestrator::Orchestrator` internally). This is a deliberate design choice from the task definition and is acceptable.
+- **Empty modules and warnings:** Empty module files may trigger `clippy` or compiler warnings in some configurations. In practice, Rust and Clippy do not warn on empty modules, so this should not be an issue.
+- **Edition 2024 implications:** The crate uses `edition = "2024"`. The module resolution behavior is the same as edition 2021 for this use case (file-per-module convention). No special handling needed.
+- **Parallel task conflict:** The sibling task "Update orchestrator Cargo.toml with dependencies" modifies `Cargo.toml` while this task modifies the `src/` directory. These tasks touch different files and can proceed in parallel without merge conflicts.
+
+## Verification
+
+1. **File structure check:**
+   - Confirm `crates/orchestrator/src/main.rs` does not exist.
+   - Confirm `crates/orchestrator/src/lib.rs` exists and contains the four `pub mod` declarations.
+   - Confirm all four module files exist: `agent_endpoint.rs`, `config.rs`, `error.rs`, `orchestrator.rs`.
+
+2. **Compilation check:**
+   ```bash
+   cargo check -p orchestrator
+   ```
+   Must succeed with no errors.
+
+3. **Lint check:**
+   ```bash
+   cargo clippy -p orchestrator
+   ```
+   Must succeed with no warnings.
+
+4. **Workspace integrity:**
+   ```bash
+   cargo check
+   ```
+   Full workspace build must still succeed (no regressions in `agent-sdk`, `agent-runtime`, `skill-loader`, `tool-registry`).
+
+5. **Test suite:**
+   ```bash
+   cargo test
+   ```
+   Full workspace tests must still pass. The orchestrator crate will have no tests yet (empty modules), but existing crate tests must not regress.

--- a/.claude/specs/issue-15/define-orchestrator-error-enum.md
+++ b/.claude/specs/issue-15/define-orchestrator-error-enum.md
@@ -1,0 +1,85 @@
+# Spec: Define OrchestratorError enum
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+
+Create the `OrchestratorError` enum in `crates/orchestrator/src/error.rs` to serve as the primary error type for all orchestrator operations (routing, dispatch, health checks, escalation). This enum follows the manual `Display + Error` pattern established by `AgentError` in `agent-sdk`, and provides a `From` conversion so orchestrator errors can flow through the `MicroAgent::invoke()` boundary as `AgentError::Internal(String)`.
+
+## Current State
+
+**`crates/agent-sdk/src/agent_error.rs`** defines the SDK-level error type using a manual `Display` implementation (no `thiserror` derive). It has five variants including `Internal(String)`, which is the catch-all for errors originating outside the agent's own logic. The type derives `Debug, Clone, PartialEq, Serialize, Deserialize` and implements `std::error::Error` as an empty impl.
+
+**`crates/orchestrator/src/main.rs`** is a placeholder 3-line `println!` stub. The orchestrator crate currently has no dependencies in `Cargo.toml` and no real logic. A sibling task will convert this from a binary to a library crate (`lib.rs` with `pub mod error;`), and another sibling task will add `agent-sdk` as a dependency.
+
+**`crates/agent-sdk/src/micro_agent.rs`** defines the `MicroAgent` trait whose `invoke()` method returns `Result<AgentResponse, AgentError>`. The orchestrator's `MicroAgent` implementation will call `dispatch()` which returns `Result<AgentResponse, OrchestratorError>`, so the `From<OrchestratorError> for AgentError` conversion is needed at that boundary.
+
+## Requirements
+
+1. Define `OrchestratorError` as a `pub enum` in `crates/orchestrator/src/error.rs` with exactly four variants:
+   - `NoRoute { input: String }` -- no registered agent matches the request input
+   - `AgentUnavailable { name: String, reason: String }` -- the target agent is unhealthy or unreachable
+   - `EscalationFailed { chain: Vec<String>, reason: String }` -- the escalation chain was exhausted without resolution
+   - `HttpError { url: String, reason: String }` -- network or HTTP failure when calling a downstream agent
+
+2. Derive `Debug, Clone` on `OrchestratorError`. Do NOT derive `Serialize`/`Deserialize` (this is an internal error type, not serialized over the wire). Do NOT derive `PartialEq` because `Vec<String>` comparisons in `EscalationFailed` are fragile for tests; instead, tests should match on variant and check fields individually.
+
+3. Implement `fmt::Display for OrchestratorError` manually (no `thiserror`), following the same match-arm pattern as `AgentError::Display`. Each variant should produce a distinct, human-readable message:
+   - `NoRoute` -> `"No route found for input: {input}"`
+   - `AgentUnavailable` -> `"Agent '{name}' unavailable: {reason}"`
+   - `EscalationFailed` -> `"Escalation failed through chain [{chain joined by " -> "}]: {reason}"`
+   - `HttpError` -> `"HTTP error calling {url}: {reason}"`
+
+4. Implement `std::error::Error for OrchestratorError` as an empty impl (matching the `AgentError` pattern).
+
+5. Implement `From<OrchestratorError> for AgentError` that converts any `OrchestratorError` into `AgentError::Internal(err.to_string())`. This uses the `Display` output as the internal error message.
+
+6. Do NOT use `thiserror` or any new dependency. The manual `Display + Error` pattern is deliberate and consistent with `agent-sdk`.
+
+7. The file should import `AgentError` from `agent_sdk` (via `agent_sdk::AgentError` -- the crate name uses an underscore in Rust code since the package name is `agent-sdk`).
+
+## Implementation Details
+
+### File to create
+
+**`crates/orchestrator/src/error.rs`**
+
+- `use std::fmt;`
+- `use agent_sdk::AgentError;`
+- Define `#[derive(Debug, Clone)] pub enum OrchestratorError` with the four variants listed above.
+- `impl fmt::Display for OrchestratorError` -- one match arm per variant, each calling `write!()` with the format strings specified in Requirements.
+- `impl std::error::Error for OrchestratorError {}` -- empty impl body.
+- `impl From<OrchestratorError> for AgentError` -- single match arm: `AgentError::Internal(err.to_string())` (no need to match per-variant, just use the `Display` output).
+
+### Integration points
+
+- **Module declaration**: The sibling task "Convert orchestrator from binary to library crate" will create `lib.rs` with `pub mod error;`. This spec only covers the `error.rs` file itself.
+- **Cargo.toml dependency**: The sibling task "Update orchestrator Cargo.toml with dependencies" will add `agent-sdk = { path = "../agent-sdk" }`. This file requires that dependency to import `AgentError`.
+- **Consumers**: `AgentEndpoint` methods will return `Result<_, OrchestratorError>` for HTTP and availability errors. `Orchestrator::route()` will return `NoRoute`. `Orchestrator::dispatch()` will return `EscalationFailed`. The `MicroAgent::invoke()` impl will use the `From` conversion at the `?` operator boundary.
+
+### Key design decisions
+
+- The `From` impl converts TO `AgentError` (not from). The direction is `From<OrchestratorError> for AgentError`, which lets orchestrator code write `Ok(self.dispatch(request)?)` in the `MicroAgent::invoke()` body and have the `?` operator auto-convert.
+- `EscalationFailed.chain` is a `Vec<String>` of agent names in the order they were tried, providing debuggability for escalation failures.
+- `HttpError` is intentionally generic (url + reason string) rather than wrapping `reqwest::Error` directly, to avoid coupling the error type to a specific HTTP client library and to keep the type `Clone`-compatible.
+
+## Dependencies
+
+- **Blocked by**: "Convert orchestrator from binary to library crate" (needs `lib.rs` with `pub mod error;`), "Update orchestrator Cargo.toml with dependencies" (needs `agent-sdk` dependency)
+- **Blocking**: "Implement AgentEndpoint struct" (returns `OrchestratorError` from its methods), "Implement Orchestrator struct with dispatch logic" (returns `OrchestratorError` from `route()` and `dispatch()`)
+
+## Risks & Edge Cases
+
+- **Dependency ordering**: This file will not compile until the Cargo.toml has `agent-sdk` as a dependency. The three Group 1 tasks should be applied together or in the order: Cargo.toml update, then lib.rs creation, then error.rs creation.
+- **Crate name resolution**: The Cargo package is `agent-sdk` but Rust normalizes hyphens to underscores, so the import is `agent_sdk::AgentError`. If the dependency is aliased differently in Cargo.toml, the import path must match.
+- **Future extensibility**: Additional variants may be needed later (e.g., `ConfigError`, `TimeoutError`). The enum is not `#[non_exhaustive]` since it is crate-internal and downstream consumers interact through the `AgentError::Internal` conversion. If this changes, `#[non_exhaustive]` should be reconsidered.
+- **Display format stability**: The `From<OrchestratorError> for AgentError` impl relies on `Display` output becoming the `Internal(String)` message. If the display format changes, error messages in logs and responses will change accordingly. This is acceptable since these are not parsed programmatically.
+
+## Verification
+
+1. `cargo check -p orchestrator` passes (requires sibling tasks to be complete first)
+2. `cargo clippy -p orchestrator` produces no warnings on the new file
+3. All four `Display` outputs match the specified format strings (verified by the sibling test task "Write unit tests for OrchestratorError" in `crates/orchestrator/tests/error_test.rs`)
+4. `From<OrchestratorError> for AgentError` converts each variant to `AgentError::Internal(...)` where the inner string matches the `Display` output
+5. `cargo test -p orchestrator` passes (once test file from the test task exists)
+6. No new dependencies are introduced beyond what the sibling Cargo.toml task specifies

--- a/.claude/specs/issue-15/define-registry-config-format-and-loader.md
+++ b/.claude/specs/issue-15/define-registry-config-format-and-loader.md
@@ -1,0 +1,199 @@
+# Spec: Define registry config format and loader
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+
+Create a `config` module for the `orchestrator` crate that defines a YAML-deserializable configuration structure for agent registry entries, with two loading paths: a primary environment-variable-based loader (`from_env`) and a secondary YAML-file-based loader (`from_file`). This module provides the data needed by the `Orchestrator` struct (Group 3) to construct its `AgentEndpoint` registry at startup. The env-based approach follows the `TOOL_ENDPOINTS` comma-separated `name=url` pattern already established in `crates/agent-runtime/src/main.rs` (lines 86-112), while the YAML path offers a richer config format for local development.
+
+## Current State
+
+- **`crates/orchestrator/`** is currently a stub binary crate with a 3-line `main.rs` printing "Hello, world!". It has no dependencies beyond the defaults. A prerequisite task will convert it to a library crate with `lib.rs` declaring `pub mod config;` and another task will add the required dependencies to `Cargo.toml` (including `serde`, `serde_yaml`).
+
+- **`crates/agent-runtime/src/config.rs`** defines the project's established config pattern:
+  - A `RuntimeConfig` struct with `#[derive(Debug, Clone)]`.
+  - A `ConfigError` enum with two variants (`MissingVar`, `InvalidValue`), each with `#[derive(Debug, Clone, PartialEq)]`, manual `fmt::Display` impl, and `impl std::error::Error`.
+  - A `from_env()` constructor that uses helper functions `read_required_var(name)` and `read_optional_var_or(name, default)` to read `std::env::var()` values.
+  - Empty strings are treated as missing (the `Ok(val) if !val.is_empty()` guard pattern).
+  - Tests use a `with_env_vars` helper and a `static ENV_LOCK: Mutex<()>` to safely serialize env-mutating tests.
+
+- **`crates/agent-runtime/src/main.rs` lines 86-112** define the `TOOL_ENDPOINTS` parsing pattern:
+  - Read `TOOL_ENDPOINTS` env var (with a default fallback).
+  - Split by comma, trim each pair, skip empty entries.
+  - Split each pair on `=` via `split_once('=')`, error if no `=` found.
+  - Trim name and endpoint individually.
+  - This pattern will be reused for `AGENT_ENDPOINTS`.
+
+- **Error convention**: The workspace does not use `thiserror`. All error types use manual `Display + Error` impls. The orchestrator will define its own `OrchestratorError` in a separate `error.rs` module (a sibling task). The config module should use `OrchestratorError` as its error type, not define its own.
+
+- **`OrchestratorError`** (defined in the sibling task) will have an `HttpError { url, reason }` variant. The config module needs error variants for config-loading failures. Since `OrchestratorError` does not have config-specific variants, the config functions should return `Result<Self, OrchestratorError>` by mapping config failures to a suitable variant. The task description specifies the return type as `Result<Self, OrchestratorError>`. Looking at the `OrchestratorError` enum, the most appropriate approach is to add a config-related mapping -- but since `OrchestratorError` is defined in a sibling task and we should not modify it, the config module should define a local `ConfigError` enum (following the `agent-runtime` pattern) and provide a `From<ConfigError> for OrchestratorError` conversion, or the `OrchestratorError` task should include a `ConfigError` variant. **Decision**: Follow the task description literally -- the functions return `Result<Self, OrchestratorError>`. The `OrchestratorError` enum (sibling task) should include a variant like `Config { reason: String }` for this purpose, or the config module should construct `OrchestratorError::HttpError` (which is a poor semantic fit). The cleanest approach: define a local `ConfigError` in config.rs and have the public-facing functions map it to `OrchestratorError`. See the Implementation Details section for the recommended approach.
+
+## Requirements
+
+1. **Define `OrchestratorConfig` struct** with a single field:
+   - `agents: Vec<AgentConfig>` -- the list of agent registry entries.
+   - Derive `Debug`, `Clone`, `serde::Deserialize`.
+
+2. **Define `AgentConfig` struct** with three fields:
+   - `name: String` -- unique agent identifier (e.g., `"cogs-analyst"`).
+   - `description: String` -- human-readable description used for routing heuristics.
+   - `url: String` -- the HTTP base URL of the agent endpoint (e.g., `"http://localhost:8081"`).
+   - Derive `Debug`, `Clone`, `serde::Deserialize`.
+
+3. **Implement `OrchestratorConfig::from_env()`** as the primary config path:
+   - Signature: `pub fn from_env() -> Result<Self, OrchestratorError>`
+   - Read `AGENT_ENDPOINTS` env var. It is **required** (no default). If missing or empty, return an error.
+   - Format: comma-separated `name=url` pairs, e.g. `analyst=http://localhost:8081,writer=http://localhost:8082`.
+   - Parsing rules (matching `TOOL_ENDPOINTS` pattern exactly):
+     - Split on `,`.
+     - Trim each segment; skip empty segments.
+     - Split each segment on `=` via `split_once('=')`. Error if no `=` found.
+     - Trim both name and url.
+     - Validate that name is non-empty and url is non-empty.
+   - Read `AGENT_DESCRIPTIONS` env var. It is **optional**. Format: comma-separated `name=description` pairs, e.g. `analyst=Financial analysis agent,writer=Content writer`. If unset, each agent gets an empty string as its description.
+   - For each entry parsed from `AGENT_ENDPOINTS`, look up a matching description from `AGENT_DESCRIPTIONS` (by name). If no match, use `""`.
+   - Construct `OrchestratorConfig { agents }` from the merged data.
+
+4. **Implement `OrchestratorConfig::from_file()`** as the secondary config path:
+   - Signature: `pub fn from_file(path: &str) -> Result<Self, OrchestratorError>`
+   - Read the file at `path` using `std::fs::read_to_string`.
+   - Parse as YAML using `serde_yaml::from_str`.
+   - Map I/O errors and YAML parse errors to `OrchestratorError`.
+   - The expected YAML format:
+     ```yaml
+     agents:
+       - name: analyst
+         description: Financial analysis agent
+         url: http://localhost:8081
+       - name: writer
+         description: Content writer
+         url: http://localhost:8082
+     ```
+
+5. **Error handling**: Functions return `Result<Self, OrchestratorError>`. Config-specific errors (missing env var, invalid format, file I/O, YAML parse) should be mapped to an appropriate `OrchestratorError` variant. If `OrchestratorError` does not have a dedicated config variant, use a reasonable mapping (e.g., construct an error with a descriptive message). The recommended approach is to coordinate with the `OrchestratorError` sibling task to include a `Config { reason: String }` variant.
+
+6. **No new dependencies beyond what the sibling Cargo.toml task provides**: The Cargo.toml task adds `serde` (with `derive`), `serde_yaml`, and others. The config module uses `serde::Deserialize` and `serde_yaml`. No additional crates are needed.
+
+7. **Empty strings treated as missing**: Following the `agent-runtime` pattern, an env var set to `""` should be treated the same as unset.
+
+8. **Functions must be 50 lines or fewer**: Break parsing logic into helpers as needed to respect the project's function-length rule.
+
+## Implementation Details
+
+### Files to create
+
+- **`crates/orchestrator/src/config.rs`** -- new module containing `OrchestratorConfig`, `AgentConfig`, and their constructors.
+
+### Files that must exist first (created by sibling tasks)
+
+- **`crates/orchestrator/src/lib.rs`** -- must declare `pub mod config;` (created by the "Convert orchestrator from binary to library crate" task).
+- **`crates/orchestrator/Cargo.toml`** -- must have `serde` and `serde_yaml` dependencies (created by the "Update orchestrator Cargo.toml with dependencies" task).
+- **`crates/orchestrator/src/error.rs`** -- must define `OrchestratorError` (created by the "Define OrchestratorError enum" task). Note: `config.rs` imports `OrchestratorError` from `crate::error`.
+
+### Types
+
+```
+OrchestratorConfig (struct)
+  - agents: Vec<AgentConfig>
+  Derives: Debug, Clone, serde::Deserialize
+
+AgentConfig (struct)
+  - name: String
+  - description: String
+  - url: String
+  Derives: Debug, Clone, serde::Deserialize
+```
+
+### Key functions
+
+```
+OrchestratorConfig::from_env() -> Result<Self, OrchestratorError>
+```
+
+Logic:
+1. Read `AGENT_ENDPOINTS` via a helper (see below). If missing/empty, return error.
+2. Parse into a `Vec<(String, String)>` of `(name, url)` pairs via `parse_comma_pairs`.
+3. Read `AGENT_DESCRIPTIONS` via `std::env::var`. If present and non-empty, parse into a `HashMap<String, String>` of `(name, description)` via the same `parse_comma_pairs` helper.
+4. For each `(name, url)`, look up description from the map (defaulting to `""`), construct `AgentConfig`.
+5. Return `Ok(OrchestratorConfig { agents })`.
+
+```
+OrchestratorConfig::from_file(path: &str) -> Result<Self, OrchestratorError>
+```
+
+Logic:
+1. `std::fs::read_to_string(path)` -- map `io::Error` to `OrchestratorError`.
+2. `serde_yaml::from_str(&contents)` -- map `serde_yaml::Error` to `OrchestratorError`.
+3. Return the deserialized `OrchestratorConfig`.
+
+### Helper functions (private)
+
+```
+fn read_required_env(name: &str) -> Result<String, OrchestratorError>
+```
+Read `std::env::var(name)`. Return error if `Err` or if value is empty. Mirrors `read_required_var` from `agent-runtime/src/config.rs`.
+
+```
+fn parse_comma_pairs(input: &str, var_name: &str) -> Result<Vec<(String, String)>, OrchestratorError>
+```
+Split `input` on `,`, trim each segment, skip empty segments, split each on `=` via `split_once('=')`, error if no `=` found (include the offending segment and `var_name` in the error message), trim both halves, validate non-empty, collect into `Vec<(String, String)>`.
+
+### Integration points
+
+- The `Orchestrator::from_config(config: OrchestratorConfig)` method (Group 3 task) consumes this config to build `AgentEndpoint` instances.
+- The orchestrator's startup path (when wired into `agent-runtime`) will call `OrchestratorConfig::from_env()` or `OrchestratorConfig::from_file()` early in initialization.
+- `AgentConfig` fields map 1:1 to `AgentEndpoint::new(name, description, url)` parameters.
+
+### YAML example file format
+
+```yaml
+agents:
+  - name: cogs-analyst
+    description: Financial analysis and reporting agent
+    url: http://localhost:8081
+  - name: skill-writer
+    description: Writes and refines skill manifests
+    url: http://localhost:8082
+```
+
+### Env var example
+
+```bash
+AGENT_ENDPOINTS="cogs-analyst=http://localhost:8081,skill-writer=http://localhost:8082"
+AGENT_DESCRIPTIONS="cogs-analyst=Financial analysis and reporting agent,skill-writer=Writes and refines skill manifests"
+```
+
+## Dependencies
+
+- Blocked by: "Convert orchestrator from binary to library crate" (provides `lib.rs` with `pub mod config;`), "Update orchestrator Cargo.toml with dependencies" (provides `serde`, `serde_yaml`), "Define OrchestratorError enum" (provides the error type used in return values)
+- Blocking: "Implement Orchestrator struct with dispatch logic" (consumes `OrchestratorConfig` via `Orchestrator::from_config`)
+
+## Risks & Edge Cases
+
+- **`OrchestratorError` may lack a config variant**: If the sibling `error.rs` task does not include a `Config { reason: String }` variant (or equivalent), the config module will need to shoehorn config errors into an ill-fitting variant. Mitigation: coordinate with the error task to include a suitable variant, or use a generic variant pattern like `OrchestratorError::Config { reason: String }`. If neither is available, wrapping config errors in `OrchestratorError::HttpError { url: "config".into(), reason }` is a last resort (semantically poor but functional).
+
+- **Duplicate agent names in `AGENT_ENDPOINTS`**: The current design does not explicitly reject duplicates. The downstream `Orchestrator` uses a `HashMap<String, AgentEndpoint>` keyed by name, so the last entry wins silently. This is acceptable for the initial implementation but should be documented. A future enhancement could reject duplicates at config-parse time.
+
+- **Descriptions without matching endpoints**: If `AGENT_DESCRIPTIONS` contains a name not present in `AGENT_ENDPOINTS`, the extra description is silently ignored. This is the expected behavior -- descriptions are supplementary metadata.
+
+- **URL validation**: The config module does NOT validate that `url` values are well-formed URLs. Validation happens implicitly when `AgentEndpoint` attempts to connect. This keeps the config module simple and avoids adding a URL-parsing dependency.
+
+- **Empty `AGENT_ENDPOINTS` after trimming**: If the env var is set to `","` or `"  "`, all segments are empty after trimming and skipping, resulting in an empty `agents` list. This should be treated as an error (at least one agent is required for the orchestrator to be useful). Alternatively, allow zero agents and let the `Orchestrator` handle the empty-registry case. **Decision**: Allow an empty list -- the config module's job is parsing, not business-rule validation. The `Orchestrator` can decide whether zero agents is an error.
+
+- **File not found for `from_file`**: `std::fs::read_to_string` returns `io::Error` with `ErrorKind::NotFound`. This should be surfaced clearly in the error message, including the file path.
+
+- **YAML with extra fields**: `serde_yaml` by default ignores extra fields (unless `#[serde(deny_unknown_fields)]` is used). The initial implementation should allow extra fields for forward compatibility.
+
+- **Test isolation for env-var tests**: Tests that set/unset `AGENT_ENDPOINTS` and `AGENT_DESCRIPTIONS` must use the `ENV_LOCK: Mutex<()>` + `with_env_vars` pattern from `agent-runtime/src/config.rs` to avoid flaky parallel test failures. The test file is a separate task ("Write unit tests for config loading"), but the config module's design should be test-friendly (pure functions that take parsed strings, not just env-reading functions).
+
+- **`=` in URL values**: URLs may contain `=` characters (e.g., query parameters). Since `split_once('=')` splits on the first `=` only, the URL portion correctly retains any subsequent `=` characters. Example: `name=http://host?foo=bar` parses as name=`name`, url=`http://host?foo=bar`.
+
+## Verification
+
+1. `cargo check -p orchestrator` passes with no errors (requires sibling tasks to be complete first).
+2. `cargo clippy -p orchestrator` reports no warnings for the new module.
+3. `cargo test -p orchestrator` continues to pass (no regressions; dedicated config tests are a separate task).
+4. The `config.rs` file contains exactly the types and functions described above.
+5. No new dependencies are added beyond those specified in the sibling Cargo.toml task.
+6. All functions are 50 lines or fewer.
+7. No commented-out code or debug statements remain in the file.

--- a/.claude/specs/issue-15/implement-agent-endpoint-struct.md
+++ b/.claude/specs/issue-15/implement-agent-endpoint-struct.md
@@ -1,0 +1,149 @@
+# Spec: Implement AgentEndpoint struct
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+
+Create the `AgentEndpoint` struct that represents a single downstream micro-agent reachable over HTTP. This is the orchestrator's primary mechanism for communicating with child agents -- it wraps `reqwest::Client` and provides typed methods for invoking an agent and checking its health. The struct must avoid importing anything from `agent-runtime` to prevent circular dependencies; it depends only on `agent-sdk` types (`AgentRequest`, `AgentResponse`, `HealthStatus`) and the orchestrator's own `OrchestratorError`.
+
+## Current State
+
+- **Orchestrator crate** (`crates/orchestrator/`) is a stub binary with a `main.rs` containing `println!("Hello, world!")` and an empty `Cargo.toml` dependencies section. Prerequisite tasks will convert it to a library crate and add dependencies before this task begins.
+- **`agent-sdk` types** (defined in `crates/agent-sdk/src/`):
+  - `AgentRequest { id: Uuid, input: String, context: Option<Value>, caller: Option<String> }` -- Serialize + Deserialize
+  - `AgentResponse { id: Uuid, output: Value, confidence: f32, escalated: bool, escalate_to: Option<String>, tool_calls: Vec<ToolCallRecord> }` -- Serialize + Deserialize
+  - `HealthStatus` -- enum with variants `Healthy`, `Degraded(String)`, `Unhealthy(String)` -- Serialize + Deserialize
+- **Health endpoint contract** (defined in `crates/agent-runtime/src/http.rs`):
+  - `GET /health` returns JSON: `{ "name": String, "version": String, "status": HealthStatus }`
+  - The `HealthResponse` struct is defined in `agent-runtime::http` and must NOT be imported (to avoid circular dependency). A local minimal DTO will be used instead.
+- **Invoke endpoint contract** (defined in `crates/agent-runtime/src/http.rs`):
+  - `POST /invoke` accepts `AgentRequest` as JSON body, returns `AgentResponse` as JSON on success
+  - On error, returns an HTTP error status with `AgentError` as the JSON body
+- **`OrchestratorError`** (to be defined by a prerequisite task in `crates/orchestrator/src/error.rs`):
+  - `HttpError { url: String, reason: String }` -- for reqwest/network failures
+  - `AgentUnavailable { name: String, reason: String }` -- for unreachable/unhealthy agents
+
+## Requirements
+
+1. Define `AgentEndpoint` as a public struct in `crates/orchestrator/src/agent_endpoint.rs` with fields:
+   - `pub name: String` -- the registered name of the downstream agent
+   - `pub description: String` -- human-readable description of what the agent does (used later for routing)
+   - `pub url: String` -- base URL of the agent (e.g., `http://localhost:3001`), no trailing slash
+   - `client: reqwest::Client` -- private, shared HTTP client instance
+
+2. Implement `AgentEndpoint::new(name: impl Into<String>, description: impl Into<String>, url: impl Into<String>) -> Self`:
+   - Construct a single `reqwest::Client` instance (reused across all calls for connection pooling)
+   - Store all fields, converting arguments to owned `String`s
+
+3. Implement `AgentEndpoint::invoke(&self, request: &AgentRequest) -> Result<AgentResponse, OrchestratorError>`:
+   - Send `POST {self.url}/invoke` with `request` serialized as JSON body
+   - Set `Content-Type: application/json` header (handled by `reqwest`'s `.json()` method)
+   - On success (2xx), deserialize the response body as `AgentResponse` and return it
+   - On HTTP error status (non-2xx), attempt to deserialize body as error context; map to `OrchestratorError::HttpError { url, reason }` where `url` is the full invoke URL and `reason` includes the HTTP status code and any body text
+   - On network/connection errors, map to `OrchestratorError::HttpError { url, reason }` with the reqwest error's display string as reason
+
+4. Implement `AgentEndpoint::health(&self) -> Result<HealthStatus, OrchestratorError>`:
+   - Send `GET {self.url}/health`
+   - Define a local private DTO struct `HealthResponseDto` with `#[derive(Deserialize)]` containing only `status: HealthStatus` (ignoring `name` and `version` fields via `#[serde(default)]` or by simply omitting them -- serde's default behavior with `Deserialize` ignores unknown fields)
+   - On success, deserialize as `HealthResponseDto` and return the `status` field
+   - On any error (network, non-2xx, deserialization), map to `OrchestratorError::AgentUnavailable { name: self.name.clone(), reason: <error description> }`
+
+5. The struct must NOT depend on `agent-runtime` crate. Only `agent-sdk` and standard/third-party crates (`reqwest`, `serde`, `serde_json`) are allowed.
+
+6. All methods must be `async` (since they perform HTTP I/O).
+
+7. Each method must be 50 lines or fewer per project rules.
+
+## Implementation Details
+
+### File to create
+
+**`crates/orchestrator/src/agent_endpoint.rs`**
+
+```
+use agent_sdk::{AgentRequest, AgentResponse, HealthStatus};
+use serde::Deserialize;
+
+use crate::error::OrchestratorError;
+```
+
+### Types to define
+
+- `AgentEndpoint` -- public struct as described above
+- `HealthResponseDto` -- private (non-`pub`) struct used only for deserializing the `/health` response:
+  ```rust
+  #[derive(Deserialize)]
+  struct HealthResponseDto {
+      status: HealthStatus,
+  }
+  ```
+  Serde will ignore the `name` and `version` fields in the JSON since they are not declared in the struct (serde's default behavior for structs is to ignore unknown fields). No `#[serde(deny_unknown_fields)]` should be used.
+
+### Methods
+
+- `new(name, description, url) -> Self`:
+  - Use `impl Into<String>` for ergonomic construction
+  - Call `reqwest::Client::new()` to create the shared client
+
+- `invoke(&self, request: &AgentRequest) -> Result<AgentResponse, OrchestratorError>`:
+  - Build URL: `format!("{}/invoke", self.url)`
+  - Use `self.client.post(url).json(request).send().await`
+  - Call `.error_for_status()` to convert non-2xx responses to reqwest errors
+  - On success, call `.json::<AgentResponse>().await`
+  - Map all `reqwest::Error` to `OrchestratorError::HttpError`
+
+- `health(&self) -> Result<HealthStatus, OrchestratorError>`:
+  - Build URL: `format!("{}/health", self.url)`
+  - Use `self.client.get(url).send().await`
+  - Call `.error_for_status()` then `.json::<HealthResponseDto>().await`
+  - Map all errors to `OrchestratorError::AgentUnavailable`
+  - Return `dto.status`
+
+### Integration points
+
+- Imported by `crates/orchestrator/src/orchestrator.rs` (future task) to build the agent registry
+- `Orchestrator::dispatch()` will call `endpoint.invoke()` and `endpoint.health()`
+- `Orchestrator::from_config()` will construct `AgentEndpoint` instances from `AgentConfig` entries
+- The `lib.rs` module declaration `pub mod agent_endpoint;` makes this available as `orchestrator::agent_endpoint::AgentEndpoint`
+
+## Dependencies
+
+- **Blocked by:**
+  - "Convert orchestrator from binary to library crate" -- `lib.rs` must declare `pub mod agent_endpoint;`
+  - "Update orchestrator Cargo.toml with dependencies" -- `reqwest`, `serde`, `agent-sdk` must be available
+  - "Define OrchestratorError enum" -- `OrchestratorError::HttpError` and `OrchestratorError::AgentUnavailable` must exist in `crate::error`
+- **Blocking:**
+  - "Implement Orchestrator struct with dispatch logic" -- uses `AgentEndpoint` in the registry
+  - "Implement MicroAgent for Orchestrator" -- indirectly, through the Orchestrator struct
+
+## Risks & Edge Cases
+
+1. **Trailing slash in URL**: If `url` is provided as `http://host:3000/`, the constructed path becomes `http://host:3000//invoke`. Mitigation: strip trailing slashes in `new()` using `url.trim_end_matches('/')`.
+
+2. **Non-2xx responses with valid AgentError body**: The invoke handler in `agent-runtime` returns structured `AgentError` JSON even on error status codes (e.g., 502 for `ToolCallFailed`). The current design maps all non-2xx to `OrchestratorError::HttpError`, which loses the structured error. This is acceptable for the initial implementation -- the Orchestrator's `dispatch()` method only needs to know the call failed. Future enhancement could preserve the `AgentError` if needed.
+
+3. **Deserialization failures**: If the downstream agent returns malformed JSON (not matching `AgentResponse` or `HealthResponseDto`), the reqwest `.json()` call will return a deserialization error. This is correctly mapped to `HttpError` / `AgentUnavailable` respectively.
+
+4. **Connection refused / timeout**: If the downstream agent is not running, `reqwest` will return a connection error. The `health()` method maps this to `AgentUnavailable`, which is the expected behavior for the orchestrator's health-check-before-dispatch pattern.
+
+5. **reqwest::Client reuse**: `reqwest::Client` internally uses connection pooling. Creating one per `AgentEndpoint` is efficient. If multiple endpoints share the same host, they could benefit from a shared client, but the per-endpoint approach is simpler and sufficient for the initial implementation.
+
+6. **HealthStatus enum variant compatibility**: The local `HealthResponseDto` deserializes `HealthStatus` from `agent-sdk`. Since both the downstream agent and the orchestrator use the same `agent-sdk` crate, the enum variants will match. If `HealthStatus` is extended in the future, both sides must be updated together (they share the same workspace dependency).
+
+7. **Borrow vs. owned in invoke**: The `invoke` method takes `&AgentRequest` (borrowed) rather than owned, because the orchestrator may need to retry the request against a different agent (e.g., during escalation). `reqwest`'s `.json()` accepts `&T where T: Serialize`, so this works without cloning.
+
+## Verification
+
+1. **Compilation**: `cargo check -p orchestrator` succeeds with no errors or warnings.
+2. **Linting**: `cargo clippy -p orchestrator` passes with no warnings.
+3. **Unit tests** (defined in a separate task but should verify):
+   - `new()` constructs an endpoint with correct field values
+   - `invoke()` sends correct JSON payload to `{url}/invoke` and returns deserialized `AgentResponse`
+   - `invoke()` maps HTTP error responses to `OrchestratorError::HttpError` with informative url and reason
+   - `invoke()` maps connection failures to `OrchestratorError::HttpError`
+   - `health()` returns the correct `HealthStatus` from a well-formed health response
+   - `health()` correctly ignores the `name` and `version` fields in the health response JSON
+   - `health()` maps connection failures to `OrchestratorError::AgentUnavailable` with the endpoint name
+   - `health()` maps non-2xx responses to `OrchestratorError::AgentUnavailable`
+4. **No dependency on agent-runtime**: `cargo tree -p orchestrator` does not list `agent-runtime` as a dependency.
+5. **All methods are under 50 lines**: Manual inspection of each method body.

--- a/.claude/specs/issue-15/implement-micro-agent-for-orchestrator.md
+++ b/.claude/specs/issue-15/implement-micro-agent-for-orchestrator.md
@@ -1,0 +1,213 @@
+# Spec: Implement MicroAgent for Orchestrator
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+
+Implement the `MicroAgent` trait (defined in `agent-sdk`) for the `Orchestrator` struct, making the orchestrator itself a first-class micro agent. This allows the orchestrator to be hosted on `agent-runtime` via the same HTTP interface (`POST /invoke`, `GET /health`) as any other agent -- the `AppState` in `agent-runtime::http` is `Arc<dyn MicroAgent>`, so any `MicroAgent` implementor is plug-compatible. The orchestrator becomes a meta-agent that receives requests, routes them to downstream agents, and reports its own health as an aggregate of its children.
+
+## Current State
+
+### MicroAgent trait (`crates/agent-sdk/src/micro_agent.rs`)
+
+```rust
+#[async_trait]
+pub trait MicroAgent: Send + Sync {
+    fn manifest(&self) -> &SkillManifest;
+    async fn invoke(&self, request: AgentRequest) -> Result<AgentResponse, AgentError>;
+    async fn health(&self) -> HealthStatus;
+}
+```
+
+The trait uses `#[async_trait]` (not native async trait methods) because the orchestrator requires `Box<dyn MicroAgent>` / `Arc<dyn MicroAgent>`, and native async methods are not dyn-compatible.
+
+### Existing MicroAgent implementation (`crates/agent-runtime/src/runtime_agent.rs`)
+
+`RuntimeAgent` is the only existing implementor. Its patterns establish the conventions this implementation should follow:
+- `manifest()` returns `&self.manifest` (a stored `SkillManifest` field).
+- `invoke()` performs the agent's core work and maps domain errors to `AgentError` variants.
+- `health()` returns `HealthStatus::Healthy` unconditionally (a leaf agent with no downstream dependencies).
+
+### Orchestrator struct (not yet implemented -- defined in task spec)
+
+Per the task breakdown, the `Orchestrator` will be defined in `crates/orchestrator/src/orchestrator.rs` with:
+```rust
+pub struct Orchestrator {
+    registry: HashMap<String, AgentEndpoint>,
+    manifest: SkillManifest,
+}
+```
+
+It will have a `dispatch(&self, request: AgentRequest) -> Result<AgentResponse, OrchestratorError>` method that handles routing, health-checking, invocation, and escalation.
+
+### HealthStatus (`crates/agent-sdk/src/health_status.rs`)
+
+```rust
+pub enum HealthStatus {
+    Healthy,
+    Degraded(String),
+    Unhealthy(String),
+}
+```
+
+`Degraded` and `Unhealthy` carry a reason string describing the issue.
+
+### OrchestratorError (to be defined in sibling task)
+
+Per the task breakdown, `OrchestratorError` will have variants `NoRoute`, `AgentUnavailable`, `EscalationFailed`, and `HttpError`, with a `From<OrchestratorError> for AgentError` conversion that maps all variants to `AgentError::Internal(err.to_string())`.
+
+### AgentEndpoint (to be defined in sibling task)
+
+`AgentEndpoint` will have a `health(&self) -> Result<HealthStatus, OrchestratorError>` method that calls `GET {url}/health` on the downstream agent and returns the parsed `HealthStatus`.
+
+### HTTP integration (`crates/agent-runtime/src/http.rs`)
+
+The runtime's HTTP layer uses `AppState = Arc<dyn MicroAgent>`. The `/invoke` handler calls `state.invoke(request)` and the `/health` handler calls `state.manifest()` and `state.health()`. Any `MicroAgent` implementor -- including `Orchestrator` -- can be wrapped in `Arc` and served through this same router.
+
+### Dependency: `futures` crate
+
+The `futures` crate (version 0.3) is already a direct dependency of both `agent-runtime` and `tool-registry`. It will need to be added to the orchestrator's `Cargo.toml` (or alternatively `futures-util` for a lighter footprint) for `futures::future::join_all`. Since it is already in the workspace lockfile, this does not introduce a new dependency to the dependency tree.
+
+## Requirements
+
+- Implement `MicroAgent for Orchestrator` in `crates/orchestrator/src/orchestrator.rs`.
+- `manifest()` must return a reference to the orchestrator's own `SkillManifest` (the `manifest` field on the struct).
+- `invoke(request)` must delegate to `self.dispatch(request)` and convert any `OrchestratorError` into `AgentError` using the `From` impl (i.e., `AgentError::Internal(err.to_string())`). The conversion can use the `?` operator with `.map_err()` or rely on the `From` impl if it is in scope.
+- `health()` must concurrently query the health of all registered agents in the registry using `futures::future::join_all`.
+- `health()` must aggregate downstream health statuses using these rules:
+  - If the registry is empty (no downstream agents), return `HealthStatus::Healthy` (the orchestrator itself is healthy even if it has nobody to route to).
+  - If at least one downstream agent reports `HealthStatus::Healthy`, the orchestrator reports `HealthStatus::Healthy`.
+  - If no agent is `Healthy` but at least one is `Degraded`, the orchestrator reports `HealthStatus::Degraded` with a message listing the degraded/unhealthy agents.
+  - If all agents are `Unhealthy` (or all health checks fail), the orchestrator reports `HealthStatus::Unhealthy` with a message summarizing the failures.
+- Health check failures (agents that return `Err(OrchestratorError)` from `AgentEndpoint::health()`) must be treated as `Unhealthy` for aggregation purposes -- they should not cause `health()` to panic or return an error.
+- The `#[async_trait]` attribute must be applied to the `impl MicroAgent for Orchestrator` block, matching the trait definition.
+- Each method must stay within the 50-line function limit per project rules.
+
+## Implementation Details
+
+### Files to modify
+
+1. **`crates/orchestrator/src/orchestrator.rs`** -- Add the `impl MicroAgent for Orchestrator` block after the existing `impl Orchestrator` block.
+
+2. **`crates/orchestrator/Cargo.toml`** -- Ensure `futures = "0.3"` is listed in `[dependencies]`. This may already be handled by the "Update orchestrator Cargo.toml with dependencies" task; if not, it must be added here. The `futures` crate is already in the workspace lockfile as a transitive dependency.
+
+### Key code structure
+
+The implementation goes in `crates/orchestrator/src/orchestrator.rs`:
+
+```rust
+#[async_trait]
+impl MicroAgent for Orchestrator {
+    fn manifest(&self) -> &SkillManifest {
+        &self.manifest
+    }
+
+    async fn invoke(&self, request: AgentRequest) -> Result<AgentResponse, AgentError> {
+        self.dispatch(request)
+            .await
+            .map_err(|e| AgentError::Internal(e.to_string()))
+    }
+
+    async fn health(&self) -> HealthStatus {
+        // described below
+    }
+}
+```
+
+### Health aggregation logic
+
+The `health()` method should:
+
+1. Collect futures for all registered agents by iterating `self.registry.values()` and calling `.health()` on each `AgentEndpoint`.
+2. Execute all futures concurrently with `futures::future::join_all`.
+3. Convert each `Result<HealthStatus, OrchestratorError>` to a `HealthStatus`, treating `Err` as `HealthStatus::Unhealthy(err.to_string())`.
+4. Classify results into three buckets: healthy count, degraded list, unhealthy list.
+5. Apply the aggregation rules:
+   - Empty registry -> `Healthy`
+   - Any healthy -> `Healthy`
+   - No healthy, some degraded -> `Degraded("N of M agents degraded: [names/reasons]")`
+   - All unhealthy -> `Unhealthy("All N agents unhealthy: [names/reasons]")`
+
+For clarity and the 50-line rule, extract the aggregation into a helper function:
+
+```rust
+fn aggregate_health(statuses: Vec<HealthStatus>) -> HealthStatus
+```
+
+This helper is a pure function (no async, no `&self`) that takes the resolved statuses and returns the aggregate. It can be a free function or an associated function on `Orchestrator`. Making it a standalone function also makes it independently unit-testable.
+
+### Imports required in `orchestrator.rs`
+
+```rust
+use agent_sdk::{
+    async_trait, AgentError, AgentRequest, AgentResponse,
+    HealthStatus, MicroAgent, SkillManifest,
+};
+use futures::future::join_all;
+```
+
+### Integration points
+
+- **With `agent-runtime`:** The orchestrator can be instantiated and wrapped in `Arc<dyn MicroAgent>`, then passed to `agent_runtime::http::build_router()` or `start_server()`. This wiring is out of scope for this task but is the reason this implementation exists.
+- **With `Orchestrator::dispatch()`:** The `invoke()` method is a thin adapter that calls `dispatch()` and converts the error type. All routing, health-gating, invocation, and escalation logic lives in `dispatch()`.
+- **With `AgentEndpoint::health()`:** The `health()` method calls `health()` on each `AgentEndpoint` in the registry. It must handle the `Result` return type gracefully.
+
+## Dependencies
+
+- **Blocked by:** "Implement Orchestrator struct with dispatch logic" (Group 3) -- the `Orchestrator` struct, its `dispatch()` method, and the `registry` field must exist before the trait can be implemented.
+- **Blocked by (transitively):** "Implement AgentEndpoint struct", "Define OrchestratorError enum", "Define registry config format and loader", "Convert orchestrator from binary to library crate", "Update orchestrator Cargo.toml with dependencies".
+- **Blocking:** "Write unit tests for AgentEndpoint" (Group 5) and "Write unit tests for Orchestrator dispatch and routing" (Group 5). These test suites exercise the full orchestrator including its `MicroAgent` behavior.
+
+## Risks & Edge Cases
+
+- **Empty registry:** An orchestrator with no registered agents is a valid state (e.g., during startup before agents are discovered). `health()` should return `Healthy` in this case, not `Unhealthy`, since the orchestrator itself is functioning -- it just has no downstream agents yet. `invoke()` will return an error via `dispatch()` -> `OrchestratorError::NoRoute`, which is correct behavior.
+
+- **All health checks fail with network errors:** If every `AgentEndpoint::health()` returns `Err`, all are treated as `Unhealthy` and the orchestrator reports `Unhealthy`. This is correct -- the orchestrator cannot serve requests if it cannot reach any downstream agent.
+
+- **Health check latency:** `join_all` runs all checks concurrently, but a single slow agent can still delay the overall health response. Consider whether `AgentEndpoint::health()` has a built-in timeout (via `reqwest` client timeout). If not, the orchestrator's `/health` endpoint could be slow. This is a concern for the `AgentEndpoint` implementation, not for this task, but worth noting.
+
+- **Large number of agents:** `join_all` spawns all futures at once. For a very large registry (hundreds of agents), this could create many simultaneous HTTP connections. In practice, orchestrators are expected to manage tens of agents at most, so this is not a concern for the initial implementation. If needed, `futures::stream::FuturesUnordered` with a concurrency limit could be used later.
+
+- **`HealthStatus` matching with strings:** `Degraded(String)` and `Unhealthy(String)` carry reason strings. The aggregation must compose meaningful messages from the individual agent statuses. Include agent names in the aggregated message so operators can identify which downstream agent is causing issues.
+
+- **Thread safety:** The `MicroAgent` trait requires `Send + Sync`. `Orchestrator` holds a `HashMap<String, AgentEndpoint>` and a `SkillManifest`, both of which are `Send + Sync` (assuming `AgentEndpoint` contains a `reqwest::Client`, which is `Send + Sync`). The `&self` receiver on all trait methods means no interior mutability is needed.
+
+- **Error conversion in `invoke()`:** The task description says to convert `OrchestratorError` to `AgentError::Internal(err.to_string())`. This discards the structured error information (variant, fields). This is acceptable because the HTTP layer serializes `AgentError` as JSON, and the `Internal` variant's string message is sufficient for debugging. If more granular error mapping is needed later (e.g., mapping `NoRoute` to a 404-like error), the conversion can be refined.
+
+## Verification
+
+1. **Compilation:**
+   ```bash
+   cargo check -p orchestrator
+   ```
+   Must succeed with no errors. The `MicroAgent` impl must satisfy all trait requirements.
+
+2. **Lint:**
+   ```bash
+   cargo clippy -p orchestrator
+   ```
+   Must succeed with no warnings.
+
+3. **Trait object compatibility:**
+   Verify that `Orchestrator` can be used as `Arc<dyn MicroAgent>`:
+   ```rust
+   let orch: Arc<dyn MicroAgent> = Arc::new(orchestrator);
+   ```
+   This must compile, confirming dyn-compatibility (object safety).
+
+4. **Unit tests (in the subsequent test task):**
+   - `manifest()` returns the correct `SkillManifest` that was provided at construction.
+   - `invoke()` delegates to `dispatch()` and returns `AgentResponse` on success.
+   - `invoke()` converts `OrchestratorError` to `AgentError::Internal` on failure.
+   - `health()` returns `Healthy` when the registry is empty.
+   - `health()` returns `Healthy` when at least one downstream agent is `Healthy`.
+   - `health()` returns `Degraded` when no agent is `Healthy` but at least one is `Degraded`.
+   - `health()` returns `Unhealthy` when all agents are `Unhealthy` or unreachable.
+   - `health()` treats agents returning `Err` from health checks as `Unhealthy`.
+   - `aggregate_health()` (if extracted as a helper) can be tested independently with synthetic `HealthStatus` vectors.
+
+5. **Workspace integrity:**
+   ```bash
+   cargo test
+   ```
+   Full workspace tests must still pass with no regressions.

--- a/.claude/specs/issue-15/implement-orchestrator-struct-with-dispatch-logic.md
+++ b/.claude/specs/issue-15/implement-orchestrator-struct-with-dispatch-logic.md
@@ -1,0 +1,199 @@
+# Spec: Implement Orchestrator struct with dispatch logic
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+
+Create the `Orchestrator` struct in `crates/orchestrator/src/orchestrator.rs` that serves as the central dispatch hub for the agent registry. The orchestrator receives incoming `AgentRequest`s, routes them to the appropriate downstream `AgentEndpoint`, handles escalation chains when agents signal low confidence, and enforces safety limits on recursion depth. This is the core logic layer that later gets wrapped with the `MicroAgent` trait (a separate task) so the orchestrator itself can run on `agent-runtime` as a homogeneous micro agent.
+
+Semantic routing via `SemanticRouter` is deferred to issue #16. This task implements a placeholder routing strategy: exact name matching from `request.context`, falling back to substring matching against endpoint descriptions.
+
+## Current State
+
+**Orchestrator crate** (`crates/orchestrator/`) is a skeleton with only a `main.rs` containing `println!("Hello, world!")` and an empty `Cargo.toml`. The crate will be converted to a library crate by a prerequisite task (Group 1).
+
+**SDK types used by this task** (all in `crates/agent-sdk/src/`):
+
+- `AgentRequest` -- has fields: `id: Uuid`, `input: String`, `context: Option<Value>`, `caller: Option<String>`. The `context` field is a `serde_json::Value` where routing information like `{"target_agent": "agent-name"}` will be placed.
+- `AgentResponse` -- has fields: `id: Uuid`, `output: Value`, `confidence: f32`, `escalated: bool`, `escalate_to: Option<String>`, `tool_calls: Vec<ToolCallRecord>`. The `escalated` and `escalate_to` fields drive the escalation chain logic.
+- `SkillManifest` -- has fields: `name: String`, `version: String`, `description: String`, `model: ModelConfig`, `preamble: String`, `tools: Vec<String>`, `constraints: Constraints`, `output: OutputSchema`. The orchestrator holds its own manifest to describe itself.
+- `HealthStatus` -- enum with `Healthy`, `Degraded(String)`, `Unhealthy(String)`.
+- `MicroAgent` trait -- defines `manifest()`, `invoke()`, `health()`. The orchestrator will implement this trait in a separate task (Group 4).
+
+**Prerequisite types created by sibling tasks** (not yet implemented):
+
+- `AgentEndpoint` (from `crates/orchestrator/src/agent_endpoint.rs`) -- struct with `name: String`, `description: String`, `url: String`, and methods `invoke(&self, request: &AgentRequest) -> Result<AgentResponse, OrchestratorError>` and `health(&self) -> Result<HealthStatus, OrchestratorError>`. Uses `reqwest` to call downstream agent HTTP endpoints.
+- `OrchestratorError` (from `crates/orchestrator/src/error.rs`) -- enum with variants: `NoRoute { input: String }`, `AgentUnavailable { name: String, reason: String }`, `EscalationFailed { chain: Vec<String>, reason: String }`, `HttpError { url: String, reason: String }`. Implements `Display`, `Error`, and `From<OrchestratorError> for AgentError`.
+- `OrchestratorConfig` / `AgentConfig` (from `crates/orchestrator/src/config.rs`) -- YAML/env-deserializable config with `agents: Vec<AgentConfig>` where each `AgentConfig` has `name`, `description`, `url`.
+
+**Patterns to follow:**
+
+- The `ConstraintEnforcer` in `crates/agent-runtime/src/constraint_enforcer.rs` demonstrates the decorator pattern around `MicroAgent` and how escalation fields are set.
+- The `RuntimeConfig::from_env()` in `crates/agent-runtime/src/config.rs` demonstrates the config-loading pattern.
+- Error types follow manual `Display + Error` implementations (not `thiserror`), as seen in `AgentError` and `ConfigError`.
+
+## Requirements
+
+- **R1**: Define a `pub struct Orchestrator` with fields `registry: HashMap<String, AgentEndpoint>` and `manifest: SkillManifest`.
+- **R2**: Implement `Orchestrator::new(manifest: SkillManifest, agents: Vec<AgentEndpoint>) -> Self` that populates the `registry` HashMap keyed by each agent's `name` field.
+- **R3**: Implement `Orchestrator::register(&mut self, endpoint: AgentEndpoint)` that inserts a single agent into the registry, keyed by its name. If an agent with the same name already exists, it is replaced.
+- **R4**: Implement `Orchestrator::route(&self, request: &AgentRequest) -> Result<&AgentEndpoint, OrchestratorError>` with two-phase lookup:
+  - Phase 1: If `request.context` is `Some(Value::Object(map))` and the map contains a `"target_agent"` key with a string value, look up that name in the registry. Return the endpoint if found, or `OrchestratorError::NoRoute` if not.
+  - Phase 2 (fallback): If no `target_agent` is specified in context, iterate all registry entries and check if `request.input` (lowercased) contains any word from the endpoint's `description` (lowercased, split by whitespace). Return the first match. This is a placeholder heuristic until `SemanticRouter` (issue #16) is implemented.
+  - Return `OrchestratorError::NoRoute { input }` if neither phase produces a match.
+- **R5**: Implement `Orchestrator::dispatch(&self, request: AgentRequest) -> Result<AgentResponse, OrchestratorError>` that:
+  - Calls `self.route(&request)` to find the target endpoint.
+  - Delegates to `try_invoke()` to perform the health check and invocation.
+  - Delegates to `handle_escalation()` if the response indicates escalation.
+  - Returns the final `AgentResponse` or an appropriate `OrchestratorError`.
+- **R6**: Implement helper `try_invoke(&self, endpoint: &AgentEndpoint, request: &AgentRequest) -> Result<AgentResponse, OrchestratorError>` that:
+  - Calls `endpoint.health()`. If the health status is `Unhealthy`, return `OrchestratorError::AgentUnavailable`.
+  - If health is `Healthy` or `Degraded`, call `endpoint.invoke(request)` and return the result.
+- **R7**: Implement helper `handle_escalation(&self, response: AgentResponse, chain: Vec<String>) -> Result<AgentResponse, OrchestratorError>` that:
+  - If `response.escalated` is `false`, return the response as-is.
+  - If `response.escalated` is `true` and `response.escalate_to` is `Some(name)`:
+    - Check the escalation chain length against `MAX_ESCALATION_DEPTH` (constant, value `5`). If exceeded, return `OrchestratorError::EscalationFailed { chain, reason: "max escalation depth exceeded" }`.
+    - Check if `name` is already in `chain` to detect cycles. If so, return `OrchestratorError::EscalationFailed { chain, reason: "escalation cycle detected" }`.
+    - Look up the escalation target in the registry. If not found, return `OrchestratorError::EscalationFailed { chain, reason: "escalation target not found" }`.
+    - Construct a new `AgentRequest` with the same `id` and `input`, but with `context` set to `{"target_agent": name}` and `caller` set to the previous agent's name.
+    - Call `try_invoke()` on the escalation target, append the target name to `chain`, and recursively call `handle_escalation()` on the result.
+  - If `response.escalated` is `true` but `response.escalate_to` is `None`, return the response as-is (the agent signaled low confidence but provided no escalation target).
+- **R8**: Implement `Orchestrator::from_config(config: OrchestratorConfig) -> Result<Self, OrchestratorError>` that:
+  - Iterates `config.agents` and constructs `AgentEndpoint::new(name, description, url)` for each.
+  - Constructs a default `SkillManifest` for the orchestrator itself (name: `"orchestrator"`, version: `"0.1.0"`, description: `"Routes requests to specialized agents"`, with sensible defaults for model, preamble, tools, constraints, and output).
+  - Calls `Orchestrator::new()` with the manifest and endpoints.
+- **R9**: Every public method must be under 50 lines. The `dispatch` method must be decomposed into `try_invoke` and `handle_escalation` helpers.
+- **R10**: The struct must be designed so that a `SemanticRouter` field can be added later (issue #16) without major refactoring. The `route()` method should be the single point where routing logic lives, making it straightforward to replace the substring heuristic with semantic routing.
+- **R11**: `dispatch`, `try_invoke`, and `handle_escalation` must be `async` methods since `AgentEndpoint::invoke()` and `AgentEndpoint::health()` are async (they make HTTP calls via `reqwest`).
+
+## Implementation Details
+
+### File to create
+
+**`crates/orchestrator/src/orchestrator.rs`**
+
+### Constants
+
+```rust
+const MAX_ESCALATION_DEPTH: usize = 5;
+```
+
+### Struct definition
+
+```rust
+use std::collections::HashMap;
+use agent_sdk::{AgentRequest, AgentResponse, HealthStatus, SkillManifest};
+use crate::agent_endpoint::AgentEndpoint;
+use crate::config::OrchestratorConfig;
+use crate::error::OrchestratorError;
+
+pub struct Orchestrator {
+    registry: HashMap<String, AgentEndpoint>,
+    manifest: SkillManifest,
+}
+```
+
+### Method signatures
+
+```rust
+impl Orchestrator {
+    pub fn new(manifest: SkillManifest, agents: Vec<AgentEndpoint>) -> Self
+    pub fn register(&mut self, endpoint: AgentEndpoint)
+    pub fn route(&self, request: &AgentRequest) -> Result<&AgentEndpoint, OrchestratorError>
+    pub async fn dispatch(&self, request: AgentRequest) -> Result<AgentResponse, OrchestratorError>
+    pub fn from_config(config: OrchestratorConfig) -> Result<Self, OrchestratorError>
+}
+
+// Private helpers
+impl Orchestrator {
+    async fn try_invoke(&self, endpoint: &AgentEndpoint, request: &AgentRequest) -> Result<AgentResponse, OrchestratorError>
+    async fn handle_escalation(&self, response: AgentResponse, chain: Vec<String>) -> Result<AgentResponse, OrchestratorError>
+}
+```
+
+### Routing logic detail
+
+In `route()`:
+1. Extract `target_agent` from context: `request.context.as_ref().and_then(|v| v.get("target_agent")).and_then(|v| v.as_str())`.
+2. If a target name is found, do `self.registry.get(name)` and return a reference, or return `NoRoute`.
+3. If no target name, iterate `self.registry.values()` and for each endpoint, check if any whitespace-delimited word from the endpoint's `description` (lowercased) appears as a substring in `request.input` (lowercased). Return the first match.
+4. Return `OrchestratorError::NoRoute { input: request.input.clone() }` if nothing matches.
+
+### Escalation logic detail
+
+In `handle_escalation()`:
+1. If `!response.escalated`, return `Ok(response)` immediately.
+2. Extract `escalate_to` name. If `None`, return `Ok(response)`.
+3. Check `chain.len() >= MAX_ESCALATION_DEPTH` for depth limit.
+4. Check `chain.contains(&name)` for cycle detection.
+5. Look up `name` in `self.registry`.
+6. Build a new `AgentRequest` preserving the original `id` and `input`, setting `context` to `json!({"target_agent": name})` and `caller` to `chain.last()`.
+7. Call `self.try_invoke(target, &new_request)`.
+8. Append `name` to `chain` and recurse into `handle_escalation(result, chain)`.
+
+### `from_config` logic detail
+
+Build `AgentEndpoint` instances from each `AgentConfig` entry. Construct a default `SkillManifest`:
+- `name`: `"orchestrator"`
+- `version`: `"0.1.0"`
+- `description`: `"Routes requests to specialized agents"`
+- `model`: `ModelConfig { provider: "none".into(), name: "none".into(), temperature: 0.0 }` (orchestrator does not use an LLM)
+- `preamble`: empty string
+- `tools`: empty vec
+- `constraints`: `Constraints { max_turns: 1, confidence_threshold: 0.0, escalate_to: None, allowed_actions: vec![] }`
+- `output`: `OutputSchema { format: "json".into(), schema: HashMap::new() }`
+
+### Integration points
+
+- **Imports from `agent-sdk`**: `AgentRequest`, `AgentResponse`, `HealthStatus`, `SkillManifest`, `ModelConfig`, `Constraints`, `OutputSchema`.
+- **Imports from sibling modules**: `AgentEndpoint` (from `crate::agent_endpoint`), `OrchestratorConfig` (from `crate::config`), `OrchestratorError` (from `crate::error`).
+- **The `MicroAgent` trait implementation** will be added in a separate task (Group 4) in the same file. The `dispatch()` method is designed to be called by `MicroAgent::invoke()` with error conversion.
+- **`serde_json`** is needed for constructing context JSON (`json!()` macro) in escalation re-dispatch.
+
+### Module declaration
+
+The parent `lib.rs` (created by a prerequisite task) must contain `pub mod orchestrator;` to expose this module.
+
+## Dependencies
+
+- **Blocked by**:
+  - "Convert orchestrator from binary to library crate" -- `lib.rs` must exist and declare `pub mod orchestrator;`
+  - "Update orchestrator Cargo.toml with dependencies" -- `agent-sdk`, `serde_json`, `tokio`, and `async-trait` must be in `Cargo.toml`
+  - "Define OrchestratorError enum" -- `crate::error::OrchestratorError` must exist with `NoRoute`, `AgentUnavailable`, `EscalationFailed`, `HttpError` variants
+  - "Implement AgentEndpoint struct" -- `crate::agent_endpoint::AgentEndpoint` must exist with `name`, `description`, `invoke()`, and `health()`
+  - "Define registry config format and loader" -- `crate::config::OrchestratorConfig` and `AgentConfig` must exist
+
+- **Blocking**:
+  - "Implement MicroAgent for Orchestrator" -- needs `dispatch()` to delegate from `MicroAgent::invoke()`
+  - "Write unit tests for Orchestrator dispatch and routing" -- tests exercise all methods defined here
+
+## Risks & Edge Cases
+
+- **Infinite escalation loops**: Agent A escalates to Agent B, which escalates back to Agent A. Mitigated by cycle detection (checking if the target name is already in the escalation chain) and the hard cap at `MAX_ESCALATION_DEPTH = 5`.
+- **Escalation target not in registry**: An agent may specify `escalate_to: Some("unknown-agent")`. The `handle_escalation` method must handle this gracefully with `EscalationFailed` rather than panicking.
+- **Race condition on health checks**: An agent might become unhealthy between the health check and the invocation. This is acceptable for now; the `invoke()` call will fail with an `HttpError` which propagates cleanly. A retry-with-fallback strategy is out of scope.
+- **Multiple substring matches in route()**: The fallback heuristic may match multiple agents. The current design returns the first match found during `HashMap` iteration, which has nondeterministic ordering. This is acceptable because the substring heuristic is explicitly a placeholder -- `SemanticRouter` (issue #16) will replace it with ranked scoring. Document this limitation with a code comment.
+- **Empty registry**: If no agents are registered, all `route()` calls return `NoRoute`. This is valid behavior, not an error in construction.
+- **Large input strings**: The substring matching iterates all registry entries and does string comparisons. With a small registry (expected: tens of agents, not thousands), this is not a performance concern.
+- **Context field conflicts**: If `request.context` contains `"target_agent"` but the value is not a string (e.g., it is a number or object), the extraction via `as_str()` returns `None` and falls through to the heuristic. This is safe but could be surprising. Add a comment noting this behavior.
+- **`from_config` default manifest**: The default `SkillManifest` uses placeholder values for `model` and `output` since the orchestrator does not use an LLM. If these fields are later validated elsewhere, the placeholders must pass validation. Using `"none"` for provider/model and `"json"` for output format (which is in `ALLOWED_OUTPUT_FORMATS`) avoids this.
+
+## Verification
+
+- **Compilation**: `cargo check -p orchestrator` succeeds with no errors (requires all prerequisite tasks to be complete).
+- **Lint**: `cargo clippy -p orchestrator` produces no warnings.
+- **Unit tests** (defined in the sibling test task, but verifying this task's correctness):
+  1. `new()` populates registry with correct keys; agents are retrievable by name.
+  2. `register()` adds an agent that can be routed to; replacing an existing name overwrites cleanly.
+  3. `route()` returns the correct endpoint when `context` contains `target_agent`.
+  4. `route()` falls back to substring matching when no `target_agent` is in context.
+  5. `route()` returns `NoRoute` when no agent matches.
+  6. `dispatch()` calls `route()`, checks health, invokes the agent, and returns the response.
+  7. `dispatch()` returns `AgentUnavailable` when the target agent is `Unhealthy`.
+  8. `dispatch()` handles a single escalation hop correctly.
+  9. `dispatch()` returns `EscalationFailed` when escalation depth exceeds `MAX_ESCALATION_DEPTH`.
+  10. `dispatch()` returns `EscalationFailed` when an escalation cycle is detected.
+  11. `dispatch()` returns `EscalationFailed` when the escalation target is not in the registry.
+  12. `from_config()` builds a valid `Orchestrator` from an `OrchestratorConfig`.
+  13. All methods are under 50 lines.
+- **Integration**: The orchestrator's `dispatch()` method signature is compatible with the planned `MicroAgent::invoke()` delegation pattern (takes `AgentRequest`, returns `Result<AgentResponse, _>` with error convertible to `AgentError`).

--- a/.claude/specs/issue-15/run-verification-suite.md
+++ b/.claude/specs/issue-15/run-verification-suite.md
@@ -1,0 +1,122 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+
+Run the full Rust verification pipeline (`cargo check`, `cargo clippy`, `cargo test`) across the entire workspace to confirm that all new orchestrator code compiles cleanly, passes linting, and passes tests -- and that no regressions have been introduced in the four existing crates (`agent-sdk`, `agent-runtime`, `skill-loader`, `tool-registry`).
+
+This is the final gate task for issue-15. It must not run until every other Group 5 task (all four test suites) and all preceding groups are complete.
+
+## Current State
+
+- **Workspace root** (`/workspaces/spore/Cargo.toml`) defines six workspace members:
+  - `crates/agent-sdk`
+  - `crates/skill-loader`
+  - `crates/tool-registry`
+  - `crates/agent-runtime`
+  - `crates/orchestrator`
+  - `tools/echo-tool`
+- **Existing crates** have integration tests in their respective `tests/` directories:
+  - `agent-sdk`: `envelope_types_test.rs`, `micro_agent_test.rs`, `skill_manifest_test.rs`
+  - `skill-loader`: `validation_test.rs`, `example_skills_test.rs`, `skill_loader_test.rs`, `validation_integration_test.rs`
+  - `tool-registry`: `mcp_connection_test.rs`, `tool_entry_test.rs`, `tool_registry_test.rs`
+  - `agent-runtime`: `constraint_enforcer_test.rs`, `http_test.rs`, `runtime_agent_test.rs`
+- **Orchestrator crate** is currently a stub binary (`src/main.rs` with `println!("Hello, world!")`). By the time this task runs, it will have been converted to a library crate with four source modules (`lib.rs`, `error.rs`, `agent_endpoint.rs`, `config.rs`, `orchestrator.rs`) and four test files (`tests/error_test.rs`, `tests/agent_endpoint_test.rs`, `tests/config_test.rs`, `tests/orchestrator_test.rs`).
+- **Orchestrator Cargo.toml** currently has no dependencies. By the time this task runs, it will have been updated with dependencies on `agent-sdk`, `reqwest`, `tokio`, `serde`, `serde_json`, `serde_yaml`, `async-trait`, and dev-dependencies `tokio` (with macros) and `axum`.
+
+## Requirements
+
+1. `cargo check` must pass with zero errors across all workspace members.
+2. `cargo clippy` must pass with zero warnings across all workspace members (using default lint levels, no `--allow` suppression of legitimate warnings).
+3. `cargo test` must pass with all tests green across all workspace members.
+4. All pre-existing tests in `agent-sdk`, `agent-runtime`, `skill-loader`, and `tool-registry` must continue to pass without modification (no regressions).
+5. All four new orchestrator test files must pass:
+   - `crates/orchestrator/tests/error_test.rs`
+   - `crates/orchestrator/tests/agent_endpoint_test.rs`
+   - `crates/orchestrator/tests/config_test.rs`
+   - `crates/orchestrator/tests/orchestrator_test.rs`
+6. No compiler warnings in any crate (treat warnings as signals to fix, not suppress).
+
+## Implementation Details
+
+This is a verification-only task. No source files are created or modified. The implementation consists of running three commands sequentially and inspecting their output.
+
+### Step 1: Type checking
+
+```bash
+cargo check --workspace 2>&1
+```
+
+- Confirm exit code 0.
+- Scan output for any `error[E...]` lines -- there must be none.
+- Note any warnings for resolution.
+
+### Step 2: Linting
+
+```bash
+cargo clippy --workspace --all-targets 2>&1
+```
+
+- Confirm exit code 0.
+- The `--all-targets` flag ensures clippy runs against library code, test code, benchmarks, and examples.
+- Scan output for any `warning:` lines originating from workspace crates (ignore external dependency warnings if any).
+- If warnings are found, they must be fixed in the relevant source files before this task can be marked complete.
+
+### Step 3: Testing
+
+```bash
+cargo test --workspace 2>&1
+```
+
+- Confirm exit code 0.
+- Verify output shows test results from all six workspace members.
+- Specifically confirm the following test suites ran and passed:
+  - **agent-sdk**: `envelope_types_test`, `micro_agent_test`, `skill_manifest_test`
+  - **skill-loader**: `validation_test`, `example_skills_test`, `skill_loader_test`, `validation_integration_test`
+  - **tool-registry**: `mcp_connection_test`, `tool_entry_test`, `tool_registry_test`
+  - **agent-runtime**: `constraint_enforcer_test`, `http_test`, `runtime_agent_test`
+  - **orchestrator**: `error_test`, `agent_endpoint_test`, `config_test`, `orchestrator_test`
+- Confirm zero test failures and zero test panics.
+
+### Handling failures
+
+If any step fails:
+1. Diagnose the root cause by reading the error output.
+2. Identify which file(s) need to be fixed. If the failure is in new orchestrator code, fix those files. If the failure is in a pre-existing crate (regression), investigate whether the orchestrator changes caused the regression (e.g., a dependency conflict, a shared type change).
+3. Re-run all three verification steps after any fix to confirm no cascading issues.
+4. Do not suppress warnings with `#[allow(...)]` attributes unless the warning is a genuine false positive.
+
+## Dependencies
+
+- **Blocked by**: All other tasks in Group 5:
+  - "Write unit tests for OrchestratorError"
+  - "Write unit tests for AgentEndpoint"
+  - "Write unit tests for Orchestrator dispatch and routing"
+  - "Write unit tests for config loading"
+  - (And transitively, all tasks in Groups 1-4)
+- **Blocking**: None. This is the terminal task for issue-15.
+
+## Risks & Edge Cases
+
+1. **Clippy version sensitivity**: Different Rust toolchain versions may surface different clippy lints. The verification should use whatever `rustup` toolchain is configured in the workspace (currently edition 2024, implying Rust nightly or a very recent stable). If clippy produces new lints not present in older toolchains, they should be addressed rather than suppressed.
+
+2. **Test isolation for env-based config tests**: The config tests modify environment variables (`AGENT_ENDPOINTS`, `AGENT_DESCRIPTIONS`). These tests must use a mutex or `serial_test` to avoid races. If `cargo test` runs tests in parallel and env-var tests interfere with each other, the fix is in the test code (use `std::sync::Mutex` or the `serial_test` crate), not in the verification step.
+
+3. **Network-dependent tests**: The `agent_endpoint_test.rs` and `orchestrator_test.rs` tests spin up local `axum` servers on ephemeral ports. These should bind to `127.0.0.1:0` to avoid port conflicts. If tests fail due to port binding issues, the fix is in the test setup code.
+
+4. **Flaky health-check tests**: Tests that rely on timing (e.g., health check timeouts) may be flaky. If a test passes locally but fails in CI, consider whether it needs a retry or a longer timeout.
+
+5. **Edition 2024 compatibility**: The orchestrator Cargo.toml uses `edition = "2024"`. Ensure the Rust toolchain supports this edition. If not, the edition may need to be downgraded to `"2021"` in a prior task.
+
+6. **Workspace lockfile consistency**: Adding new direct dependencies to the orchestrator crate may update `Cargo.lock`. Verify that `Cargo.lock` changes are limited to the new direct dependencies and do not unexpectedly upgrade versions for existing crates.
+
+## Verification
+
+This task IS the verification step for the entire issue-15 implementation. It is complete when:
+
+1. `cargo check --workspace` exits with code 0 and zero errors.
+2. `cargo clippy --workspace --all-targets` exits with code 0 and zero workspace warnings.
+3. `cargo test --workspace` exits with code 0, all tests pass, and zero tests are ignored/skipped unexpectedly.
+4. The output of `cargo test` explicitly shows passing results from all five crates' test suites (agent-sdk, skill-loader, tool-registry, agent-runtime, orchestrator).
+5. No source files in `agent-sdk`, `agent-runtime`, `skill-loader`, or `tool-registry` were modified (confirming zero regressions requiring changes to existing code).

--- a/.claude/specs/issue-15/update-orchestrator-cargo-toml-with-dependencies.md
+++ b/.claude/specs/issue-15/update-orchestrator-cargo-toml-with-dependencies.md
@@ -1,0 +1,120 @@
+# Spec: Update orchestrator Cargo.toml with dependencies
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+Add all required dependencies to `crates/orchestrator/Cargo.toml` so that subsequent tasks (Groups 2-4) can compile against them. The orchestrator crate currently has an empty `[dependencies]` section. All dependencies being added already exist in `Cargo.lock` as transitive dependencies of other workspace crates, so this change introduces zero new crates to the dependency tree.
+
+## Current State
+
+**`crates/orchestrator/Cargo.toml`** is a minimal stub:
+```toml
+[package]
+name = "orchestrator"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+```
+There is no `[dev-dependencies]` section, and the `[dependencies]` section is empty.
+
+**Workspace lockfile (`Cargo.lock`)** already contains every crate being added:
+| Crate | Locked version | Pulled in by |
+|---|---|---|
+| `async-trait` | 0.1.89 | `agent-sdk` |
+| `serde` | 1.0.228 | `agent-sdk`, `agent-runtime`, others |
+| `serde_json` | 1.0.149 | `agent-sdk`, `agent-runtime`, others |
+| `serde_yaml` | 0.9.34 | `agent-sdk` (dev-dep) |
+| `tokio` | 1.50.0 | `agent-runtime`, others |
+| `reqwest` | 0.13.2 | `rig-core` (transitive) |
+| `axum` | 0.8.8 | `agent-runtime` |
+
+**`crates/agent-runtime/Cargo.toml`** serves as the reference for dependency declaration patterns in this workspace. It uses:
+- Path dependencies for workspace crates: `agent-sdk = { path = "../agent-sdk" }`
+- Version-only for simple crates: `serde_json = "1"`
+- Version with features for crates needing feature flags: `serde = { version = "1", features = ["derive"] }`, `tokio = { version = "1", features = ["full"] }`
+
+**`crates/agent-sdk/Cargo.toml`** also serves as a reference, using the same patterns and already declaring `async-trait = "0.1"`, `serde_yaml = "0.9"` (as dev-dep), and `tokio` (as dev-dep).
+
+## Requirements
+
+1. Add the following entries under `[dependencies]` in `crates/orchestrator/Cargo.toml`:
+   - `agent-sdk = { path = "../agent-sdk" }` -- provides `MicroAgent`, `AgentRequest`, `AgentResponse`, `AgentError`, `HealthStatus`, `SkillManifest`
+   - `reqwest = { version = "0.13", features = ["json"] }` -- HTTP client for calling downstream agent endpoints
+   - `tokio = { version = "1", features = ["full"] }` -- async runtime (needed for async methods and `join_all` in health checks)
+   - `serde = { version = "1", features = ["derive"] }` -- serialization/deserialization with derive macros
+   - `serde_json = "1"` -- JSON handling for request/response bodies
+   - `serde_yaml = "0.9"` -- YAML config file parsing
+   - `async-trait = "0.1"` -- async trait support for `MicroAgent` impl
+
+2. Add a `[dev-dependencies]` section with:
+   - `tokio = { version = "1", features = ["macros", "rt"] }` -- test runtime with `#[tokio::test]` macro support
+   - `axum = "0.8"` -- used to spin up mock HTTP servers in integration tests
+
+3. The `[package]` section must remain unchanged (`name = "orchestrator"`, `version = "0.1.0"`, `edition = "2024"`).
+
+4. After modification, `cargo check -p orchestrator` must succeed without errors.
+
+5. `Cargo.lock` must not gain any new top-level crate entries (all dependencies are already present as transitive deps).
+
+6. `cargo clippy -p orchestrator` must produce no warnings.
+
+7. All existing workspace tests (`cargo test`) must continue to pass with no regressions.
+
+## Implementation Details
+
+**File to modify:** `crates/orchestrator/Cargo.toml`
+
+The final file content should be:
+
+```toml
+[package]
+name = "orchestrator"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+agent-sdk = { path = "../agent-sdk" }
+reqwest = { version = "0.13", features = ["json"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+async-trait = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+axum = "0.8"
+```
+
+**Ordering convention:** Follow the pattern from `agent-runtime/Cargo.toml` -- path dependencies first, then external crates. This is a soft convention; the key requirement is that all entries are present and correct.
+
+**No other files need modification.** The `Cargo.lock` will be automatically updated by Cargo to reflect the new direct dependency edges, but since all crates are already resolved in the lockfile, the lock entries themselves should not change (only the dependency graph metadata within the lock may shift minimally).
+
+## Dependencies
+
+- **Blocked by:** Nothing -- this is a Group 1 task that can be done immediately in parallel with the other Group 1 tasks.
+- **Blocking:** All Group 2 and Group 3 tasks:
+  - "Implement AgentEndpoint struct" (needs `reqwest`, `serde`, `agent-sdk`)
+  - "Define registry config format and loader" (needs `serde`, `serde_yaml`)
+  - "Implement Orchestrator struct with dispatch logic" (needs all deps)
+  - "Implement MicroAgent for Orchestrator" (needs `async-trait`, `agent-sdk`)
+  - All Group 5 test tasks (need `axum` and `tokio` dev-deps)
+
+## Risks & Edge Cases
+
+1. **`serde_yaml` deprecation warning:** The locked version is `0.9.34+deprecated`. The `serde_yaml` crate has been deprecated in favor of alternatives, but it is already used by `agent-sdk` as a dev-dependency, so using the same version here is consistent. If the workspace migrates away from `serde_yaml` in the future, the orchestrator crate will need to follow suit.
+
+2. **`reqwest` version compatibility:** The spec requests `version = "0.13"` which will resolve to `0.13.2` (already locked). If the workspace upgrades `reqwest` via `rig-core`, the semver range `"0.13"` will accept any `0.13.x` patch. No risk here.
+
+3. **Duplicate `tokio` in `[dependencies]` and `[dev-dependencies]`:** Cargo handles this correctly -- the `[dev-dependencies]` entry adds the `macros` and `rt` features only for test/bench targets, while the `[dependencies]` entry with `features = ["full"]` applies to the library. Since `"full"` already includes `"macros"` and `"rt"`, the dev-dependency entry is technically redundant but is included explicitly for clarity and to match the `agent-sdk` pattern.
+
+4. **Edition 2024 compatibility:** The crate uses `edition = "2024"`. All listed dependencies support Rust edition 2024. No compatibility issues expected.
+
+## Verification
+
+1. Run `cargo check -p orchestrator` -- must succeed with exit code 0.
+2. Run `cargo clippy -p orchestrator` -- must produce no warnings or errors.
+3. Run `cargo test` (full workspace) -- must pass with no regressions in existing crates.
+4. Inspect `Cargo.lock` diff to confirm no entirely new crate entries were added (only dependency-graph edges may change).
+5. Verify the final `Cargo.toml` contains all seven `[dependencies]` entries and both `[dev-dependencies]` entries listed in the Requirements section.

--- a/.claude/specs/issue-15/write-unit-tests-for-agent-endpoint.md
+++ b/.claude/specs/issue-15/write-unit-tests-for-agent-endpoint.md
@@ -1,0 +1,164 @@
+# Spec: Write unit tests for AgentEndpoint
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+
+Create integration-style unit tests for `AgentEndpoint` that verify its `invoke()` and `health()` methods correctly communicate with downstream agent HTTP servers, properly deserialize successful responses, and map error conditions to the appropriate `OrchestratorError` variants. These tests use a real axum HTTP server (bound to a random port on localhost) rather than mocking `reqwest` directly, ensuring the full HTTP round-trip is exercised.
+
+## Current State
+
+**`crates/agent-runtime/tests/http_test.rs`** establishes the project's axum test pattern. It uses `tower::ServiceExt::oneshot` to send requests directly into an axum `Router` without binding a TCP port. This approach works for testing axum handlers, but is **not suitable for `AgentEndpoint` tests** because `AgentEndpoint` uses `reqwest::Client` to make outbound HTTP calls -- it needs a real listening TCP server.
+
+The test file builds a `MockAgent` implementing `MicroAgent`, wraps it in `Arc<dyn MicroAgent>`, passes it to `agent_runtime::http::build_router()`, and uses helper functions (`build_invoke_request`, `read_body`) for constructing requests and reading responses. The mock supports configurable error modes (`ErrorMode::None`, `ErrorMode::Internal`, `ErrorMode::ToolCallFailed`) and health statuses.
+
+**`crates/agent-runtime/src/http.rs`** defines the server-side HTTP handlers. Key structures:
+- `HealthResponse { name: String, version: String, status: HealthStatus }` -- the JSON shape returned by `GET /health`
+- `POST /invoke` accepts `Json<AgentRequest>` and returns `Json<AgentResponse>` or an `AppError` (which maps `AgentError` variants to HTTP status codes: `Internal` -> 500, `ToolCallFailed` -> 502, etc.)
+
+**`crates/agent-sdk/src/`** types used in the test:
+- `AgentRequest { id: Uuid, input: String, context: Option<Value>, caller: Option<String> }` -- created via `AgentRequest::new(input)`
+- `AgentResponse { id: Uuid, output: Value, confidence: f32, escalated: bool, escalate_to: Option<String>, tool_calls: Vec<ToolCallRecord> }`
+- `HealthStatus` -- enum with `Healthy`, `Degraded(String)`, `Unhealthy(String)`
+
+**`AgentEndpoint`** (to be created by a predecessor task) is expected to have:
+- `new(name: String, description: String, url: String) -> Self` -- constructs with a `reqwest::Client`
+- `invoke(&self, request: &AgentRequest) -> Result<AgentResponse, OrchestratorError>` -- POST to `{url}/invoke`, map errors to `OrchestratorError::HttpError`
+- `health(&self) -> Result<HealthStatus, OrchestratorError>` -- GET `{url}/health`, extract `status` field, map errors to `OrchestratorError::AgentUnavailable`
+
+**`OrchestratorError`** (to be created by a predecessor task) has variants:
+- `HttpError { url: String, reason: String }` -- for network/HTTP failures
+- `AgentUnavailable { name: String, reason: String }` -- for health check failures
+
+**`crates/orchestrator/Cargo.toml`** currently has no dependencies. A predecessor task will add `axum = "0.8"` as a dev-dependency and `reqwest`, `agent-sdk`, `tokio`, `serde`, `serde_json` as regular dependencies.
+
+## Requirements
+
+1. **Test: `invoke_sends_correct_json_and_returns_agent_response`**
+   - Start a mock axum server on `127.0.0.1:0` (OS-assigned port) that implements `POST /invoke` returning a valid `AgentResponse` JSON.
+   - Create an `AgentEndpoint` pointing at the server's address.
+   - Call `endpoint.invoke(&request)` and verify the returned `AgentResponse` has the correct `id`, `output`, `confidence`, `escalated`, and `tool_calls` fields.
+   - Verify the server received the correct `AgentRequest` JSON (matching `id`, `input`, `context`, `caller` fields).
+
+2. **Test: `invoke_maps_http_errors_to_orchestrator_error`**
+   - Start a mock axum server that returns HTTP 500 (Internal Server Error) for `POST /invoke`.
+   - Call `endpoint.invoke(&request)` and verify the result is `Err(OrchestratorError::HttpError { .. })`.
+   - Verify the error's `url` field contains the endpoint URL and the `reason` field contains meaningful error information.
+
+3. **Test: `health_returns_correct_health_status`**
+   - Start a mock axum server that returns a valid `HealthResponse` JSON with `status: Healthy` on `GET /health`.
+   - Call `endpoint.health()` and verify it returns `Ok(HealthStatus::Healthy)`.
+   - Repeat with `Degraded("reason")` to verify non-trivial status deserialization.
+
+4. **Test: `health_maps_connection_failures_to_agent_unavailable`**
+   - Create an `AgentEndpoint` pointing at a URL where no server is listening (e.g., `http://127.0.0.1:1` or a port known to be closed).
+   - Call `endpoint.health()` and verify the result is `Err(OrchestratorError::AgentUnavailable { .. })`.
+   - Verify the error's `name` field matches the endpoint's name and the `reason` field contains connection failure information.
+
+5. All tests must be `#[tokio::test]` async tests.
+
+6. The mock server must use `agent_runtime::http::build_router()` with a `MockAgent` implementing `MicroAgent`, following the same pattern as `crates/agent-runtime/tests/http_test.rs`. This reuses the real HTTP handler logic rather than hand-coding axum routes.
+
+7. The mock server must be spawned on a background tokio task using `tokio::net::TcpListener::bind("127.0.0.1:0")` and `axum::serve()`, so that `reqwest` can make real HTTP connections to it.
+
+## Implementation Details
+
+### File to create
+
+**`crates/orchestrator/tests/agent_endpoint_test.rs`**
+
+### Helper: `MockAgent` struct
+
+Reuse the same pattern from `crates/agent-runtime/tests/http_test.rs`:
+- Define an `ErrorMode` enum with variants `None` and `Internal` (only need enough to test success and error paths).
+- Define a `MockAgent` struct with fields: `manifest: SkillManifest`, `error_mode: ErrorMode`, `health_status: HealthStatus`.
+- Implement `MicroAgent` for `MockAgent`:
+  - `manifest()` returns `&self.manifest`
+  - `invoke()` returns `Ok(AgentResponse { ... })` in normal mode or `Err(AgentError::Internal(...))` in error mode
+  - `health()` returns `self.health_status.clone()`
+- Define `make_manifest() -> SkillManifest` helper (same as in `http_test.rs`).
+
+### Helper: `start_mock_server`
+
+```
+async fn start_mock_server(error_mode: ErrorMode, health_status: HealthStatus) -> String
+```
+
+- Creates a `MockAgent` and wraps it in `Arc<dyn MicroAgent>`.
+- Calls `agent_runtime::http::build_router(state)` to get the axum `Router`.
+- Binds a `tokio::net::TcpListener` to `127.0.0.1:0`.
+- Captures `listener.local_addr()` to determine the assigned port.
+- Spawns `axum::serve(listener, router)` on a background tokio task.
+- Returns the base URL as `format!("http://127.0.0.1:{}", port)`.
+
+### Test functions
+
+1. **`invoke_sends_correct_json_and_returns_agent_response`**
+   - `let url = start_mock_server(ErrorMode::None, HealthStatus::Healthy).await;`
+   - `let endpoint = AgentEndpoint::new("test-agent".into(), "desc".into(), url);`
+   - `let request = AgentRequest::new("hello".into());`
+   - `let response = endpoint.invoke(&request).await.unwrap();`
+   - Assert `response.id == request.id`, `response.output == json!({"result": "ok"})`, `response.confidence` is approximately 0.95, `response.escalated == false`, `response.tool_calls.is_empty()`.
+
+2. **`invoke_maps_http_errors_to_orchestrator_error`**
+   - `let url = start_mock_server(ErrorMode::Internal, HealthStatus::Healthy).await;`
+   - `let endpoint = AgentEndpoint::new("test-agent".into(), "desc".into(), url);`
+   - `let request = AgentRequest::new("trigger error".into());`
+   - `let result = endpoint.invoke(&request).await;`
+   - Assert `result.is_err()`.
+   - Match on the error and verify it is `OrchestratorError::HttpError { url, reason }` where `url` contains "/invoke" and `reason` is non-empty.
+
+3. **`health_returns_correct_health_status`**
+   - `let url = start_mock_server(ErrorMode::None, HealthStatus::Healthy).await;`
+   - `let endpoint = AgentEndpoint::new("test-agent".into(), "desc".into(), url);`
+   - `let status = endpoint.health().await.unwrap();`
+   - Assert `status == HealthStatus::Healthy`.
+   - Optionally repeat with `HealthStatus::Degraded("high latency".into())` in a separate test or as a second assertion block within the same test.
+
+4. **`health_maps_connection_failures_to_agent_unavailable`**
+   - `let endpoint = AgentEndpoint::new("test-agent".into(), "desc".into(), "http://127.0.0.1:1".into());` (no server listening)
+   - `let result = endpoint.health().await;`
+   - Assert `result.is_err()`.
+   - Match on the error and verify it is `OrchestratorError::AgentUnavailable { name, reason }` where `name == "test-agent"` and `reason` contains connection-related text.
+
+### Dev-dependencies required in `crates/orchestrator/Cargo.toml`
+
+The predecessor task "Update orchestrator Cargo.toml with dependencies" must include these dev-dependencies:
+- `tokio = { version = "1", features = ["macros", "rt"] }` (for `#[tokio::test]`)
+- `axum = "0.8"` (for `axum::serve` in the mock server)
+- `agent-runtime = { path = "../agent-runtime" }` (for `agent_runtime::http::build_router`)
+- `agent-sdk = { path = "../agent-sdk" }` (for `AgentRequest`, `AgentResponse`, `HealthStatus`, `MicroAgent`, etc.)
+- `serde_json = "1"` (for `json!()` macro in assertions)
+
+Note: `agent-runtime` as a dev-dependency does NOT create a circular dependency problem. Circular dependencies are only an issue for regular `[dependencies]`. Dev-dependencies form a separate graph and cycles are allowed by Cargo.
+
+### Integration points
+
+- Depends on `orchestrator::agent_endpoint::AgentEndpoint` (the struct under test).
+- Depends on `orchestrator::error::OrchestratorError` (to match error variants).
+- Depends on `agent_runtime::http::build_router` (to create the mock server router).
+- Depends on `agent_sdk::{MicroAgent, AgentRequest, AgentResponse, HealthStatus, AgentError, SkillManifest, ...}` (for mock agent and type assertions).
+
+## Dependencies
+
+- **Blocked by**: "Implement MicroAgent for Orchestrator" (which transitively depends on all Group 1-3 tasks including AgentEndpoint, OrchestratorError, the Cargo.toml updates, and the lib.rs conversion)
+- **Blocking**: Nothing (non-blocking; this is a leaf task in Group 5)
+
+## Risks & Edge Cases
+
+- **Port conflicts**: Using `127.0.0.1:0` for OS-assigned ports eliminates port conflict risks. Each test gets its own port.
+- **Server shutdown**: The mock server is spawned on a background task and will be dropped when the test completes. Since `axum::serve` runs until the listener is dropped, and the tokio runtime shuts down after the test, cleanup is automatic. No explicit shutdown signal is needed.
+- **Race condition on server readiness**: After `tokio::spawn(axum::serve(...))`, the server may not be immediately ready to accept connections. In practice, binding the `TcpListener` before spawning means the port is already listening; `axum::serve` just starts accepting. If flakiness occurs, a small `tokio::time::sleep` can be added, but this is unlikely to be needed.
+- **HTTP 500 handling in `invoke()`**: The `AgentEndpoint::invoke()` method must decide how to handle non-2xx HTTP responses. If the server returns 500, `reqwest` will still return `Ok(Response)` (not an error). The implementation must check the status code and map non-2xx responses to `OrchestratorError::HttpError`. The test should verify this behavior explicitly.
+- **`reqwest` connection refused**: When connecting to a port with no listener, `reqwest` returns a connection error (not an HTTP error). The `AgentEndpoint::health()` implementation must catch this and convert it to `OrchestratorError::AgentUnavailable`. Port 1 is used in the test because it is a privileged port that no test server will be listening on.
+- **Circular dependency concern**: Adding `agent-runtime` as a dev-dependency is safe because Cargo allows cycles in the dev-dependency graph. However, if `agent-runtime` ever adds `orchestrator` as a regular dependency, the dev-dependency from `orchestrator` tests back to `agent-runtime` is still fine. Only regular dependency cycles are forbidden.
+- **`HealthResponse` deserialization**: `AgentEndpoint::health()` deserializes a local DTO (not `agent_runtime::http::HealthResponse`) to avoid a regular dependency on `agent-runtime`. The test implicitly validates that the local DTO is compatible with the actual `HealthResponse` format because the mock server uses the real `agent-runtime` handler.
+
+## Verification
+
+1. `cargo test -p orchestrator --test agent_endpoint_test` passes all four tests
+2. `cargo clippy -p orchestrator --tests` produces no warnings on the test file
+3. Each test exercises a distinct code path in `AgentEndpoint`: successful invoke, error invoke, successful health, connection-failure health
+4. The mock server pattern is consistent with `crates/agent-runtime/tests/http_test.rs` (reusing `build_router`, `MockAgent`, `MicroAgent` trait impl)
+5. No test depends on external services, network connectivity, or hardcoded ports
+6. Tests complete within a reasonable time (< 5 seconds total) since they use localhost connections only

--- a/.claude/specs/issue-15/write-unit-tests-for-config-loading.md
+++ b/.claude/specs/issue-15/write-unit-tests-for-config-loading.md
@@ -1,0 +1,148 @@
+# Spec: Write unit tests for config loading
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+Create a comprehensive unit test suite for the orchestrator config module (`crates/orchestrator/src/config.rs`), validating both the YAML file-based and environment variable-based configuration loading paths. This ensures the config layer is reliable before other components (like `Orchestrator::from_config`) depend on it.
+
+## Current State
+
+### Config module (not yet implemented — blocked by "Define registry config format and loader")
+
+Per the task breakdown, `crates/orchestrator/src/config.rs` will define:
+
+```rust
+#[derive(Deserialize)]
+pub struct OrchestratorConfig {
+    pub agents: Vec<AgentConfig>,
+}
+
+#[derive(Deserialize)]
+pub struct AgentConfig {
+    pub name: String,
+    pub description: String,
+    pub url: String,
+}
+```
+
+With two loading methods:
+- `OrchestratorConfig::from_file(path: &str) -> Result<Self, OrchestratorError>` — reads and parses a YAML file.
+- `OrchestratorConfig::from_env() -> Result<Self, OrchestratorError>` — reads `AGENT_ENDPOINTS` env var (format: `name=url,name2=url2`) and optional `AGENT_DESCRIPTIONS` env var.
+
+### Env-testing pattern (from `crates/agent-runtime/src/config.rs`)
+
+The project uses a `Mutex`-based pattern to serialize tests that modify environment variables:
+
+- A static `ENV_LOCK: Mutex<()>` ensures mutual exclusion.
+- A helper `with_env_vars(vars: &[(&str, Option<&str>)], f: F)` saves original values, sets/removes vars, runs the closure, then restores originals.
+- Each call to `env::set_var` / `env::remove_var` is wrapped in `unsafe {}` with a comment explaining serialization via the lock.
+
+### Test conventions in the project
+
+- Integration test files live under `crates/<crate>/tests/<name>_test.rs`.
+- Tests import from the crate's public API (e.g., `use orchestrator::config::{OrchestratorConfig, AgentConfig};`).
+- Each `#[test]` function has a descriptive snake_case name indicating the scenario.
+- Assertions use `assert_eq!` for value comparisons and pattern-matching for error variant checks.
+- No external test framework (no `rstest`, `proptest`, etc.) — only `#[test]` and standard library assertions.
+
+## Requirements
+
+1. **YAML config parses correctly with multiple agents** — Construct a valid YAML string with 2+ agents, write it to a temp file (using `std::fs::write` + `tempfile` or a hardcoded path in a temp dir), call `OrchestratorConfig::from_file()`, and assert the returned `OrchestratorConfig` contains the expected `AgentConfig` entries with correct `name`, `description`, and `url` fields.
+
+2. **Empty agents list is valid** — Parse a YAML string with `agents: []`, verify it succeeds and returns an `OrchestratorConfig` with an empty `agents` vec. This confirms the config layer does not impose a minimum agent count.
+
+3. **Malformed YAML returns appropriate error** — Pass invalid YAML content (e.g., `"agents: [[[broken"`) to the config parser and assert the result is an error. Verify the error is the expected variant (likely mapping to an `OrchestratorError` variant that wraps the parse failure reason).
+
+4. **Env-based config parses `AGENT_ENDPOINTS` format correctly** — Use the `with_env_vars` helper to set `AGENT_ENDPOINTS=agent1=http://localhost:8001,agent2=http://localhost:8002` and optionally `AGENT_DESCRIPTIONS=agent1=First agent,agent2=Second agent`. Call `OrchestratorConfig::from_env()` and assert the result contains the correct agent configs.
+
+5. **Missing `AGENT_ENDPOINTS` env var returns error** — Use `with_env_vars` to ensure `AGENT_ENDPOINTS` is unset, call `from_env()`, and assert it returns an error (the env-based path requires at least the endpoints variable).
+
+6. **Env mutex serialization** — All env-modifying tests must use the `with_env_vars` helper and `ENV_LOCK` mutex to prevent test interference, following the exact pattern from `crates/agent-runtime/src/config.rs`.
+
+## Implementation Details
+
+### File to create
+- **`crates/orchestrator/tests/config_test.rs`** — The sole deliverable. Contains all config-loading tests.
+
+### Structure of the test file
+
+```
+// Imports: orchestrator config types, std::env, std::sync::Mutex, std::io::Write, tempfile or std::fs
+
+// ENV_LOCK: static Mutex<()> for serializing env-modifying tests
+
+// with_env_vars helper (copied/adapted from agent-runtime pattern)
+
+// --- YAML tests (no env interaction, no mutex needed) ---
+// fn yaml_config_parses_multiple_agents()
+// fn yaml_config_empty_agents_list_is_valid()
+// fn yaml_config_malformed_returns_error()
+
+// --- Env tests (all use with_env_vars + ENV_LOCK) ---
+// fn env_config_parses_agent_endpoints()
+// fn env_config_missing_agent_endpoints_returns_error()
+```
+
+### Key types/interfaces to use
+- `orchestrator::config::OrchestratorConfig` — the main config struct
+- `orchestrator::config::AgentConfig` — individual agent entry
+- `orchestrator::error::OrchestratorError` — error type returned by config loading methods
+- `OrchestratorConfig::from_file(path)` — YAML file loading
+- `OrchestratorConfig::from_env()` — env var loading
+
+### Temp file handling for YAML tests
+- Use `std::env::temp_dir()` to get a temp directory, write YAML content to a unique file (e.g., using a UUID or test-specific name in the path), call `from_file()` with that path, then clean up with `std::fs::remove_file()`. Alternatively, if `tempfile` is available as a dev-dependency, use `NamedTempFile`.
+- If neither is suitable, the config module may also expose a `from_yaml_str()` or similar method that can be tested without file I/O. The spec should prefer testing through the public API (`from_file`), but the implementation task may choose to expose a string-parsing helper for testability.
+
+### YAML content for tests
+
+Multiple agents:
+```yaml
+agents:
+  - name: summarizer
+    description: Summarizes text
+    url: http://localhost:8001
+  - name: translator
+    description: Translates text
+    url: http://localhost:8002
+```
+
+Empty list:
+```yaml
+agents: []
+```
+
+Malformed:
+```yaml
+agents: [[[not valid yaml
+```
+
+### Env var format
+
+The `AGENT_ENDPOINTS` format follows the `TOOL_ENDPOINTS` pattern from `crates/agent-runtime/src/main.rs` lines 86-112:
+- Comma-separated pairs: `name=url,name2=url2`
+- Each pair split on `=` into name and URL
+- Whitespace around entries is trimmed
+- Empty entries between commas are skipped
+
+The `AGENT_DESCRIPTIONS` env var (optional) follows the same format: `name=description,name2=description2`.
+
+## Dependencies
+- **Blocked by:** "Define registry config format and loader" — the config module (`crates/orchestrator/src/config.rs`) must exist with `OrchestratorConfig`, `AgentConfig`, `from_file()`, and `from_env()` before tests can be written against them.
+- **Blocking:** Nothing — this is a leaf task.
+
+## Risks & Edge Cases
+
+- **Config API not yet finalized:** The exact method signatures and error types for `from_file` and `from_env` are specified in the task breakdown but may evolve during implementation. The test file must be written against the actual public API of the config module once it exists. If `from_file` takes a `&Path` instead of `&str`, or returns a different error type, tests must adapt.
+- **`tempfile` crate availability:** The project avoids unnecessary dependencies. YAML tests that need temp files should use `std::fs` + `std::env::temp_dir()` rather than adding a `tempfile` dev-dependency. Use a unique subdirectory or filename to avoid collisions with parallel test runs.
+- **Env var pollution between tests:** The `with_env_vars` helper must restore original values even if the test closure panics. The current pattern in `agent-runtime` does NOT use `catch_unwind` (it relies on the mutex preventing concurrent access). This is acceptable but means a panicking test could leave env vars dirty. This is a known minor risk, consistent with the existing codebase approach.
+- **`AGENT_DESCRIPTIONS` optionality:** The task breakdown says `AGENT_DESCRIPTIONS` is optional. Tests should verify that `from_env` works both with and without this variable set. When omitted, agents should get an empty or default description.
+- **Malformed `AGENT_ENDPOINTS` entries:** Consider edge cases like `name_only_no_equals`, `=url_without_name`, or an empty string. These may or may not be in scope for this test file depending on the config module's validation logic, but the spec should note them as potential additional tests.
+- **`unsafe` env operations:** The `env::set_var` and `env::remove_var` functions are `unsafe` in Rust 2024 edition (which this crate uses per `edition = "2024"` in Cargo.toml). Tests must wrap these calls in `unsafe {}` blocks with appropriate safety comments, matching the existing pattern.
+
+## Verification
+- `cargo test -p orchestrator --test config_test` passes with all tests green.
+- `cargo test` across the full workspace shows no regressions.
+- `cargo clippy -p orchestrator` reports no warnings in the test file.
+- Each of the 5 specified test scenarios has a corresponding `#[test]` function that exercises the stated behavior.
+- Env-modifying tests use the mutex-based `with_env_vars` pattern and do not interfere with each other or with other test files.

--- a/.claude/specs/issue-15/write-unit-tests-for-orchestrator-dispatch-and-routing.md
+++ b/.claude/specs/issue-15/write-unit-tests-for-orchestrator-dispatch-and-routing.md
@@ -1,0 +1,160 @@
+# Spec: Write unit tests for Orchestrator dispatch and routing
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+
+Create a comprehensive integration test suite (`crates/orchestrator/tests/orchestrator_test.rs`) that validates the `Orchestrator` struct's dispatch, routing, escalation, health aggregation, and `MicroAgent` trait implementation. These tests use mock HTTP servers (via `axum` + `tokio::net::TcpListener`) to simulate real downstream agents, verifying that the orchestrator correctly routes requests, handles failures, enforces escalation chain limits, and exposes itself as a `MicroAgent`.
+
+## Current State
+
+- **Orchestrator crate**: Currently a stub with only `src/main.rs` printing "Hello, world!". The task breakdown (issue-15) plans to convert it to a library crate with modules `agent_endpoint`, `error`, `orchestrator`, and `config`.
+- **Orchestrator types (planned, not yet implemented)**:
+  - `Orchestrator` struct with `registry: HashMap<String, AgentEndpoint>` and `manifest: SkillManifest`
+  - Methods: `new()`, `register()`, `route()`, `dispatch()`, `from_config()`
+  - `MicroAgent` trait implementation: `manifest()`, `invoke()` (delegates to `dispatch()`), `health()` (aggregates downstream health)
+  - `AgentEndpoint` struct: wraps `reqwest::Client`, calls downstream agents via HTTP (`POST /invoke`, `GET /health`)
+  - `OrchestratorError` enum: `NoRoute`, `AgentUnavailable`, `EscalationFailed`, `HttpError`
+- **Mock test pattern** (`crates/agent-runtime/tests/constraint_enforcer_test.rs`): Uses a `MockAgent` struct implementing `MicroAgent` with configurable `response_confidence`, `error_mode`, and `health_status`. Helper function `make_manifest_with_threshold()` builds a `SkillManifest` with specific constraint values. Each test constructs the mock, wraps it in the system under test, and asserts on the output.
+- **HTTP test pattern** (`crates/agent-runtime/tests/http_test.rs`): Uses `axum::Router` with `tower::ServiceExt::oneshot()` for in-process HTTP testing. Also uses `agent_runtime::http::build_router()` to create a real HTTP router from a `MockAgent`. Both patterns are available for this test file.
+- **Key SDK types**: `AgentRequest` has `id: Uuid`, `input: String`, `context: Option<Value>`, `caller: Option<String>`. `AgentResponse` has `id`, `output`, `confidence`, `escalated: bool`, `escalate_to: Option<String>`, `tool_calls`. `HealthStatus` is an enum: `Healthy`, `Degraded(String)`, `Unhealthy(String)`.
+- **Routing mechanism (planned)**: The orchestrator looks up agent by name from `request.context` (specifically a `"target_agent": "name"` field in the context JSON), falling back to substring matching of `request.input` against endpoint descriptions.
+
+## Requirements
+
+### Test Infrastructure
+- Stand up mock HTTP servers using `axum` routers bound to `TcpListener` on `127.0.0.1:0` (OS-assigned port), each simulating a downstream agent with configurable behavior (success, escalation, error, health status).
+- Each mock server must implement `POST /invoke` and `GET /health` endpoints matching the `agent-runtime` HTTP API contract (see `crates/agent-runtime/src/http.rs`).
+- Mock servers must be configurable per-test to return specific `AgentResponse` values (including `escalated: true` and `escalate_to: Some(...)`) and specific `HealthStatus` values.
+- Use `Arc<Mutex<...>>` or `Arc<AtomicBool>` for mock servers that need to track whether they were called (to verify routing correctness).
+
+### Test Cases
+
+1. **`dispatch_routes_to_correct_agent_based_on_context_target`**
+   - Register two agents ("agent-a" and "agent-b") pointing to two different mock HTTP servers.
+   - Create an `AgentRequest` with `context: Some(json!({"target_agent": "agent-b"}))`.
+   - Call `dispatch()` and assert the response came from agent-b's mock (use a distinguishing output value like `{"source": "agent-b"}`).
+   - Verify agent-a's mock was NOT called.
+
+2. **`dispatch_returns_no_route_when_no_agent_matches`**
+   - Register one agent named "agent-a".
+   - Create an `AgentRequest` with `context: Some(json!({"target_agent": "nonexistent-agent"}))`.
+   - Call `dispatch()` and assert it returns `Err(OrchestratorError::NoRoute { .. })`.
+   - Verify the error's `input` field contains the request input.
+
+3. **`dispatch_skips_unhealthy_agents`**
+   - Register two agents: "agent-a" (mock returns `Unhealthy`) and "agent-b" (mock returns `Healthy`).
+   - Create a request that could route to either (e.g., via description-based fallback routing, or test the specific behavior when the targeted agent is unhealthy).
+   - Call `dispatch()` targeting "agent-a" and assert it returns `Err(OrchestratorError::AgentUnavailable { .. })` with the agent name and health reason.
+   - Alternatively, if the orchestrator falls through to the next matching agent, assert the response came from agent-b.
+
+4. **`dispatch_handles_escalation`**
+   - Register two agents: "agent-primary" (mock returns `AgentResponse` with `escalated: true, escalate_to: Some("agent-fallback")`) and "agent-fallback" (mock returns a normal successful `AgentResponse`).
+   - Create a request targeting "agent-primary".
+   - Call `dispatch()` and assert the final response is from "agent-fallback" (the escalation target).
+   - Verify both mock servers were called (primary first, then fallback).
+
+5. **`dispatch_returns_escalation_failed_when_chain_exhausted`**
+   - Register agents that form a circular or terminal escalation chain: "agent-a" escalates to "agent-b", "agent-b" escalates to "agent-c", "agent-c" escalates to a nonexistent agent (or back to "agent-a" to test cycle detection).
+   - Call `dispatch()` targeting "agent-a".
+   - Assert it returns `Err(OrchestratorError::EscalationFailed { chain, reason })`.
+   - Assert the `chain` vector contains the names of all agents in the escalation path.
+   - Also test that the recursion/depth limit (5 levels per the implementation notes) is respected.
+
+6. **`register_adds_agents_that_can_be_dispatched_to`**
+   - Create an `Orchestrator` with an empty agent list.
+   - Call `register()` to add a new `AgentEndpoint`.
+   - Create a request targeting that agent by name.
+   - Call `dispatch()` and assert it succeeds, confirming the registered agent is reachable.
+
+7. **`health_returns_healthy_when_at_least_one_downstream_agent_is_healthy`**
+   - Register three agents: one `Healthy`, one `Degraded`, one `Unhealthy`.
+   - Call `health()` on the `Orchestrator` (via the `MicroAgent` trait).
+   - Assert it returns `HealthStatus::Healthy`.
+   - Also test the edge cases:
+     - All agents `Degraded` returns `Degraded`.
+     - All agents `Unhealthy` returns `Unhealthy`.
+     - Single healthy agent among many unhealthy returns `Healthy`.
+
+8. **`micro_agent_invoke_delegates_to_dispatch_and_converts_errors`**
+   - Cast the `Orchestrator` as `&dyn MicroAgent`.
+   - Call `invoke()` with a request that would produce `OrchestratorError::NoRoute`.
+   - Assert the result is `Err(AgentError::Internal(msg))` where `msg` contains the `NoRoute` error's display string.
+   - Call `invoke()` with a valid request and assert success.
+
+### Mock Server Design
+- Create a helper function `start_mock_agent(name, response, health_status) -> (String, JoinHandle)` that:
+  - Binds a `TcpListener` to `127.0.0.1:0`.
+  - Extracts the assigned port to build the base URL `http://127.0.0.1:{port}`.
+  - Spawns an `axum::serve()` task in the background.
+  - Returns the base URL (for constructing `AgentEndpoint`) and the join handle (for cleanup).
+- The mock server uses `Arc<dyn MicroAgent>` with a `MockAgent` struct (following the pattern from `constraint_enforcer_test.rs`) that returns the configured response/health.
+- Reuse `agent_runtime::http::build_router()` to build the mock server's router -- this ensures the mock exactly matches the real HTTP API contract. This requires `agent-runtime` as a dev-dependency.
+- Each test should shut down mock servers after completion (dropping the join handle or using `abort()`).
+
+## Implementation Details
+
+### Files to create
+- `crates/orchestrator/tests/orchestrator_test.rs` -- the test file containing all 8 test cases and mock infrastructure.
+
+### Files to modify
+- `crates/orchestrator/Cargo.toml` -- ensure dev-dependencies include: `tokio = { version = "1", features = ["macros", "rt-multi-thread"] }`, `axum = "0.8"`, `serde_json = "1"`, `agent-runtime = { path = "../agent-runtime" }` (dev-dependency only, for `build_router`), `agent-sdk = { path = "../agent-sdk" }`.
+
+### Key types and functions to add in the test file
+
+```rust
+// Mock agent for spawning HTTP servers
+struct MockAgent {
+    name: String,
+    manifest: SkillManifest,
+    response: AgentResponse,       // preconfigured response to return
+    health_status: HealthStatus,
+    invoked: Arc<AtomicBool>,      // tracks whether invoke was called
+}
+
+// Helper to build a SkillManifest with a given name
+fn make_manifest(name: &str) -> SkillManifest { ... }
+
+// Helper to build a mock AgentResponse with a distinguishing source marker
+fn make_response(request_id: Uuid, source: &str, escalated: bool, escalate_to: Option<String>) -> AgentResponse { ... }
+
+// Helper to start a mock HTTP server, returns (base_url, join_handle)
+async fn start_mock_agent(
+    name: &str,
+    response: AgentResponse,
+    health_status: HealthStatus,
+) -> (String, tokio::task::JoinHandle<()>, Arc<AtomicBool>) { ... }
+
+// Helper to build an AgentRequest with a target_agent context
+fn make_targeted_request(target: &str) -> AgentRequest { ... }
+```
+
+### Integration points
+- Imports from `orchestrator`: `Orchestrator`, `AgentEndpoint`, `OrchestratorError`
+- Imports from `agent-sdk`: `AgentRequest`, `AgentResponse`, `AgentError`, `HealthStatus`, `MicroAgent`, `SkillManifest`, `ModelConfig`, `Constraints`, `OutputSchema`, `async_trait`
+- Imports from `agent-runtime::http`: `build_router` (for mock servers)
+- The tests validate the contract between `Orchestrator` and `AgentEndpoint` over HTTP, ensuring the orchestrator correctly calls downstream agents and processes their responses.
+
+## Dependencies
+
+- **Blocked by**: "Implement MicroAgent for Orchestrator" -- the `Orchestrator` struct, `AgentEndpoint`, `OrchestratorError`, and `MicroAgent` impl must all exist before these tests can compile.
+- **Blocking**: None (non-blocking). This is a leaf task in the dependency graph.
+
+## Risks & Edge Cases
+
+- **Port conflicts**: Using `127.0.0.1:0` for OS-assigned ports eliminates port conflicts. Tests must extract the actual port from the bound listener before spawning the server.
+- **Test isolation**: Each test spawns its own mock servers and orchestrator instance. No shared mutable state between tests. Tests can run in parallel.
+- **Mock server lifecycle**: Background `tokio::spawn` tasks must be aborted after each test to prevent resource leaks. Use `JoinHandle::abort()` in cleanup or rely on the tokio runtime dropping tasks at the end of each `#[tokio::test]`.
+- **Circular escalation**: The escalation chain test (test 5) must verify that the recursion limit prevents infinite loops. If agents A -> B -> A, the orchestrator should detect the cycle or hit the depth limit (5) and return `EscalationFailed`.
+- **Race conditions in health checks**: The orchestrator checks agent health before dispatching. If a mock server is slow to start, the health check might fail. Mitigate by awaiting the `TcpListener::bind()` and only returning the URL after the server is ready.
+- **`agent-runtime` as dev-dependency**: Adding `agent-runtime` as a dev-dependency of `orchestrator` is safe because dev-dependencies do not affect the production dependency graph. This avoids the circular dependency concern mentioned in the implementation notes (the production dependency is `orchestrator -> agent-sdk`, not `orchestrator -> agent-runtime`).
+- **Escalation target not registered**: Test 5 should cover the case where `escalate_to` names an agent that does not exist in the registry, which should produce `EscalationFailed` rather than a panic.
+- **Empty registry**: Ensure `dispatch()` on an orchestrator with no registered agents returns `NoRoute`, not a panic.
+
+## Verification
+
+- `cargo check -p orchestrator` compiles the crate and test file without errors.
+- `cargo test -p orchestrator --test orchestrator_test` runs all 8 tests and they pass.
+- `cargo clippy -p orchestrator` reports no warnings in the test file.
+- `cargo test` (workspace-wide) shows no regressions in other crates.
+- Each test assertion is specific and tests exactly one behavior (no multi-purpose tests that could mask failures).

--- a/.claude/specs/issue-15/write-unit-tests-for-orchestrator-error.md
+++ b/.claude/specs/issue-15/write-unit-tests-for-orchestrator-error.md
@@ -1,0 +1,143 @@
+# Spec: Write unit tests for OrchestratorError
+
+> From: .claude/tasks/issue-15.md
+
+## Objective
+
+Create an integration test file `crates/orchestrator/tests/error_test.rs` that validates the `OrchestratorError` enum's `Display` implementation for all four variants and its `From<OrchestratorError> for AgentError` conversion. This ensures the error type produces correct human-readable messages and integrates properly with the SDK's `AgentError::Internal` boundary, which is the mechanism by which orchestrator errors flow through `MicroAgent::invoke()`.
+
+## Current State
+
+**`crates/agent-sdk/src/agent_error.rs`** -- Defines `AgentError` with five variants, including `Internal(String)`, which is the target of the `From<OrchestratorError>` conversion. Implements manual `Display` and `std::error::Error`. Derives `Debug, Clone, PartialEq, Serialize, Deserialize`.
+
+**`crates/agent-sdk/tests/envelope_types_test.rs`** -- The primary test pattern to follow. Key conventions:
+- One `#[test]` function per logical concern, using descriptive snake_case names (e.g., `agent_error_display_contains_expected_substrings`).
+- Tests `Display` output by calling `format!("{}", error)` and asserting on substrings with `assert!(display.contains(...), "expected '...' in: {display}")`, using the custom failure message pattern to show what was actually produced.
+- Tests error equality using `assert_eq!` and `assert_ne!` on the type directly.
+- No test framework beyond `#[test]`; no `tokio::test`; no external test utilities.
+
+**`crates/agent-runtime/src/provider.rs` (inline `#[cfg(test)]` block)** -- The secondary test pattern. Key conventions:
+- Tests `Display` using both exact `assert_eq!(err.to_string(), "...")` for simple variants and `assert!(msg.contains(...))` for compound variants.
+- Tests each variant in its own `#[test]` function rather than grouping all variants into one test.
+- Uses `matches!(err, ProviderError::MissingApiKey { .. })` for variant matching.
+
+**`crates/orchestrator/src/error.rs`** -- Does not yet exist. Per the "Define OrchestratorError enum" spec, it will contain:
+- `OrchestratorError` enum with four variants: `NoRoute { input }`, `AgentUnavailable { name, reason }`, `EscalationFailed { chain, reason }`, `HttpError { url, reason }`
+- Derives `Debug, Clone` (no `PartialEq`)
+- Manual `Display` with these format strings:
+  - `NoRoute` -> `"No route found for input: {input}"`
+  - `AgentUnavailable` -> `"Agent '{name}' unavailable: {reason}"`
+  - `EscalationFailed` -> `"Escalation failed through chain [{chain joined by " -> "}]: {reason}"`
+  - `HttpError` -> `"HTTP error calling {url}: {reason}"`
+- `impl std::error::Error for OrchestratorError {}` (empty)
+- `impl From<OrchestratorError> for AgentError` converting to `AgentError::Internal(err.to_string())`
+
+**`crates/orchestrator/tests/`** -- Directory does not yet exist.
+
+## Requirements
+
+1. Create `crates/orchestrator/tests/error_test.rs` as an integration test file.
+
+2. Test `Display` output for all four `OrchestratorError` variants:
+   - `NoRoute { input }` -- verify the display string contains the input value and matches the expected format.
+   - `AgentUnavailable { name, reason }` -- verify the display string contains both the agent name and the reason.
+   - `EscalationFailed { chain, reason }` -- verify the display string contains the chain elements joined by `" -> "` and the reason.
+   - `HttpError { url, reason }` -- verify the display string contains both the URL and the reason.
+
+3. Test `From<OrchestratorError> for AgentError` conversion:
+   - For each of the four variants, construct the `OrchestratorError`, convert it to `AgentError` using `.into()`, and verify the result is `AgentError::Internal(String)` where the inner string matches the `Display` output of the original error.
+
+4. Test `EscalationFailed` with edge cases:
+   - Empty chain (`chain: vec![]`) -- display should handle gracefully.
+   - Single-element chain -- no `" -> "` separator.
+   - Multi-element chain -- elements joined by `" -> "`.
+
+5. Verify `OrchestratorError` implements `std::error::Error` (compile-time check via a generic function that accepts `T: std::error::Error`).
+
+6. Follow the test naming convention from the reference files: `{type_under_test}_{behavior_being_tested}` in snake_case (e.g., `orchestrator_error_no_route_display`, `orchestrator_error_converts_to_agent_error_internal`).
+
+7. Use `assert_eq!` for exact display string matching where the format is fully specified, and `assert!(contains)` with custom failure messages for substring checks where exactness is secondary to content verification.
+
+8. Do not use `assert_eq!` directly on `OrchestratorError` values -- the type does not derive `PartialEq`. Use `matches!()` for variant matching and check fields individually.
+
+## Implementation Details
+
+### File to create
+
+**`crates/orchestrator/tests/error_test.rs`**
+
+Imports:
+- `use agent_sdk::AgentError;`
+- `use orchestrator::error::OrchestratorError;`
+
+Test functions (one per test, following the `provider.rs` pattern of separate functions per variant):
+
+1. **`no_route_display_contains_input`** -- Construct `OrchestratorError::NoRoute { input: "analyze quarterly report".into() }`, call `to_string()`, assert the output equals `"No route found for input: analyze quarterly report"`.
+
+2. **`agent_unavailable_display_contains_name_and_reason`** -- Construct `OrchestratorError::AgentUnavailable { name: "summarizer".into(), reason: "connection refused".into() }`, call `to_string()`, assert the output contains `"summarizer"` and `"connection refused"`. Can also use `assert_eq!` for the exact string `"Agent 'summarizer' unavailable: connection refused"`.
+
+3. **`escalation_failed_display_contains_chain_and_reason`** -- Construct with `chain: vec!["agent-a".into(), "agent-b".into(), "agent-c".into()], reason: "all agents exhausted".into()`, assert the display output contains `"agent-a -> agent-b -> agent-c"` and `"all agents exhausted"`.
+
+4. **`escalation_failed_display_with_single_agent_chain`** -- Construct with `chain: vec!["solo-agent".into()], reason: "declined".into()`, assert display contains `"solo-agent"` without any `" -> "` separator.
+
+5. **`escalation_failed_display_with_empty_chain`** -- Construct with `chain: vec![], reason: "no agents configured".into()`, assert display handles it gracefully (the `[]` in the output will be empty, resulting in `"Escalation failed through chain []: no agents configured"`).
+
+6. **`http_error_display_contains_url_and_reason`** -- Construct `OrchestratorError::HttpError { url: "http://localhost:8080/invoke".into(), reason: "timeout".into() }`, assert the output equals `"HTTP error calling http://localhost:8080/invoke: timeout"`.
+
+7. **`no_route_converts_to_agent_error_internal`** -- Construct `NoRoute`, convert via `let agent_err: AgentError = err.into();`, use `matches!(agent_err, AgentError::Internal(ref msg) if msg.contains("No route"))` or destructure and assert the inner string equals `err_display`.
+
+8. **`agent_unavailable_converts_to_agent_error_internal`** -- Same pattern for `AgentUnavailable`.
+
+9. **`escalation_failed_converts_to_agent_error_internal`** -- Same pattern for `EscalationFailed`.
+
+10. **`http_error_converts_to_agent_error_internal`** -- Same pattern for `HttpError`.
+
+11. **`orchestrator_error_implements_std_error`** -- A compile-time verification function:
+    ```rust
+    fn assert_is_std_error<T: std::error::Error>(_: &T) {}
+    ```
+    Call it with each variant to confirm the `Error` trait is implemented. This test passes if it compiles.
+
+### Key patterns from reference files
+
+From `envelope_types_test.rs`:
+```rust
+let display = format!("{}", tool_call_failed);
+assert!(display.contains("web_search"), "expected 'web_search' in: {display}");
+```
+
+From `provider.rs` tests:
+```rust
+let err = ProviderError::UnsupportedProvider { provider: "cohere".to_string() };
+assert_eq!(err.to_string(), "unsupported provider: cohere");
+```
+
+The test file should use a blend of both: `assert_eq!` for variants with a simple, fully predictable format, and `assert!(contains)` with custom messages for variants where testing key substrings is more robust (particularly `EscalationFailed` with its chain joining logic).
+
+### Integration points
+
+- The test file is an integration test (in `tests/` directory), so it imports `orchestrator::error::OrchestratorError` and `agent_sdk::AgentError` as external crate paths.
+- Requires the `orchestrator` crate to be a library crate (depends on the "Convert orchestrator from binary to library crate" task being complete).
+- Requires the `orchestrator` Cargo.toml to have `agent-sdk` as a dependency (depends on the "Update orchestrator Cargo.toml with dependencies" task).
+- The `orchestrator` Cargo.toml does NOT need a dev-dependency on `agent-sdk` because `agent-sdk` is already a regular dependency -- integration tests can use it directly.
+
+## Dependencies
+
+- **Blocked by**: "Define OrchestratorError enum" (the type under test must exist), which itself is blocked by "Convert orchestrator from binary to library crate" and "Update orchestrator Cargo.toml with dependencies"
+- **Blocking**: Nothing -- this is a leaf task in the dependency graph
+
+## Risks & Edge Cases
+
+- **No `PartialEq` on `OrchestratorError`**: Per the error enum spec, `OrchestratorError` does not derive `PartialEq`, so tests cannot use `assert_eq!` on error values directly. Tests must use `matches!()` for variant matching and check individual fields or use `Display` output comparison. The `AgentError` type does derive `PartialEq`, so `assert_eq!` can be used on the converted `AgentError` value directly.
+- **Display format coupling**: Tests that use `assert_eq!` on exact display strings are coupled to the format strings in `error.rs`. If the format changes, these tests must be updated. This is intentional -- the tests exist specifically to lock down the display format.
+- **EscalationFailed chain join format**: The `" -> "` join format for the chain vector is a specific behavior that must be tested. Edge cases (empty vec, single element) should be covered to prevent panics or unexpected output.
+- **Integration test vs inline test**: The task specifies an integration test file (`tests/error_test.rs`) rather than inline `#[cfg(test)]` tests. This is the correct choice since it tests the public API surface of the `error` module as external consumers would use it.
+
+## Verification
+
+1. `cargo test -p orchestrator --test error_test` runs all tests and they pass.
+2. `cargo clippy -p orchestrator --tests` produces no warnings on the test file.
+3. All four `Display` variant outputs are covered by at least one test.
+4. All four `From<OrchestratorError> for AgentError` conversions are covered by at least one test.
+5. The `EscalationFailed` chain edge cases (empty, single, multi) are each covered.
+6. `cargo test` across the full workspace still passes (no regressions).

--- a/.claude/specs/issue-16/add-embedding-error-variant-to-orchestrator-error.md
+++ b/.claude/specs/issue-16/add-embedding-error-variant-to-orchestrator-error.md
@@ -1,0 +1,83 @@
+# Spec: Add `EmbeddingError` variant to `OrchestratorError`
+
+> From: .claude/tasks/issue-16.md
+
+## Objective
+
+Add an `EmbeddingError { reason: String }` variant to the `OrchestratorError` enum so that the upcoming `SemanticRouter` can propagate embedding-related failures (network timeouts, provider API errors, malformed responses, etc.) through the orchestrator's existing error hierarchy. Without this variant, the semantic router would have no type-safe way to surface embedding failures to callers.
+
+## Current State
+
+`crates/orchestrator/src/error.rs` defines `OrchestratorError` as a `#[derive(Debug, Clone)]` enum with five variants:
+
+- `NoRoute { input: String }` -- no agent matched the request
+- `AgentUnavailable { name: String, reason: String }` -- agent exists but is unhealthy
+- `EscalationFailed { chain: Vec<String>, reason: String }` -- escalation chain broke
+- `HttpError { url: String, reason: String }` -- downstream HTTP call failed
+- `Config { reason: String }` -- configuration problem
+
+Each variant uses owned `String` fields (no lifetimes, no generic parameters). The enum implements:
+- `fmt::Display` with a `match` arm per variant
+- `std::error::Error` (empty impl, relying on `Display`)
+- `From<OrchestratorError> for AgentError` converting to `AgentError::Internal(err.to_string())`
+
+The `Clone` derive is significant: any new variant must also be `Clone`-compatible, which rules out storing rig-core's `EmbeddingError` directly (it contains `reqwest::Error` which is not `Clone`). The task description specifies `reason: String` which satisfies this constraint by stringifying the upstream error.
+
+## Requirements
+
+1. Add variant `EmbeddingError { reason: String }` to the `OrchestratorError` enum.
+2. Add a corresponding arm to the `Display` impl that formats as `"Embedding error: {reason}"`.
+3. The enum must continue to derive `Debug` and `Clone` without issue (the `String` field guarantees this).
+4. The existing `impl std::error::Error for OrchestratorError` and `impl From<OrchestratorError> for AgentError` require no changes -- they work automatically with the new variant via `Display`.
+5. No new dependencies or imports are needed in `error.rs` for this change.
+6. The crate must compile, pass clippy, and pass all existing tests after the change.
+
+## Implementation Details
+
+**File to modify:** `crates/orchestrator/src/error.rs`
+
+**Change 1 -- Add the variant to the enum:**
+
+Insert `EmbeddingError { reason: String }` as the last variant in the `OrchestratorError` enum (after `Config`). Placement after the existing variants preserves logical grouping: the first three variants are routing/agent lifecycle errors, `HttpError` and `Config` are infrastructure errors, and `EmbeddingError` is also infrastructure-level.
+
+**Change 2 -- Add the Display arm:**
+
+Add a match arm in the `Display` impl:
+
+```rust
+OrchestratorError::EmbeddingError { reason } => {
+    write!(f, "Embedding error: {}", reason)
+}
+```
+
+Place it after the `Config` arm to mirror the variant declaration order.
+
+**No other files need modification** for this task. The `SemanticRouter` (a later task) will create `OrchestratorError::EmbeddingError` instances by converting rig-core's embedding errors into `reason: String` at the call site, e.g.:
+
+```rust
+model.embed_text(text).await.map_err(|e| OrchestratorError::EmbeddingError {
+    reason: e.to_string(),
+})?;
+```
+
+## Dependencies
+
+- **Blocked by:** Nothing (Group 1 task, can be done in parallel with other Group 1 tasks)
+- **Blocking:** "Implement `SemanticRouter` struct with two-phase routing" (Group 2) -- the SemanticRouter will return `OrchestratorError::EmbeddingError` when embedding calls fail
+
+## Risks & Edge Cases
+
+- **Non-exhaustive match in downstream code:** Any existing code that matches on `OrchestratorError` with explicit variant arms (without a wildcard `_`) will fail to compile after adding this variant. A search of the codebase confirms there are no such external matches -- all pattern matches on `OrchestratorError` are in `error.rs` itself (the `Display` impl), and the `From<OrchestratorError> for AgentError` impl uses `.to_string()` which delegates to `Display`. No breakage expected.
+- **Clone constraint:** rig-core's `EmbeddingError` wraps `reqwest::Error` which is not `Clone`. By using `reason: String` instead of storing the upstream error directly, we preserve the `Clone` derive. The tradeoff is loss of the original error chain for programmatic inspection, but this is acceptable since the orchestrator's error-handling pattern already stringifies errors at the boundary (see the `From<OrchestratorError> for AgentError` impl).
+- **Display format consistency:** The format `"Embedding error: {reason}"` follows the same pattern as `"Config error: {reason}"` and `"HTTP error calling {url}: {reason}"`, keeping user-facing messages consistent.
+
+## Verification
+
+1. Run `cargo check -p orchestrator` -- must succeed with no errors.
+2. Run `cargo clippy -p orchestrator` -- must produce no new warnings.
+3. Run `cargo test -p orchestrator` -- all existing tests must continue to pass.
+4. Manually inspect `error.rs` and confirm:
+   - The new variant is present in the enum with field `reason: String`.
+   - The `Display` impl has a matching arm.
+   - The `#[derive(Debug, Clone)]` still compiles (trivially true with `String` field).
+   - The `impl std::error::Error` and `impl From<OrchestratorError> for AgentError` require no changes.

--- a/.claude/specs/issue-16/add-embedding-model-configuration-to-orchestrator-config.md
+++ b/.claude/specs/issue-16/add-embedding-model-configuration-to-orchestrator-config.md
@@ -1,0 +1,136 @@
+# Spec: Add embedding model configuration to `OrchestratorConfig`
+
+> From: .claude/tasks/issue-16.md
+
+## Objective
+
+Extend `OrchestratorConfig` with optional embedding model settings so the orchestrator can be configured to use semantic routing. When these fields are absent, the orchestrator falls back to exact-match-only routing (no semantic fallback). This provides the configuration plumbing that `Orchestrator::from_config()` will use to decide whether to construct a `SemanticRouter`.
+
+## Current State
+
+`OrchestratorConfig` in `crates/orchestrator/src/config.rs` currently has a single field:
+
+```rust
+pub struct OrchestratorConfig {
+    pub agents: Vec<AgentConfig>,
+}
+```
+
+It supports two construction paths:
+- `from_file(path)` -- deserializes from a YAML file via `serde_yaml`.
+- `from_env()` -- reads `AGENT_ENDPOINTS` (required) and `AGENT_DESCRIPTIONS` (optional) environment variables, parsing comma-separated `key=value` pairs.
+
+Both `OrchestratorConfig` and `AgentConfig` derive `Debug`, `Clone`, and `Deserialize`.
+
+The existing test file (`crates/orchestrator/tests/config_test.rs`) covers YAML parsing, empty agents, malformed YAML, env-based parsing, and missing required env vars. Tests that modify env vars use a shared `ENV_LOCK` mutex and a `with_env_vars` helper for safe setup/teardown.
+
+## Requirements
+
+- Add three new optional fields to `OrchestratorConfig`:
+  - `embedding_provider: Option<String>` -- embedding service provider identifier (e.g., `"openai"`).
+  - `embedding_model: Option<String>` -- specific model name (e.g., `"text-embedding-3-small"`).
+  - `similarity_threshold: Option<f64>` -- cosine similarity threshold for semantic routing; defaults to `0.7` when semantic routing is used but no threshold is explicitly configured.
+- All three fields must be optional. Omitting them is not an error; it means semantic routing is disabled.
+- `from_env()` must read these from environment variables: `EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`, and `SIMILARITY_THRESHOLD`.
+- `from_file()` must deserialize these from YAML (serde handles this automatically given correct field names and `Option` types).
+- `SIMILARITY_THRESHOLD` must be parsed as `f64`. An invalid (non-numeric) value must return `OrchestratorError::Config` with a descriptive reason.
+- Existing behavior must be fully preserved: all current tests must continue to pass without modification. YAML files and env configurations that omit the new fields must parse successfully with `None` values.
+- The `similarity_threshold` field stores the raw `Option<f64>` from configuration. The default of `0.7` is applied downstream by the consumer (e.g., `Orchestrator::from_config()`), not inside `OrchestratorConfig` itself. This keeps the config struct a faithful representation of what the user provided.
+
+## Implementation Details
+
+### File to modify: `crates/orchestrator/src/config.rs`
+
+**Struct changes:**
+
+Add three fields to `OrchestratorConfig`. Use `#[serde(default)]` on each new field so that YAML files without these keys deserialize correctly (serde defaults `Option<T>` to `None`, but the explicit attribute makes the intent clear and guards against future refactors):
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+pub struct OrchestratorConfig {
+    pub agents: Vec<AgentConfig>,
+    #[serde(default)]
+    pub embedding_provider: Option<String>,
+    #[serde(default)]
+    pub embedding_model: Option<String>,
+    #[serde(default)]
+    pub similarity_threshold: Option<f64>,
+}
+```
+
+**`from_env()` changes:**
+
+After the existing agent-building logic and before the final `Ok(OrchestratorConfig { agents })`, read the three new environment variables:
+
+1. `EMBEDDING_PROVIDER` -- read via `std::env::var`. If the var is missing or empty, set to `None`. Otherwise `Some(value.trim().to_string())`.
+2. `EMBEDDING_MODEL` -- same approach as `EMBEDDING_PROVIDER`.
+3. `SIMILARITY_THRESHOLD` -- read via `std::env::var`. If missing or empty, set to `None`. If present, parse with `value.trim().parse::<f64>()`. On parse failure, return `OrchestratorError::Config { reason: "SIMILARITY_THRESHOLD must be a valid floating-point number, got '...'" }`.
+
+Add a helper function to keep `from_env()` clean:
+
+```rust
+fn read_optional_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .map(|v| v.trim().to_string())
+}
+```
+
+And a parsing helper for the threshold:
+
+```rust
+fn parse_optional_f64_env(name: &str) -> Result<Option<f64>, OrchestratorError> {
+    match read_optional_env(name) {
+        None => Ok(None),
+        Some(val) => val.parse::<f64>().map(Some).map_err(|_| OrchestratorError::Config {
+            reason: format!("{name} must be a valid floating-point number, got '{val}'"),
+        }),
+    }
+}
+```
+
+Update the return statement in `from_env()`:
+
+```rust
+Ok(OrchestratorConfig {
+    agents,
+    embedding_provider: read_optional_env("EMBEDDING_PROVIDER"),
+    embedding_model: read_optional_env("EMBEDDING_MODEL"),
+    similarity_threshold: parse_optional_f64_env("SIMILARITY_THRESHOLD")?,
+})
+```
+
+**No changes needed to `from_file()`** -- serde_yaml handles the new `Option` fields automatically (absent keys become `None`).
+
+### Integration points
+
+- `Orchestrator::from_config()` (in `crates/orchestrator/src/orchestrator.rs`, modified by the "Integrate `SemanticRouter` into `Orchestrator`" task) will read these fields to decide whether to construct a `SemanticRouter`. If `embedding_provider` is `Some`, it will initialize the embedding model and build the router; otherwise, semantic routing is skipped.
+- The `similarity_threshold` value (or its `0.7` default) will be passed to `SemanticRouter::new()`.
+
+## Dependencies
+
+- Blocked by: "Implement `SemanticRouter` struct with two-phase routing" (the config fields are designed to match the `SemanticRouter` constructor API)
+- Blocking: "Write integration tests for semantic routing in `Orchestrator`", "Write unit tests for config embedding fields"
+
+## Risks & Edge Cases
+
+- **Whitespace-only env values**: `EMBEDDING_PROVIDER="  "` should be treated as unset (`None`), not as `Some("  ")`. The `read_optional_env` helper handles this by trimming and filtering empty strings.
+- **Threshold out of range**: A `SIMILARITY_THRESHOLD` of `-1.0` or `5.0` is technically a valid `f64` and will parse successfully. Range validation is the responsibility of the consumer (`SemanticRouter` or `Orchestrator::from_config()`), not the config parser, since the config layer should be a faithful representation of user input.
+- **YAML type coercion**: In YAML, `similarity_threshold: 0.7` deserializes as `f64` natively. However, `similarity_threshold: "0.7"` (quoted string) will fail serde deserialization. This is acceptable and consistent with YAML conventions.
+- **Partial configuration**: Setting `EMBEDDING_MODEL` without `EMBEDDING_PROVIDER` is allowed at the config level (both are independently optional). Validation of logical consistency (e.g., "model requires provider") belongs in the consumer, not in config parsing.
+- **Backward compatibility**: All existing YAML configs and env-based configs will continue to work because the new fields are `Option` with `#[serde(default)]`. No existing tests need modification.
+
+## Verification
+
+- `cargo check -p orchestrator` compiles without errors or warnings.
+- `cargo clippy -p orchestrator` passes with no warnings.
+- `cargo test -p orchestrator` passes -- all existing tests continue to pass unchanged.
+- The following behaviors are verified by the "Write unit tests for config embedding fields" task:
+  1. YAML with all three embedding fields parses correctly, values are `Some(...)`.
+  2. YAML without any embedding fields parses correctly, values are all `None`.
+  3. `from_env()` reads `EMBEDDING_PROVIDER` and `EMBEDDING_MODEL` as `Option<String>`.
+  4. `from_env()` parses `SIMILARITY_THRESHOLD` as `Option<f64>`.
+  5. `from_env()` with invalid `SIMILARITY_THRESHOLD` (e.g., `"notanumber"`) returns `OrchestratorError::Config`.
+  6. `from_env()` with missing embedding env vars produces `None` values (not errors).
+  7. `from_env()` with whitespace-only embedding env vars produces `None` values.

--- a/.claude/specs/issue-16/add-rig-core-dependency-to-orchestrator-cargo-toml.md
+++ b/.claude/specs/issue-16/add-rig-core-dependency-to-orchestrator-cargo-toml.md
@@ -1,0 +1,74 @@
+# Spec: Add `rig-core` dependency to orchestrator `Cargo.toml`
+
+> From: .claude/tasks/issue-16.md
+
+## Objective
+
+Add `rig-core`, `tracing`, and `tokio` (dev) dependencies to the orchestrator crate so that the upcoming `SemanticRouter` implementation can use rig-core's embedding types (`EmbeddingModel` trait, `Embedding` struct, `VectorDistance` trait, `EmbeddingError`) and structured logging via `tracing`. None of these crates are new to the workspace dependency tree -- they are already pulled in by `agent-runtime` and present in the lockfile.
+
+## Current State
+
+`crates/orchestrator/Cargo.toml` currently has the following dependencies:
+
+**[dependencies]:**
+- `agent-sdk` (path dep)
+- `async-trait = "0.1"`
+- `futures = "0.3"`
+- `reqwest = { version = "0.13", features = ["json"] }`
+- `serde = { version = "1", features = ["derive"] }`
+- `serde_json = "1"`
+- `serde_yaml = "0.9"`
+
+**[dev-dependencies]:**
+- `tokio = { version = "1", features = ["macros", "rt", "net"] }`
+- `axum = "0.8"`
+- `uuid = { version = "1", features = ["v4"] }`
+
+The `agent-runtime` crate already depends on `rig-core = { version = "0.32", features = ["rmcp"] }` and `tracing = "0.1"`. The workspace `Cargo.toml` does not use `[workspace.dependencies]` -- each crate specifies its own dependency versions directly.
+
+## Requirements
+
+1. Add `rig-core = { version = "0.32" }` to `[dependencies]` in `crates/orchestrator/Cargo.toml`. No extra features are needed (the orchestrator does not need the `rmcp` feature that `agent-runtime` uses).
+2. Add `tracing = "0.1"` to `[dependencies]` in `crates/orchestrator/Cargo.toml`.
+3. The existing `[dev-dependencies]` entry for `tokio` already has `features = ["macros", "rt", "net"]` which is a superset of the requirement (`["macros", "rt"]`). No change is needed for tokio.
+4. No new crates should appear in `Cargo.lock` -- verify that `cargo check -p orchestrator` resolves without downloading new crate sources.
+5. The crate must continue to compile cleanly: `cargo check -p orchestrator` must succeed.
+6. `cargo clippy -p orchestrator` must produce no new warnings.
+
+## Implementation Details
+
+**File to modify:** `crates/orchestrator/Cargo.toml`
+
+**Changes:**
+
+Add two lines to the `[dependencies]` section:
+
+```toml
+rig-core = { version = "0.32" }
+tracing = "0.1"
+```
+
+Place them in a logical order within the existing dependency list. A reasonable placement is alphabetical, which would put `rig-core` after `reqwest` and `tracing` after `serde_yaml`.
+
+No changes to `[dev-dependencies]` are needed since tokio already has the required features.
+
+No Rust source files are modified in this task -- this is purely a manifest change.
+
+## Dependencies
+
+- **Blocked by:** Nothing (Group 1 task, can be done in parallel with other Group 1 tasks)
+- **Blocking:** "Implement `SemanticRouter` struct with two-phase routing" (Group 2) -- the SemanticRouter source code will import types from `rig_core` and `tracing`
+
+## Risks & Edge Cases
+
+- **Version mismatch:** If a different version of `rig-core` were specified, it could pull in a second copy of the crate and bloat the binary. Mitigation: use the exact same major.minor version (`0.32`) as `agent-runtime`.
+- **Feature conflicts:** The orchestrator does not enable the `rmcp` feature. This is intentional -- `rmcp` is only needed by `agent-runtime` for MCP transport. Cargo will unify features at the workspace level, so both crates share the same compiled `rig-core` artifact.
+- **Lockfile churn:** Since these crates are already in the lockfile, `Cargo.lock` should only gain new dependency edges (orchestrator -> rig-core, orchestrator -> tracing) without adding new crate versions. If the lockfile diff shows new crate downloads, investigate before proceeding.
+
+## Verification
+
+1. Run `cargo check -p orchestrator` -- must succeed with no errors.
+2. Run `cargo clippy -p orchestrator` -- must produce no new warnings.
+3. Run `cargo test -p orchestrator` -- all existing tests must continue to pass.
+4. Inspect the `Cargo.lock` diff and confirm no new crate versions were added (only new dependency edges for the orchestrator package).
+5. Confirm `rig-core` types are importable by temporarily adding `use rig_core::embeddings::EmbeddingModel;` to a test or source file (optional manual check, not required to be committed).

--- a/.claude/specs/issue-16/implement-semantic-router-struct-with-two-phase-routing.md
+++ b/.claude/specs/issue-16/implement-semantic-router-struct-with-two-phase-routing.md
@@ -1,0 +1,301 @@
+# Spec: Implement `SemanticRouter` struct with two-phase routing
+
+> From: .claude/tasks/issue-16.md
+
+## Objective
+
+Create the `SemanticRouter` struct that replaces the orchestrator's placeholder substring-matching heuristic (`route_by_description_match`) with embedding-based cosine similarity routing. The router implements a two-phase strategy: (1) fast exact-match on an `"intent"` field in the request context, and (2) fallback to semantic similarity by embedding the request input and comparing it against pre-computed agent description embeddings using rig-core's `EmbeddingModel` trait.
+
+This is the core component of issue-16 (semantic routing). All other tasks in the issue either prepare for it (error variants, dependencies) or build on top of it (orchestrator integration, tests).
+
+## Current State
+
+- **`crates/orchestrator/src/orchestrator.rs`**: The `Orchestrator` currently routes in two phases:
+  - Phase 1 (`route_by_target_agent`): Checks `request.context["target_agent"]` for an exact agent name match.
+  - Phase 2 (`route_by_description_match`): A substring heuristic that lowercases the input and agent descriptions, then checks if any description word (3+ chars) appears in the input. This is nondeterministic (HashMap iteration order) and low quality. The SemanticRouter will replace this phase.
+
+- **`crates/orchestrator/src/error.rs`**: Defines `OrchestratorError` with variants `NoRoute`, `AgentUnavailable`, `EscalationFailed`, `HttpError`, and `Config`. Does NOT yet have an `EmbeddingError` variant (prerequisite task will add it).
+
+- **`crates/orchestrator/src/lib.rs`**: Exports modules `agent_endpoint`, `config`, `error`, and `orchestrator`. Does NOT yet declare `semantic_router` (the integration task will add it).
+
+- **`crates/orchestrator/Cargo.toml`**: Does NOT yet depend on `rig-core` (prerequisite task will add it).
+
+- **`agent_sdk::AgentRequest`** (in `crates/agent-sdk/src/agent_request.rs`):
+  ```rust
+  pub struct AgentRequest {
+      pub id: Uuid,
+      pub input: String,
+      pub context: Option<Value>,  // serde_json::Value
+      pub caller: Option<String>,
+  }
+  ```
+  The `context` field is an `Option<serde_json::Value>` -- a JSON object that may contain `"target_agent"` (used by the existing orchestrator) and `"intent"` (used by the new SemanticRouter).
+
+- **`crates/orchestrator/src/agent_endpoint.rs`**: Defines `AgentEndpoint` with fields `name: String`, `description: String`, `url: String`, and a private `client: reqwest::Client`. The SemanticRouter does NOT use `AgentEndpoint` directly -- it works with `(name, description)` pairs and returns agent names as strings. The orchestrator integration task will bridge between the router's string output and the registry's `AgentEndpoint` lookup.
+
+- **rig-core 0.32 embedding API** (from `/usr/local/cargo/registry/src/.../rig-core-0.32.0/src/embeddings/`):
+  - `EmbeddingModel` trait (in `embedding.rs`): Has `embed_text(&self, text: &str) -> impl Future<Output = Result<Embedding, EmbeddingError>>` and `embed_texts(...)`. The trait requires `WasmCompatSend + WasmCompatSync` (which resolves to `Send + Sync` on non-WASM targets). It is NOT dyn-compatible because methods return `impl Future`.
+  - `Embedding` struct (in `embedding.rs`): `{ document: String, vec: Vec<f64> }`. Derives `Clone`, `Default`, `Deserialize`, `Serialize`, `Debug`.
+  - `EmbeddingError` enum (in `embedding.rs`): Variants include `HttpError`, `JsonError`, `UrlError`, `DocumentError`, `ResponseError`, `ProviderError`.
+  - `VectorDistance` trait (in `distance.rs`): Implemented for `Embedding`. Provides `cosine_similarity(&self, other: &Self, normalized: bool) -> f64` where `normalized: false` computes the full formula (dot product / product of magnitudes).
+
+## Requirements
+
+1. Create a new file `crates/orchestrator/src/semantic_router.rs`.
+
+2. Define a private `AgentProfile` struct with fields:
+   - `name: String` -- the agent's unique name.
+   - `description: String` -- the agent's human-readable description (kept for debugging/logging).
+   - `description_embedding: Embedding` -- the pre-computed embedding of the description text.
+
+3. Define a public `SemanticRouter` struct with fields:
+   - `agents: Vec<AgentProfile>` -- the list of registered agents with their pre-computed embeddings.
+   - `similarity_threshold: f64` -- the minimum cosine similarity score required for a semantic match.
+
+4. Implement `SemanticRouter::new`:
+   - Signature: `pub async fn new<M: EmbeddingModel>(model: &M, agents: Vec<(String, String)>, threshold: f64) -> Result<Self, OrchestratorError>`
+   - Takes `(name, description)` pairs in the `agents` parameter.
+   - Calls `model.embed_text(&description)` for each agent's description to pre-compute embeddings at construction time.
+   - Maps rig-core's `EmbeddingError` to `OrchestratorError::EmbeddingError { reason }`.
+   - Returns the constructed `SemanticRouter` with all description embeddings cached.
+
+5. Implement `SemanticRouter::route`:
+   - Signature: `pub async fn route<M: EmbeddingModel>(&self, model: &M, request: &AgentRequest) -> Result<String, OrchestratorError>`
+   - **Phase 1 (exact intent match):** Check `request.context` for an `"intent"` key. If present and its string value (via `as_str()`) matches an agent name case-insensitively, return that agent's name immediately. If the value is not a string (e.g., number, object), skip to Phase 2.
+   - **Phase 2 (semantic similarity):** Call `model.embed_text(&request.input)` to embed the request input. Call a helper function `find_best_match` to compute cosine similarity against all pre-computed description embeddings. If the highest similarity score exceeds `self.similarity_threshold`, return that agent's name. Otherwise, return `OrchestratorError::NoRoute { input: request.input.clone() }`.
+   - The embedding model is passed by reference (not stored in the struct) to avoid making the struct generic and to sidestep rig-core's non-dyn-compatible trait.
+
+6. Implement `SemanticRouter::register`:
+   - Signature: `pub async fn register<M: EmbeddingModel>(&mut self, model: &M, name: String, description: String) -> Result<(), OrchestratorError>`
+   - Embeds the description text using `model.embed_text(&description)`.
+   - Pushes a new `AgentProfile` onto `self.agents`.
+   - Maps `EmbeddingError` to `OrchestratorError::EmbeddingError { reason }`.
+
+7. Implement a private helper function `find_best_match`:
+   - Signature: `fn find_best_match(input_embedding: &Embedding, agents: &[AgentProfile], threshold: f64) -> Option<String>`
+   - Iterates all agents, computing `input_embedding.cosine_similarity(&agent.description_embedding, false)` for each (using the `VectorDistance` trait).
+   - Tracks the agent with the highest similarity score.
+   - Returns `Some(name)` if the highest score exceeds `threshold`, otherwise `None`.
+   - Must be under 50 lines per project rules.
+
+8. Implement a private helper function for Phase 1 intent extraction:
+   - Signature: `fn match_intent(agents: &[AgentProfile], context: &Option<serde_json::Value>) -> Option<String>`
+   - Extracts `context["intent"]` as a string, compares case-insensitively against agent names.
+   - Returns `Some(agent_name)` on match, `None` otherwise.
+   - Must be under 50 lines per project rules.
+
+9. All functions must be under 50 lines each.
+
+10. No test module in this file. Tests are a separate task.
+
+11. No commented-out code or debug statements.
+
+12. Use `tracing::debug!` for logging routing decisions (intent match found, semantic match score, no route).
+
+## Implementation Details
+
+### File to create
+
+**`crates/orchestrator/src/semantic_router.rs`**
+
+**Imports needed:**
+```rust
+use agent_sdk::AgentRequest;
+use rig::embeddings::{Embedding, EmbeddingModel};
+use rig::embeddings::distance::VectorDistance;
+use serde_json::Value;
+
+use crate::error::OrchestratorError;
+```
+Note: The exact import paths for rig-core types must be verified at implementation time. `rig::embeddings::Embedding` is the most likely path based on `rig-core`'s module structure (`src/embeddings/embedding.rs` re-exported through `src/embeddings/mod.rs`). The crate is imported as `rig-core` in `Cargo.toml` but used as `rig_core` or `rig` in Rust code -- check how `agent-runtime` imports it (the `Cargo.toml` uses `rig-core = { version = "0.32" }` which becomes `rig_core` in Rust, but rig-core may re-export as `rig`).
+
+**Struct definitions:**
+```rust
+struct AgentProfile {
+    name: String,
+    description: String,
+    description_embedding: Embedding,
+}
+
+pub struct SemanticRouter {
+    agents: Vec<AgentProfile>,
+    similarity_threshold: f64,
+}
+```
+`AgentProfile` is private to the module. `SemanticRouter` is public. Neither struct needs `Clone` or `Serialize`/`Deserialize` -- the `Embedding` struct inside `AgentProfile` is `Clone` but the router itself is not expected to be cloned.
+
+**`new` implementation sketch:**
+```rust
+pub async fn new<M: EmbeddingModel>(
+    model: &M,
+    agents: Vec<(String, String)>,
+    threshold: f64,
+) -> Result<Self, OrchestratorError> {
+    let mut profiles = Vec::with_capacity(agents.len());
+    for (name, description) in agents {
+        let embedding = model
+            .embed_text(&description)
+            .await
+            .map_err(|e| OrchestratorError::EmbeddingError {
+                reason: e.to_string(),
+            })?;
+        profiles.push(AgentProfile {
+            name,
+            description,
+            description_embedding: embedding,
+        });
+    }
+    Ok(Self {
+        agents: profiles,
+        similarity_threshold: threshold,
+    })
+}
+```
+
+**`route` implementation sketch:**
+```rust
+pub async fn route<M: EmbeddingModel>(
+    &self,
+    model: &M,
+    request: &AgentRequest,
+) -> Result<String, OrchestratorError> {
+    if let Some(name) = match_intent(&self.agents, &request.context) {
+        tracing::debug!(agent = %name, "routed via intent match");
+        return Ok(name);
+    }
+
+    let input_embedding = model
+        .embed_text(&request.input)
+        .await
+        .map_err(|e| OrchestratorError::EmbeddingError {
+            reason: e.to_string(),
+        })?;
+
+    match find_best_match(&input_embedding, &self.agents, self.similarity_threshold) {
+        Some(name) => {
+            tracing::debug!(agent = %name, "routed via semantic similarity");
+            Ok(name)
+        }
+        None => Err(OrchestratorError::NoRoute {
+            input: request.input.clone(),
+        }),
+    }
+}
+```
+
+**`find_best_match` implementation sketch:**
+```rust
+fn find_best_match(
+    input_embedding: &Embedding,
+    agents: &[AgentProfile],
+    threshold: f64,
+) -> Option<String> {
+    let mut best_name: Option<&str> = None;
+    let mut best_score = threshold;
+
+    for agent in agents {
+        let score = input_embedding
+            .cosine_similarity(&agent.description_embedding, false);
+        if score > best_score {
+            best_score = score;
+            best_name = Some(&agent.name);
+        }
+    }
+
+    best_name.map(|n| n.to_string())
+}
+```
+Note: `best_score` is initialized to `threshold` so that only agents exceeding the threshold are considered. If multiple agents tie, the first one encountered wins (deterministic because `Vec` has stable iteration order, unlike `HashMap`).
+
+**`match_intent` implementation sketch:**
+```rust
+fn match_intent(
+    agents: &[AgentProfile],
+    context: &Option<Value>,
+) -> Option<String> {
+    let context = context.as_ref()?;
+    let intent = context.get("intent")?.as_str()?;
+    let intent_lower = intent.to_lowercase();
+
+    agents
+        .iter()
+        .find(|a| a.name.to_lowercase() == intent_lower)
+        .map(|a| a.name.clone())
+}
+```
+
+### Key design decisions
+
+1. **Model passed by reference, not stored:** The `EmbeddingModel` trait in rig-core 0.32 returns `impl Future` from its methods, making it NOT dyn-compatible (`Box<dyn EmbeddingModel>` is impossible). Storing the model as a generic type parameter on the struct (`SemanticRouter<M: EmbeddingModel>`) would propagate the generic through the entire `Orchestrator` type, complicating integration. Instead, the model is passed by reference to `new()`, `route()`, and `register()`. The tradeoff: the caller must keep the model alive and pass it to every call.
+
+2. **Pre-computed description embeddings:** Agent descriptions are embedded once at construction/registration time and cached in `AgentProfile.description_embedding`. Only the request input needs embedding at routing time, keeping per-request latency to a single embedding API call.
+
+3. **`Vec<AgentProfile>` not `HashMap`:** Using a `Vec` instead of a `HashMap` because: (a) the number of agents is small (dozens, not thousands), (b) we need to iterate all agents for similarity comparison anyway, (c) `Vec` has deterministic iteration order (unlike `HashMap`), making tie-breaking predictable.
+
+4. **Cosine similarity with `normalized: false`:** rig-core's `VectorDistance::cosine_similarity` takes a `normalized` flag. We pass `false` because we cannot assume embeddings from the model are unit-normalized. With `false`, the full formula is used: dot product / (magnitude1 * magnitude2).
+
+5. **Threshold comparison uses strict `>` not `>=`:** `find_best_match` uses `score > best_score` where `best_score` starts at `threshold`. This means an exact threshold match does NOT qualify -- the score must strictly exceed it. This avoids edge cases where floating-point imprecision at the boundary causes inconsistent routing.
+
+6. **Error mapping:** rig-core's `EmbeddingError` is mapped to `OrchestratorError::EmbeddingError { reason: e.to_string() }`. This is a lossy conversion (the original error type is not preserved), but it avoids adding a rig-core dependency to the error type's public API. The string representation from rig-core's `Display` impl provides sufficient diagnostic information.
+
+### Integration points
+
+- **Upstream (rig-core):** Consumes `EmbeddingModel` trait, `Embedding` struct, `VectorDistance` trait, and `EmbeddingError` enum from rig-core 0.32.
+- **Upstream (agent-sdk):** Uses `AgentRequest` to access `input` and `context` fields.
+- **Upstream (error):** Uses `OrchestratorError::NoRoute` and `OrchestratorError::EmbeddingError` (the latter added by the prerequisite task).
+- **Downstream (orchestrator):** The "Integrate `SemanticRouter` into `Orchestrator`" task will add `pub mod semantic_router;` to `lib.rs`, store an `Option<SemanticRouter>` in the `Orchestrator` struct, and call `router.route(model, request)` from `dispatch()`.
+
+## Dependencies
+
+- **Blocked by:**
+  - "Add `EmbeddingError` variant to `OrchestratorError`" -- the `route()` and `new()` methods return `OrchestratorError::EmbeddingError`, which must exist first.
+  - "Add `rig-core` dependency to orchestrator `Cargo.toml`" -- the file imports `rig_core` types (`Embedding`, `EmbeddingModel`, `VectorDistance`), which require the dependency to be present.
+- **Blocking:**
+  - "Integrate `SemanticRouter` into `Orchestrator`" -- the orchestrator integration task adds `pub mod semantic_router;` to `lib.rs` and uses the `SemanticRouter` inside `Orchestrator::dispatch()`.
+  - "Write unit tests for `SemanticRouter`" -- the test task creates a mock `EmbeddingModel` and exercises `new()`, `route()`, and `register()`.
+
+## Risks & Edge Cases
+
+1. **rig-core import paths.** The exact Rust module paths for rig-core types (`Embedding`, `EmbeddingModel`, `VectorDistance`) may differ from the sketched imports. rig-core 0.32 uses `rig-core` as the crate name (becomes `rig_core` in Rust), but `agent-runtime` imports it as `rig-core` and the crate may re-export types at different paths. Mitigation: verify import paths by checking how `agent-runtime` uses rig-core, or by running `cargo doc -p rig-core --open` after the dependency is added.
+
+2. **Empty agents list.** If `SemanticRouter::new` is called with an empty `agents` vec, the router will have no agents. Phase 1 and Phase 2 will both find nothing, and `route()` will always return `NoRoute`. This is valid behavior, not an error.
+
+3. **Embedding API failures.** If the embedding model provider is unreachable or returns errors (rate limits, invalid API key), `new()` will fail at the first agent that cannot be embedded. This is fail-fast behavior -- if we cannot embed descriptions, the router is useless. Similarly, `route()` will fail if the input cannot be embedded. Both map to `OrchestratorError::EmbeddingError`.
+
+4. **Zero-magnitude embeddings.** If an embedding model returns a zero vector for some input, `cosine_similarity` will produce `NaN` (division by zero). The `NaN > threshold` comparison will evaluate to `false`, so the agent will simply not match. This is safe but could be confusing if it happens silently. The `tracing::debug!` logging will help diagnose this.
+
+5. **Case sensitivity of intent matching.** The spec requires case-insensitive matching for the `"intent"` field. The implementation lowercases both the intent value and agent names before comparison. This means an intent of `"Finance-Agent"` will match an agent named `"finance-agent"`. The returned name is the original (not lowercased) agent name from the profile.
+
+6. **Intent field vs target_agent field.** The existing `Orchestrator.route_by_target_agent` checks `context["target_agent"]`. The `SemanticRouter` checks `context["intent"]`. These are different keys serving different purposes: `target_agent` is an explicit override (preserved in the orchestrator's fast path), while `intent` is a semantic hint that the router interprets. Both can coexist in the same request context without conflict.
+
+7. **Deterministic tie-breaking.** When multiple agents have the same cosine similarity score above the threshold, `find_best_match` returns the first one encountered in the `Vec`. Since `Vec` iteration is stable and deterministic, this is reproducible. However, the "winner" depends on the order agents were registered. This is acceptable for the current scale (small number of agents).
+
+8. **Threshold boundary.** The strict `>` comparison means a score of exactly 0.7 (with threshold 0.7) does NOT match. This is a deliberate design choice to avoid floating-point edge cases. If this proves too aggressive, the threshold can be lowered by the caller.
+
+9. **Performance with many agents.** The `find_best_match` function iterates all agents linearly. For the expected scale (tens of agents), this is negligible. If the number of agents grows to thousands, a vector index (e.g., approximate nearest neighbor) would be needed, but that is out of scope.
+
+## Verification
+
+After implementation (and after both blocking prerequisite tasks are complete), run:
+
+```bash
+cargo check -p orchestrator
+cargo clippy -p orchestrator
+```
+
+Both must pass with no errors and no warnings. (`cargo test -p orchestrator` may fail if the module is not yet wired into `lib.rs` -- that is done by the integration task.)
+
+Additionally verify:
+
+- The file `crates/orchestrator/src/semantic_router.rs` exists.
+- `SemanticRouter` is `pub struct` with `agents: Vec<AgentProfile>` and `similarity_threshold: f64`.
+- `AgentProfile` is a private struct (no `pub`) with `name`, `description`, and `description_embedding` fields.
+- `new()` is `pub async fn` with generic `M: EmbeddingModel`, takes `(String, String)` pairs, and pre-computes embeddings.
+- `route()` is `pub async fn` with generic `M: EmbeddingModel`, implements Phase 1 (intent match) then Phase 2 (semantic similarity).
+- `register()` is `pub async fn` with generic `M: EmbeddingModel`, embeds the description and pushes to the agents list.
+- `find_best_match` is a private function that computes cosine similarity and returns the best match above threshold.
+- `match_intent` is a private function that extracts `context["intent"]` and compares case-insensitively.
+- All functions are under 50 lines each.
+- No test module, no commented-out code, no debug statements in the file.
+- Error mapping from `EmbeddingError` to `OrchestratorError::EmbeddingError` is present in `new()`, `route()`, and `register()`.
+- `tracing::debug!` is used for logging routing decisions.

--- a/.claude/specs/issue-16/integrate-semantic-router-into-orchestrator.md
+++ b/.claude/specs/issue-16/integrate-semantic-router-into-orchestrator.md
@@ -1,0 +1,342 @@
+# Spec: Integrate `SemanticRouter` into `Orchestrator`
+
+> From: .claude/tasks/issue-16.md
+
+## Objective
+
+Replace the orchestrator's placeholder substring-matching heuristic (`route_by_description_match`) with the `SemanticRouter` for embedding-based routing. The orchestrator must continue to work without a `SemanticRouter` (backward compatibility for tests and deployments without an embedding model), while gaining the ability to perform cosine-similarity routing when a `SemanticRouter` is present.
+
+## Current State
+
+**`crates/orchestrator/src/orchestrator.rs`** defines the `Orchestrator` struct with two fields:
+
+```rust
+pub struct Orchestrator {
+    registry: HashMap<String, AgentEndpoint>,
+    manifest: SkillManifest,
+}
+```
+
+Routing is performed by `route()`, which calls two private helpers in sequence:
+
+1. `route_by_target_agent(&self, request: &AgentRequest) -> Option<&AgentEndpoint>` -- Checks `request.context` for a `"target_agent"` string key and does a direct registry lookup. This is the fast path.
+2. `route_by_description_match(&self, request: &AgentRequest) -> Option<&AgentEndpoint>` -- Substring heuristic: lowercases both the input and each endpoint's description, then checks if any description word (3+ chars) appears in the input. Returns the first match found (nondeterministic due to HashMap iteration order). **This method is the placeholder that the `SemanticRouter` replaces.**
+
+`dispatch()` is already `async`. It calls `self.route(&request)` synchronously, then proceeds to `try_invoke()` and `handle_escalation()`.
+
+**`crates/orchestrator/src/lib.rs`** currently exports four modules:
+
+```rust
+pub mod agent_endpoint;
+pub mod config;
+pub mod error;
+pub mod orchestrator;
+```
+
+**`crates/orchestrator/src/config.rs`** defines `OrchestratorConfig` with a single `agents: Vec<AgentConfig>` field. A sibling task ("Add embedding model configuration to `OrchestratorConfig`") will extend this with optional embedding provider/model/threshold fields.
+
+**`crates/orchestrator/src/error.rs`** defines `OrchestratorError` with variants: `NoRoute`, `AgentUnavailable`, `EscalationFailed`, `HttpError`, `Config`. A prerequisite task adds `EmbeddingError { reason: String }`.
+
+**Existing tests** in `crates/orchestrator/tests/orchestrator_test.rs` construct `Orchestrator` via `Orchestrator::new(manifest, agents)` and use `target_agent` context for routing. None of the existing tests rely on `route_by_description_match`. The `dispatch()` tests call `dispatch(request).await`.
+
+**`SemanticRouter`** (created by a prerequisite task in `crates/orchestrator/src/semantic_router.rs`):
+
+```rust
+pub struct SemanticRouter {
+    agents: Vec<AgentProfile>,
+    similarity_threshold: f64,
+}
+```
+
+Key API surface:
+- `async fn new<M: EmbeddingModel>(model: &M, agents: Vec<(String, String)>, threshold: f64) -> Result<Self, OrchestratorError>` -- Pre-computes description embeddings.
+- `async fn route<M: EmbeddingModel>(&self, model: &M, request: &AgentRequest) -> Result<String, OrchestratorError>` -- Returns the agent **name** (not a reference to `AgentEndpoint`). Two-phase: (1) check `request.context` for `"intent"` key and exact-match agent names, (2) embed `request.input` and cosine-similarity match.
+- `async fn register<M: EmbeddingModel>(&mut self, model: &M, name: String, description: String) -> Result<(), OrchestratorError>` -- Adds a new agent profile.
+
+The `EmbeddingModel` trait (from rig-core) is not dyn-compatible, so it cannot be stored as `Box<dyn EmbeddingModel>`. It must be passed as a generic parameter at call sites.
+
+## Requirements
+
+- **R1**: Add a `semantic_router: Option<SemanticRouter>` field to the `Orchestrator` struct.
+- **R2**: Update `Orchestrator::new()` to accept an optional `SemanticRouter`. Signature becomes: `pub fn new(manifest: SkillManifest, agents: Vec<AgentEndpoint>, semantic_router: Option<SemanticRouter>) -> Self`.
+- **R3**: Keep the synchronous `route()` method for backward compatibility. It must continue to perform `route_by_target_agent()` as its only lookup. Remove the call to `route_by_description_match()` from `route()`, making it return `NoRoute` when no `target_agent` context is present. This preserves the existing synchronous API without losing functionality, because the semantic path is invoked from `dispatch()`.
+- **R4**: Add a new `async fn route_semantic<M: EmbeddingModel>(&self, model: &M, request: &AgentRequest) -> Result<&AgentEndpoint, OrchestratorError>` method. This method calls `self.semantic_router.as_ref()` to get the router, calls `router.route(model, request).await` to get an agent name, then looks up the name in `self.registry`. Returns `OrchestratorError::NoRoute` if the router is absent, returns no match, or the returned name is not in the registry.
+- **R5**: Modify `dispatch()` to use a three-phase routing strategy:
+  1. Try `route_by_target_agent()` -- if the request has `context.target_agent`, use it. This is the fast synchronous path.
+  2. If no `target_agent`, and a `SemanticRouter` is present, try `route_semantic()`. Since `dispatch()` is already async, this does not change its signature. **Note**: `dispatch()` currently does not have access to an embedding model. A new method `dispatch_with_model()` (see R6) handles this.
+  3. Fall through to `OrchestratorError::NoRoute`.
+- **R6**: Add `pub async fn dispatch_with_model<M: EmbeddingModel>(&self, request: AgentRequest, model: &M) -> Result<AgentResponse, OrchestratorError>`. This method performs the full three-phase routing: (1) `route_by_target_agent`, (2) `route_semantic` via the `SemanticRouter`, (3) `NoRoute`. After routing, it delegates to `try_invoke` and `handle_escalation` identically to the existing `dispatch()`.
+- **R7**: The existing `dispatch()` must continue to work without an embedding model. When no `SemanticRouter` is present (or when `dispatch()` is called without a model), routing falls through to only `route_by_target_agent`, then `NoRoute`. This preserves backward compatibility with all existing tests.
+- **R8**: Remove `route_by_description_match()` entirely. It is the substring heuristic that the `SemanticRouter` replaces.
+- **R9**: Update `Orchestrator::from_config()` to accept and wire through a `SemanticRouter` when available. Since constructing a `SemanticRouter` requires an async embedding call, `from_config` cannot build it synchronously. Two options: (a) `from_config` passes `None` and the caller sets the router later, or (b) add `async fn from_config_with_model<M: EmbeddingModel>(config: OrchestratorConfig, model: &M) -> Result<Self, OrchestratorError>` that builds the `SemanticRouter` from the agent descriptions in config. Implement option (b) and keep option (a) as the existing `from_config` path (which passes `semantic_router: None`).
+- **R10**: Update `crates/orchestrator/src/lib.rs` to add `pub mod semantic_router;`.
+- **R11**: All public methods must remain under 50 lines per project rules.
+- **R12**: No new crate dependencies. The `rig-core` dependency is added by a prerequisite task.
+
+## Implementation Details
+
+### Files to modify
+
+**`crates/orchestrator/src/lib.rs`**
+
+Add the `semantic_router` module export:
+
+```rust
+pub mod agent_endpoint;
+pub mod config;
+pub mod error;
+pub mod orchestrator;
+pub mod semantic_router;
+```
+
+**`crates/orchestrator/src/orchestrator.rs`**
+
+#### Import additions
+
+Add to the existing imports:
+
+```rust
+use crate::semantic_router::SemanticRouter;
+```
+
+Add a conditional import for `EmbeddingModel` from rig-core (used in generic method bounds):
+
+```rust
+use rig::embeddings::EmbeddingModel;
+```
+
+#### Struct change
+
+```rust
+pub struct Orchestrator {
+    registry: HashMap<String, AgentEndpoint>,
+    manifest: SkillManifest,
+    semantic_router: Option<SemanticRouter>,
+}
+```
+
+#### `new()` signature change
+
+```rust
+pub fn new(
+    manifest: SkillManifest,
+    agents: Vec<AgentEndpoint>,
+    semantic_router: Option<SemanticRouter>,
+) -> Self {
+    let registry = agents
+        .into_iter()
+        .map(|agent| (agent.name.clone(), agent))
+        .collect();
+    Self { registry, manifest, semantic_router }
+}
+```
+
+#### Remove `route_by_description_match()`
+
+Delete the entire `route_by_description_match` method (lines 84-93 of the current file).
+
+#### Simplify `route()`
+
+The synchronous `route()` now only does the `target_agent` exact match:
+
+```rust
+pub fn route(&self, request: &AgentRequest) -> Result<&AgentEndpoint, OrchestratorError> {
+    if let Some(endpoint) = self.route_by_target_agent(request) {
+        return Ok(endpoint);
+    }
+    Err(OrchestratorError::NoRoute {
+        input: request.input.clone(),
+    })
+}
+```
+
+#### Add `route_semantic()`
+
+New private async method:
+
+```rust
+async fn route_semantic<M: EmbeddingModel>(
+    &self,
+    model: &M,
+    request: &AgentRequest,
+) -> Result<&AgentEndpoint, OrchestratorError> {
+    let router = self.semantic_router.as_ref().ok_or_else(|| {
+        OrchestratorError::NoRoute {
+            input: request.input.clone(),
+        }
+    })?;
+
+    let agent_name = router.route(model, request).await?;
+
+    self.registry.get(&agent_name).ok_or_else(|| {
+        OrchestratorError::NoRoute {
+            input: request.input.clone(),
+        }
+    })
+}
+```
+
+#### Add `dispatch_with_model()`
+
+New public async method that performs the full three-phase routing:
+
+```rust
+pub async fn dispatch_with_model<M: EmbeddingModel>(
+    &self,
+    request: AgentRequest,
+    model: &M,
+) -> Result<AgentResponse, OrchestratorError> {
+    let endpoint = self.route_with_model(&request, model).await?;
+    let response = self.try_invoke(endpoint, &request).await?;
+    let chain = vec![endpoint.name.clone()];
+    self.handle_escalation(response, &request, chain).await
+}
+```
+
+Add a private helper for the three-phase routing:
+
+```rust
+async fn route_with_model<M: EmbeddingModel>(
+    &self,
+    request: &AgentRequest,
+    model: &M,
+) -> Result<&AgentEndpoint, OrchestratorError> {
+    // Phase 1: exact target_agent match (fast path)
+    if let Some(endpoint) = self.route_by_target_agent(request) {
+        return Ok(endpoint);
+    }
+
+    // Phase 2: semantic routing via embedding similarity
+    if self.semantic_router.is_some() {
+        return self.route_semantic(model, request).await;
+    }
+
+    // Phase 3: no route found
+    Err(OrchestratorError::NoRoute {
+        input: request.input.clone(),
+    })
+}
+```
+
+#### Modify existing `dispatch()`
+
+The existing `dispatch()` retains its current signature for backward compatibility. Without an embedding model it can only do exact matching:
+
+```rust
+pub async fn dispatch(
+    &self,
+    request: AgentRequest,
+) -> Result<AgentResponse, OrchestratorError> {
+    let endpoint = self.route(&request)?;
+    let response = self.try_invoke(endpoint, &request).await?;
+    let chain = vec![endpoint.name.clone()];
+    self.handle_escalation(response, &request, chain).await
+}
+```
+
+This is unchanged from the current implementation (just calls `route()` which now only does `target_agent` matching).
+
+#### Update `from_config()`
+
+Keep the existing synchronous `from_config` but pass `None` for the semantic router:
+
+```rust
+pub fn from_config(config: OrchestratorConfig) -> Result<Self, OrchestratorError> {
+    let client = build_shared_client();
+    let agents: Vec<AgentEndpoint> = config
+        .agents
+        .into_iter()
+        .map(|ac| AgentEndpoint::new(ac.name, ac.description, ac.url, client.clone()))
+        .collect();
+
+    let manifest = build_default_manifest();
+    Ok(Self::new(manifest, agents, None))
+}
+```
+
+#### Add `from_config_with_model()`
+
+New async constructor that builds a `SemanticRouter` from config:
+
+```rust
+pub async fn from_config_with_model<M: EmbeddingModel>(
+    config: OrchestratorConfig,
+    model: &M,
+    similarity_threshold: f64,
+) -> Result<Self, OrchestratorError> {
+    let client = build_shared_client();
+    let agent_pairs: Vec<(String, String)> = config
+        .agents
+        .iter()
+        .map(|ac| (ac.name.clone(), ac.description.clone()))
+        .collect();
+
+    let agents: Vec<AgentEndpoint> = config
+        .agents
+        .into_iter()
+        .map(|ac| AgentEndpoint::new(ac.name, ac.description, ac.url, client.clone()))
+        .collect();
+
+    let semantic_router = SemanticRouter::new(model, agent_pairs, similarity_threshold).await?;
+    let manifest = build_default_manifest();
+    Ok(Self::new(manifest, agents, Some(semantic_router)))
+}
+```
+
+#### Routing priority order (summary)
+
+The complete routing priority for `dispatch_with_model`:
+
+1. `context.target_agent` exact match (existing fast path, synchronous, in `route_by_target_agent`)
+2. `context.intent` exact match (inside `SemanticRouter::route`, phase 1)
+3. Embedding cosine similarity fallback (inside `SemanticRouter::route`, phase 2)
+4. `OrchestratorError::NoRoute`
+
+For the existing `dispatch()` (no model available):
+
+1. `context.target_agent` exact match
+2. `OrchestratorError::NoRoute`
+
+### Key integration points
+
+- `SemanticRouter::route()` returns a `String` (agent name), not an `&AgentEndpoint`. The orchestrator bridges this by looking up the name in `self.registry`.
+- `EmbeddingModel` is a generic parameter on methods, not stored in the struct. This avoids making `Orchestrator` generic, which would complicate the `MicroAgent` trait implementation.
+- The `MicroAgent::invoke()` implementation continues to call `dispatch()` (not `dispatch_with_model`), so the trait-based interface does not use semantic routing. A future enhancement could store a model reference, but that is out of scope.
+- `route_by_target_agent()` is kept as-is since it is the fast path that both `route()` and `route_with_model()` check first.
+
+## Dependencies
+
+- **Blocked by**:
+  - "Implement `SemanticRouter` struct with two-phase routing" -- `crates/orchestrator/src/semantic_router.rs` must exist with the `SemanticRouter` struct and its `new()`, `route()`, and `register()` methods.
+  - "Add `EmbeddingError` variant to `OrchestratorError`" -- `OrchestratorError::EmbeddingError` must exist for `SemanticRouter::route` error propagation.
+  - "Add `rig-core` dependency to orchestrator `Cargo.toml`" -- `rig-core` must be in dependencies for the `EmbeddingModel` trait import.
+
+- **Blocking**:
+  - "Write integration tests for semantic routing in `Orchestrator`" -- tests that exercise `dispatch_with_model` with a mock `EmbeddingModel`.
+
+## Risks & Edge Cases
+
+- **`SemanticRouter` returns a name not in registry**: This can happen if agents are registered in the `SemanticRouter` but not in the orchestrator's `registry`, or vice versa. The `route_semantic` method handles this by returning `NoRoute` when the registry lookup fails. Mitigation: document that `SemanticRouter` and `registry` must be kept in sync. The constructors (`new`, `from_config_with_model`) handle this by building both from the same agent list.
+- **Embedding API failure during routing**: If the embedding model call fails in `route_semantic`, the error propagates as `OrchestratorError::EmbeddingError`. The caller sees a clear error rather than a silent fallback. This is intentional -- a transient embedding failure should not silently degrade to "no route found" since that would be confusing to debug.
+- **Backward compatibility of `new()` signature**: Changing `new()` from 2 parameters to 3 is a breaking change for all call sites. All existing tests construct `Orchestrator::new(manifest, agents)` and must be updated to `Orchestrator::new(manifest, agents, None)`. This is a mechanical change across test files.
+- **`MicroAgent::invoke()` does not use semantic routing**: The `MicroAgent` trait implementation calls `dispatch()` which has no access to an embedding model. Users who want semantic routing must call `dispatch_with_model()` directly. This is acceptable because the `MicroAgent` trait interface is fixed and cannot carry a generic model parameter.
+- **Thread safety**: `SemanticRouter` stores pre-computed `Vec<AgentProfile>` and a `f64` threshold. These are read-only after construction, so `&self` access in `route()` is safe. The `Orchestrator` does not need additional synchronization.
+- **`register()` does not update the `SemanticRouter`**: Calling `orchestrator.register(endpoint)` adds an agent to the `registry` but not to the `SemanticRouter`. To register an agent in both, the caller must also call `semantic_router.register(model, name, description).await`. This asymmetry is a known limitation. Documenting this in a code comment is sufficient for now.
+- **Empty `SemanticRouter` (no agents)**: If the `SemanticRouter` is constructed with an empty agent list, `route()` will always return `NoRoute` from the semantic path. This is correct behavior.
+
+## Verification
+
+- **Compilation**: `cargo check -p orchestrator` succeeds with no errors after all prerequisite tasks are complete.
+- **Lint**: `cargo clippy -p orchestrator` produces no warnings.
+- **Existing tests pass**: All tests in `crates/orchestrator/tests/orchestrator_test.rs` continue to pass after updating `Orchestrator::new()` calls to include the `None` semantic router parameter. No test behavior changes.
+- **Backward compatibility**: `dispatch()` without a model still works with `target_agent` context routing.
+- **New API surface**: `dispatch_with_model()` compiles with a generic `EmbeddingModel` parameter and performs three-phase routing.
+- **`route_by_description_match` removed**: The substring heuristic method no longer exists in the source.
+- **Module export**: `use orchestrator::semantic_router::SemanticRouter;` compiles from external crates and tests.
+- **Integration tests** (defined in a downstream task) will verify:
+  1. `dispatch_with_model()` routes by `target_agent` context (priority 1).
+  2. `dispatch_with_model()` routes by `intent` context via `SemanticRouter` (priority 2).
+  3. `dispatch_with_model()` routes by embedding similarity (priority 3).
+  4. `dispatch_with_model()` returns `NoRoute` when no match is found.
+  5. `dispatch()` without a model returns `NoRoute` when no `target_agent` is set (does not panic or use stale heuristic).
+  6. `from_config_with_model()` constructs a fully wired orchestrator with semantic routing.

--- a/.claude/specs/issue-16/run-verification-suite.md
+++ b/.claude/specs/issue-16/run-verification-suite.md
@@ -1,0 +1,113 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-16.md
+
+## Objective
+Run the full workspace verification suite (`cargo check`, `cargo clippy`, `cargo test`) to confirm that all changes introduced by issue-16 (semantic routing) compile cleanly, pass lint, and cause no test regressions in any workspace crate. This is the final gate before the issue can be considered complete.
+
+## Current State
+The workspace contains six members defined in the root `Cargo.toml`:
+- `crates/agent-sdk` -- core SDK types (`AgentRequest`, `AgentResponse`, `MicroAgent` trait, etc.)
+- `crates/skill-loader` -- skill manifest loading
+- `crates/tool-registry` -- tool discovery and registration
+- `crates/agent-runtime` -- runtime execution (already depends on `rig-core`)
+- `crates/orchestrator` -- request routing and agent dispatch (target of issue-16 changes)
+- `tools/echo-tool` -- example tool binary
+
+The orchestrator crate currently has four test files under `crates/orchestrator/tests/`:
+- `agent_endpoint_test.rs`
+- `config_test.rs`
+- `error_test.rs`
+- `orchestrator_test.rs`
+
+After issue-16 work completes, additional test files will exist:
+- `crates/orchestrator/tests/semantic_router_test.rs` (new)
+- Updated `orchestrator_test.rs` with semantic routing integration tests
+- Updated `config_test.rs` with embedding config field tests
+
+The orchestrator crate will have new source files:
+- `crates/orchestrator/src/semantic_router.rs` (new module)
+- Modified `error.rs` (new `EmbeddingError` variant)
+- Modified `config.rs` (new embedding configuration fields)
+- Modified `orchestrator.rs` (SemanticRouter integration, removal of `route_by_description_match`)
+- Modified `lib.rs` (new `pub mod semantic_router;` declaration)
+- Modified `Cargo.toml` (added `rig-core` and `tracing` dependencies, `tokio` dev-dependency update)
+
+There is no CI workflow (no `.github/workflows/` files). The project relies on the stop-quality-gate hook at `.claude/hooks/stop-quality-gate.sh`, which runs `cargo test` as part of its checks. There is no Makefile or dedicated test script.
+
+## Requirements
+- `cargo check` must succeed across the entire workspace with zero errors
+- `cargo clippy` must succeed across the entire workspace with zero warnings (all default lints clean)
+- `cargo test` must succeed across the entire workspace with zero failures
+- All pre-existing tests in `agent-sdk`, `agent-runtime`, `skill-loader`, `tool-registry`, and `tools/echo-tool` must continue to pass (no regressions)
+- All pre-existing orchestrator tests (`agent_endpoint_test`, `config_test`, `error_test`, `orchestrator_test`) must continue to pass
+- All new orchestrator tests (`semantic_router_test`, updated `orchestrator_test`, updated `config_test`) must pass
+- The `semantic_router` module must compile without any warnings under `cargo clippy`
+- No unused imports, dead code, or other compiler warnings in any modified file
+
+## Implementation Details
+This task involves no code changes. It is a command-line verification-only task.
+
+**Commands to run (in order):**
+
+1. **Type check the full workspace:**
+   ```
+   cargo check --workspace
+   ```
+   Confirms all crates compile. Catches missing imports, type errors, trait bound issues (especially relevant for `EmbeddingModel` generics in `semantic_router.rs`).
+
+2. **Lint the full workspace:**
+   ```
+   cargo clippy --workspace -- -D warnings
+   ```
+   Runs Clippy with warnings-as-errors. Catches idiomatic issues, unnecessary clones, missing error handling, etc. The `-D warnings` flag ensures no warnings are silently ignored.
+
+3. **Run all tests:**
+   ```
+   cargo test --workspace
+   ```
+   Runs every `#[test]` and `#[tokio::test]` across all six workspace members. Verifies both unit tests (in `src/`) and integration tests (in `tests/`).
+
+**Per-crate verification focus:**
+
+- `agent-sdk`: No changes expected. Tests must pass unchanged, confirming the SDK types used by the orchestrator are still compatible.
+- `agent-runtime`: No changes expected. Already depends on `rig-core`, so no version conflict should arise from the orchestrator also depending on `rig-core`.
+- `skill-loader`: No changes expected. Tests must pass unchanged.
+- `tool-registry`: No changes expected. Tests must pass unchanged.
+- `tools/echo-tool`: No changes expected. Must still compile.
+- `orchestrator`: The primary crate under change. All existing and new tests must pass. The `semantic_router` module must produce zero Clippy warnings.
+
+**Specific things to watch for:**
+
+- `rig-core` version compatibility: Both `agent-runtime` and `orchestrator` depend on `rig-core`. Verify there is no version conflict in `Cargo.lock` (both should resolve to the same `0.32.x` version).
+- Async test runtime: New tests use `#[tokio::test]`. Verify the `tokio` dev-dependency features (`macros`, `rt`) are sufficient.
+- Mock `EmbeddingModel` implementation: The mock in `semantic_router_test.rs` must satisfy `rig-core`'s `EmbeddingModel` trait bounds. Any trait changes in rig-core 0.32 would surface here.
+- Removed `route_by_description_match`: Existing `orchestrator_test.rs` tests that relied on description-match routing must have been updated to use either `target_agent` context or the new `SemanticRouter`. Verify no tests are broken by the removal.
+
+## Dependencies
+- Blocked by: All other issue-16 tasks:
+  - "Add `EmbeddingError` variant to `OrchestratorError`"
+  - "Add `rig-core` dependency to orchestrator `Cargo.toml`"
+  - "Implement `SemanticRouter` struct with two-phase routing"
+  - "Integrate `SemanticRouter` into `Orchestrator`"
+  - "Add embedding model configuration to `OrchestratorConfig`"
+  - "Write unit tests for `SemanticRouter`"
+  - "Write integration tests for semantic routing in `Orchestrator`"
+  - "Write unit tests for config embedding fields"
+- Blocking: Nothing (this is the final task)
+
+## Risks & Edge Cases
+- **rig-core version mismatch**: If `agent-runtime` pins a different minor version of `rig-core` than the orchestrator, Cargo may pull two copies, causing trait incompatibility (e.g., `agent_runtime::rig_core::Embedding` != `orchestrator::rig_core::Embedding`). Mitigation: both crates should depend on `rig-core = "0.32"` without conflicting feature flags, resolving to a single copy.
+- **Flaky network-dependent tests**: If any test accidentally calls a real embedding API instead of using the mock, it will fail in environments without network access or API keys. Mitigation: verify all `SemanticRouter` tests use `MockEmbeddingModel`, not a real provider.
+- **Platform-specific compilation**: Floating-point arithmetic in cosine similarity may produce slightly different results on different architectures. Mitigation: tests should use tolerance-based assertions (e.g., `assert!((similarity - expected).abs() < 1e-6)`) rather than exact equality.
+- **Test ordering or state leakage**: Integration tests that modify environment variables (e.g., `EMBEDDING_PROVIDER`) could interfere with each other if run in parallel. Mitigation: config tests should use unique env var names or run with `#[serial]` if needed.
+- **Clippy false positives on generics**: Complex generic bounds on `EmbeddingModel` methods may trigger Clippy suggestions that conflict with rig-core's API design. Mitigation: targeted `#[allow(...)]` attributes with explanatory comments, only if unavoidable.
+
+## Verification
+- `cargo check --workspace` exits with code 0 and produces no error output
+- `cargo clippy --workspace -- -D warnings` exits with code 0 and produces no warning output
+- `cargo test --workspace` exits with code 0, and the summary line shows all tests passing with 0 failures
+- The test output includes results from all six workspace members, confirming none were skipped
+- The test output includes the new test names from `semantic_router_test.rs` (e.g., `exact_intent_match`, `semantic_fallback`, `no_match_below_threshold`, etc.)
+- The test output includes updated tests from `orchestrator_test.rs` and `config_test.rs`
+- No `warning:` lines appear in the compilation output for any file in `crates/orchestrator/src/`

--- a/.claude/specs/issue-16/write-integration-tests-for-semantic-routing-in-orchestrator.md
+++ b/.claude/specs/issue-16/write-integration-tests-for-semantic-routing-in-orchestrator.md
@@ -1,0 +1,201 @@
+# Spec: Write integration tests for semantic routing in `Orchestrator`
+
+> From: .claude/tasks/issue-16.md
+
+## Objective
+
+Add integration tests to `crates/orchestrator/tests/orchestrator_test.rs` that exercise the semantic routing path through `dispatch()`. These tests verify that the `SemanticRouter`, once integrated into `Orchestrator`, correctly routes requests by intent context, by embedding-based cosine similarity, and that it returns `NoRoute` when no agent matches. They also confirm that the existing `target_agent` fast path still takes priority over semantic routing, and that orchestrators constructed without a `SemanticRouter` continue to work as before (backward compatibility).
+
+## Current State
+
+### Existing test file: `crates/orchestrator/tests/orchestrator_test.rs`
+
+The file contains 8 integration tests exercising the orchestrator's dispatch, routing, escalation, health, and MicroAgent trait delegation. Key patterns used:
+
+- **Mock HTTP servers** via `axum`: `start_mock_agent()` spins up a real HTTP server on `127.0.0.1:0` with `/health` and `/invoke` endpoints. The `MockAgentConfig` struct drives the canned responses.
+- **`create_mock_endpoint()`**: Combines the mock server with an `AgentEndpoint`, returning a ready-to-register endpoint.
+- **`build_test_manifest()`**: Returns a minimal `SkillManifest` for orchestrator construction.
+- **`build_success_response()` / `build_escalation_response()`**: Factory helpers for `AgentResponse` instances.
+- **Orchestrator construction**: `Orchestrator::new(manifest, vec![agent1, agent2])` -- currently takes a `SkillManifest` and a `Vec<AgentEndpoint>`. No semantic router is passed.
+- **Routing via context**: All tests use `context: Some(json!({"target_agent": "agent-name"}))` to select the target agent.
+
+### Planned changes from blocking tasks
+
+The "Integrate `SemanticRouter` into `Orchestrator`" task will:
+- Add an `Option<SemanticRouter>` field to `Orchestrator`.
+- Modify `dispatch()` to: (1) try `route_by_target_agent()` exact match, (2) try `SemanticRouter` if present, (3) return `NoRoute`. The `route_by_description_match()` substring heuristic will be removed.
+- The `Orchestrator::new()` signature will change to accept an optional `SemanticRouter`, or a new constructor/builder will be added.
+
+The `SemanticRouter` (from the "Implement `SemanticRouter` struct" task):
+- Constructor: `async fn new<M: EmbeddingModel>(model: &M, agents: Vec<(String, String)>, threshold: f64) -> Result<Self, OrchestratorError>` -- pre-computes description embeddings.
+- Routing: `async fn route<M: EmbeddingModel>(&self, model: &M, request: &AgentRequest) -> Result<String, OrchestratorError>` -- Phase 1: intent exact match from `context.intent`, Phase 2: cosine similarity fallback.
+- The embedding model is passed by reference (not stored), so `dispatch()` in the orchestrator will also need access to the model at call time.
+
+The "Add embedding model configuration to `OrchestratorConfig`" task adds `embedding_provider`, `embedding_model`, and `similarity_threshold` fields to `OrchestratorConfig`. These are not directly used in the integration tests (tests construct the orchestrator manually, not via `from_config()`), but the overall API shape informs how the orchestrator will be assembled.
+
+### `MockEmbeddingModel` strategy (from the unit test task spec)
+
+The "Write unit tests for `SemanticRouter`" task specifies a `MockEmbeddingModel` that maps known strings to fixed embedding vectors:
+- `"financial queries"` -> `[1.0, 0.0, 0.0]`
+- `"weather forecasts"` -> `[0.0, 1.0, 0.0]`
+- `"What are my expenses?"` -> `[0.9, 0.1, 0.0]` (high similarity to financial)
+- `"random gibberish"` -> `[0.3, 0.3, 0.3]` (low similarity to everything)
+
+This mock implements rig-core's `EmbeddingModel` trait, returning deterministic `Embedding` vectors without any network calls.
+
+## Requirements
+
+1. **Intent-based routing through dispatch**: A request with `context: {"intent": "finance-agent"}` dispatched through an orchestrator with a `SemanticRouter` must route to the agent named `"finance-agent"` and return that agent's response. No `target_agent` context key is set.
+
+2. **Semantic similarity routing through dispatch**: A request with input `"What are my expenses?"` and no `intent` or `target_agent` context must be routed to the agent whose description has the highest cosine similarity above threshold (the "financial" agent). The mock HTTP server for that agent must receive the invocation and return its canned response.
+
+3. **NoRoute when no agent matches semantically**: A request with input that produces a low-similarity embedding (e.g., `"random gibberish"`) and no `intent` or `target_agent` context must result in `OrchestratorError::NoRoute` when dispatched through an orchestrator with a `SemanticRouter`.
+
+4. **target_agent takes priority over intent**: A request with both `context: {"target_agent": "agent-a", "intent": "agent-b"}` must route to `"agent-a"` (the `target_agent` fast path in the orchestrator), not `"agent-b"` (the intent path in the `SemanticRouter`). This confirms the orchestrator's routing priority order: target_agent > intent > semantic similarity.
+
+5. **Backward compatibility**: All 8 existing tests must continue to pass without modification. An orchestrator constructed without a `SemanticRouter` (i.e., `None`) must still work with exact `target_agent` matching. This requirement is verified by running the existing tests, not by writing new ones.
+
+## Implementation Details
+
+### File to modify: `crates/orchestrator/tests/orchestrator_test.rs`
+
+### New imports
+
+Add the following imports at the top of the file (exact imports depend on the final `SemanticRouter` and rig-core API):
+
+```rust
+use orchestrator::semantic_router::SemanticRouter;
+use rig_core::embeddings::{Embedding, EmbeddingModel};
+```
+
+### `MockEmbeddingModel` struct
+
+Define a `MockEmbeddingModel` in the test file (or import from a shared test utilities module if the unit test task creates one). The mock should:
+
+- Store a `HashMap<String, Vec<f64>>` mapping known input strings to fixed embedding vectors.
+- Implement rig-core's `EmbeddingModel` trait:
+  - `embed_text(text)` looks up the text in the map; if not found, returns a zero vector (or a low-magnitude default).
+  - `embed_texts(texts)` calls `embed_text` for each.
+  - `ndims()` returns the dimensionality (e.g., 3).
+- Use the same vector assignments from the unit test task:
+  - Agent descriptions: `"Handles financial queries"` -> `[1.0, 0.0, 0.0]`, `"Provides weather forecasts"` -> `[0.0, 1.0, 0.0]`.
+  - Request inputs: `"What are my expenses?"` -> `[0.9, 0.1, 0.0]`, `"random gibberish"` -> `[0.3, 0.3, 0.3]`.
+
+### Helper: `create_semantic_orchestrator()`
+
+Add a helper function that constructs an `Orchestrator` wired with a `SemanticRouter` and mock HTTP agent backends:
+
+```rust
+async fn create_semantic_orchestrator(
+    mock_model: &MockEmbeddingModel,
+    agents: Vec<(&str, &str, HealthStatus, AgentResponse)>,
+) -> Orchestrator {
+    // 1. Create mock HTTP endpoints for each agent
+    // 2. Build (name, description) pairs for SemanticRouter::new()
+    // 3. Construct SemanticRouter with mock_model and threshold 0.7
+    // 4. Construct Orchestrator with the SemanticRouter and AgentEndpoints
+}
+```
+
+The exact signature will adapt to the final `Orchestrator` constructor API. If the orchestrator stores the `SemanticRouter` but needs the model passed to `dispatch()`, the helper should return both the orchestrator and model, or the tests should keep the model in scope.
+
+### Test 1: `dispatch_with_semantic_router_routes_by_intent`
+
+```
+Setup:
+  - Two agents: "finance-agent" (desc: "Handles financial queries") and
+    "weather-agent" (desc: "Provides weather forecasts")
+  - Both healthy, each returns a distinct success response
+  - Orchestrator constructed with SemanticRouter
+Request:
+  - input: "something unrelated"
+  - context: {"intent": "finance-agent"}
+  - No target_agent
+Assert:
+  - dispatch() returns Ok with finance-agent's response
+```
+
+### Test 2: `dispatch_with_semantic_router_routes_by_similarity`
+
+```
+Setup:
+  - Same two agents as Test 1
+  - Orchestrator constructed with SemanticRouter
+Request:
+  - input: "What are my expenses?"
+  - context: None (or empty, no target_agent, no intent)
+Assert:
+  - dispatch() returns Ok with finance-agent's response
+  - (The mock embedding for this input has highest cosine similarity to
+    the financial agent's description embedding)
+```
+
+### Test 3: `dispatch_with_semantic_router_returns_no_route`
+
+```
+Setup:
+  - Same two agents as Test 1
+  - Orchestrator constructed with SemanticRouter (threshold 0.7)
+Request:
+  - input: "random gibberish"
+  - context: None
+Assert:
+  - dispatch() returns Err(OrchestratorError::NoRoute { .. })
+  - (The mock embedding [0.3, 0.3, 0.3] has cosine similarity below 0.7
+    against both [1.0, 0.0, 0.0] and [0.0, 1.0, 0.0])
+```
+
+### Test 4: `dispatch_with_semantic_router_prefers_target_agent_over_intent`
+
+```
+Setup:
+  - Two agents: "agent-a" and "agent-b", both healthy, distinct responses
+  - Orchestrator constructed with SemanticRouter
+Request:
+  - input: "test"
+  - context: {"target_agent": "agent-a", "intent": "agent-b"}
+Assert:
+  - dispatch() returns Ok with agent-a's response
+  - (target_agent takes priority in the orchestrator's routing chain,
+    before the SemanticRouter is even consulted)
+```
+
+### Test 5: Backward compatibility (no new test needed)
+
+The existing 8 tests already verify that an orchestrator without a `SemanticRouter` works correctly. After the "Integrate `SemanticRouter`" task modifies `Orchestrator::new()`, those tests must continue to pass by constructing the orchestrator without a semantic router (passing `None` or using a backward-compatible constructor). If the constructor signature changes, the existing tests will need a minimal update (e.g., adding `None` for the semantic router parameter), but the test logic and assertions remain unchanged.
+
+**Important**: If the `Orchestrator::new()` signature changes to require an `Option<SemanticRouter>`, the 8 existing test calls to `Orchestrator::new(manifest, agents)` will need to become `Orchestrator::new(manifest, agents, None)` (or equivalent). This is a mechanical change, not a logic change. Document this as part of the integration task, not this test task.
+
+### Embedding model lifetime consideration
+
+The `SemanticRouter::route()` method takes `&M` where `M: EmbeddingModel`. The `Orchestrator::dispatch()` method is `async fn dispatch(&self, request)`. The integration task will need to decide how the model is threaded through. Two likely patterns:
+
+- **Option A**: The `Orchestrator` stores a `Box<dyn EmbeddingModel>` (not possible -- the trait is not dyn-compatible per implementation notes).
+- **Option B**: The `Orchestrator` stores an `Option<SemanticRouter>` and `dispatch()` gains a generic model parameter or the model is stored via type erasure.
+- **Option C**: A new `dispatch_with_model<M>(&self, model: &M, request)` method is added, and `dispatch()` only does exact matching.
+
+The tests must align with whichever pattern the integration task chooses. The spec describes the test intent; exact method signatures will be adapted during implementation.
+
+## Dependencies
+
+- **Blocked by**:
+  - "Integrate `SemanticRouter` into `Orchestrator`" -- the `Orchestrator` must accept and use a `SemanticRouter` for the new tests to compile
+  - "Add embedding model configuration to `OrchestratorConfig`" -- while tests construct manually (not via config), the overall API design from this task influences constructor signatures
+- **Blocking**: Nothing (non-blocking task)
+
+## Risks & Edge Cases
+
+- **rig-core `EmbeddingModel` trait instability**: The mock must implement rig-core 0.32's `EmbeddingModel` trait exactly. If the trait has associated types, default methods, or async-fn-in-trait constraints that are hard to mock, the `MockEmbeddingModel` may need careful construction. Mitigation: review the exact trait definition in rig-core 0.32 before implementing.
+- **Cosine similarity edge cases**: The mock vectors are chosen so that similarity results are deterministic and clearly above or below threshold. For example, `cosine_similarity([0.9, 0.1, 0.0], [1.0, 0.0, 0.0])` is approximately 0.994 (well above 0.7), and `cosine_similarity([0.3, 0.3, 0.3], [1.0, 0.0, 0.0])` is approximately 0.577 (below 0.7). These values should be verified during implementation.
+- **Constructor signature changes**: If `Orchestrator::new()` changes its signature (e.g., adding an `Option<SemanticRouter>` parameter), the 8 existing tests will need a mechanical update. This is expected and documented above. The key risk is that the integration task's constructor design is not finalized when this test task begins. Mitigation: this task is blocked by the integration task.
+- **Async test ordering**: Tests that share no state are independent. The mock HTTP servers bind to random ports, so there is no port conflict risk. No shared mutable state exists between tests.
+- **Model lifetime across async boundaries**: The `MockEmbeddingModel` must live long enough for `dispatch()` to complete. Since it is created at the start of each test and the test awaits `dispatch()`, this is straightforward. If the orchestrator stores a reference to the model, the test must ensure the model outlives the orchestrator. Likely the model is passed per-call, making this a non-issue.
+- **Removing `route_by_description_match()`**: The integration task removes the substring heuristic. The existing `dispatch_returns_no_route` test currently triggers `NoRoute` by specifying a nonexistent `target_agent`. With the heuristic removed, an orchestrator without a `SemanticRouter` will always return `NoRoute` when `target_agent` doesn't match -- this is fine since the existing test already uses a nonexistent target. However, if any existing test relied on the substring heuristic (none currently do), it would break.
+
+## Verification
+
+- `cargo test -p orchestrator` passes with all 8 existing tests and all 4 new tests green.
+- `cargo clippy -p orchestrator` produces no warnings in the test file.
+- Each new test is independent and can be run individually via `cargo test -p orchestrator <test_name>`.
+- The 4 new tests cover the 4 specified routing scenarios: intent routing, similarity routing, no-match, and priority ordering.
+- Backward compatibility is confirmed by the 8 existing tests continuing to pass unchanged (or with only mechanical constructor signature updates).

--- a/.claude/specs/issue-16/write-unit-tests-for-config-embedding-fields.md
+++ b/.claude/specs/issue-16/write-unit-tests-for-config-embedding-fields.md
@@ -1,0 +1,125 @@
+# Spec: Write unit tests for config embedding fields
+
+> From: .claude/tasks/issue-16.md
+
+## Objective
+Add unit tests to `crates/orchestrator/tests/config_test.rs` that verify the new optional embedding configuration fields (`embedding_provider`, `embedding_model`, `similarity_threshold`) parse correctly from both YAML files and environment variables. These tests ensure the config layer correctly handles the presence, absence, and invalid values of embedding settings without breaking existing agent configuration parsing.
+
+## Current State
+
+### Existing config structure (`crates/orchestrator/src/config.rs`)
+- `OrchestratorConfig` has a single field: `agents: Vec<AgentConfig>`.
+- `AgentConfig` has fields: `name`, `description`, `url` (all `String`).
+- `from_file(path)` reads and deserializes YAML via `serde_yaml`.
+- `from_env()` reads `AGENT_ENDPOINTS` (required) and `AGENT_DESCRIPTIONS` (optional) env vars, parsing comma-separated `key=value` pairs.
+
+### Existing test patterns (`crates/orchestrator/tests/config_test.rs`)
+- Uses a static `ENV_LOCK: Mutex<()>` to serialize env-mutating tests.
+- `with_env_vars` helper sets env vars, runs a closure, then restores originals. Uses `unsafe` env set/remove under the mutex guard.
+- YAML tests write temp files to `std::env::temp_dir()`, parse with `from_file()`, assert fields, then clean up.
+- Env tests use `with_env_vars` wrapping `OrchestratorConfig::from_env`.
+- Error cases assert on `OrchestratorError::Config { .. }` variant via `matches!`.
+
+### Blocking dependency
+The "Add embedding model configuration to `OrchestratorConfig`" task will add three new optional fields to `OrchestratorConfig`:
+- `embedding_provider: Option<String>` (e.g., `"openai"`)
+- `embedding_model: Option<String>` (e.g., `"text-embedding-3-small"`)
+- `similarity_threshold: Option<f64>` (defaults to 0.7 when not specified)
+
+For env-based config, these will be read from `EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`, and `SIMILARITY_THRESHOLD` env vars. All three are optional -- absence means `None`, not an error.
+
+## Requirements
+
+1. **YAML with embedding settings parses correctly**: A YAML file containing `embedding_provider`, `embedding_model`, and `similarity_threshold` alongside the `agents` list must parse into an `OrchestratorConfig` with all fields populated. Assert each embedding field has the expected `Some(value)`.
+
+2. **YAML without embedding settings still parses**: An existing-style YAML file with only `agents` (no embedding keys) must still parse successfully. Assert all three embedding fields are `None`. This confirms backward compatibility of the YAML format.
+
+3. **Env-based config reads `EMBEDDING_PROVIDER` and `EMBEDDING_MODEL`**: When `EMBEDDING_PROVIDER` and `EMBEDDING_MODEL` env vars are set alongside `AGENT_ENDPOINTS`, `from_env()` must return a config where `embedding_provider` and `embedding_model` are `Some(...)` with the correct values.
+
+4. **`SIMILARITY_THRESHOLD` env var parses as f64**: When `SIMILARITY_THRESHOLD` is set to a valid float string (e.g., `"0.85"`), `from_env()` must return `similarity_threshold` as `Some(0.85_f64)`. The parsed value must be exactly the expected float.
+
+5. **Missing embedding env vars result in `None`**: When `EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`, and `SIMILARITY_THRESHOLD` are all absent (unset), `from_env()` must still succeed (given valid `AGENT_ENDPOINTS`) and all three embedding fields must be `None`.
+
+6. **Invalid `SIMILARITY_THRESHOLD` returns an error**: When `SIMILARITY_THRESHOLD` is set to a non-numeric string (e.g., `"not_a_number"`), `from_env()` must return `Err(OrchestratorError::Config { .. })`.
+
+7. **Partial embedding env vars are valid**: Setting only `EMBEDDING_PROVIDER` without `EMBEDDING_MODEL` (or vice versa) must not cause an error. Each field is independently optional.
+
+## Implementation Details
+
+### File to modify
+- `crates/orchestrator/tests/config_test.rs`
+
+### New test functions to add
+
+**`yaml_config_with_embedding_settings_parses_correctly`**
+- Write a YAML string containing `agents` plus `embedding_provider: openai`, `embedding_model: text-embedding-3-small`, `similarity_threshold: 0.85`.
+- Write to a temp file, parse with `from_file()`.
+- Assert `config.embedding_provider` is `Some("openai".to_string())`.
+- Assert `config.embedding_model` is `Some("text-embedding-3-small".to_string())`.
+- Assert `config.similarity_threshold` is `Some(0.85)`.
+- Also assert `config.agents` still parses correctly (at least check length).
+- Clean up temp dir.
+
+**`yaml_config_without_embedding_settings_parses`**
+- Use an existing-format YAML with only `agents: []` or a populated agents list.
+- Parse with `from_file()`, assert it succeeds.
+- Assert `config.embedding_provider.is_none()`.
+- Assert `config.embedding_model.is_none()`.
+- Assert `config.similarity_threshold.is_none()`.
+- Note: The existing `empty_agents_list_is_valid` test partially covers this, but this test explicitly asserts the embedding fields are `None`.
+
+**`env_config_reads_embedding_provider_and_model`**
+- Use `with_env_vars` to set `AGENT_ENDPOINTS`, `AGENT_DESCRIPTIONS`, `EMBEDDING_PROVIDER` (e.g., `"openai"`), and `EMBEDDING_MODEL` (e.g., `"text-embedding-3-small"`).
+- Clear `SIMILARITY_THRESHOLD` (set to `None`).
+- Call `OrchestratorConfig::from_env()`.
+- Assert `config.embedding_provider` is `Some("openai".to_string())`.
+- Assert `config.embedding_model` is `Some("text-embedding-3-small".to_string())`.
+- Assert `config.similarity_threshold.is_none()`.
+
+**`env_config_parses_similarity_threshold_as_f64`**
+- Use `with_env_vars` to set `AGENT_ENDPOINTS`, `SIMILARITY_THRESHOLD` to `"0.85"`.
+- Clear `EMBEDDING_PROVIDER` and `EMBEDDING_MODEL` (set to `None`).
+- Call `OrchestratorConfig::from_env()`.
+- Assert `config.similarity_threshold` is `Some(0.85_f64)`.
+- Use `assert!((val - 0.85).abs() < f64::EPSILON)` or `assert_eq!` depending on parsing exactness.
+
+**`missing_embedding_env_vars_result_in_none`**
+- Use `with_env_vars` to set only `AGENT_ENDPOINTS` and `AGENT_DESCRIPTIONS`. Explicitly clear `EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`, and `SIMILARITY_THRESHOLD` (all `None`).
+- Call `OrchestratorConfig::from_env()`.
+- Assert all three embedding fields are `None`.
+- Assert agents still parse correctly.
+
+**`invalid_similarity_threshold_returns_error`**
+- Use `with_env_vars` to set `AGENT_ENDPOINTS` and `SIMILARITY_THRESHOLD` to `"not_a_number"`.
+- Call `OrchestratorConfig::from_env()`.
+- Assert result is `Err`.
+- Assert error matches `OrchestratorError::Config { .. }`.
+
+**`partial_embedding_env_vars_are_valid`**
+- Use `with_env_vars` to set `AGENT_ENDPOINTS` and `EMBEDDING_PROVIDER` (e.g., `"openai"`), but clear `EMBEDDING_MODEL` and `SIMILARITY_THRESHOLD`.
+- Call `OrchestratorConfig::from_env()`.
+- Assert `config.embedding_provider` is `Some("openai".to_string())`.
+- Assert `config.embedding_model.is_none()`.
+- Assert `config.similarity_threshold.is_none()`.
+
+### Patterns to follow
+- Each YAML test: create a unique temp dir (e.g., `orchestrator_test_<test_name>`), write YAML, parse, assert, clean up.
+- Each env test: wrap in `with_env_vars`, explicitly list all relevant env vars (including clearing the ones not under test), call `from_env()`.
+- Error assertions: use `matches!(err, OrchestratorError::Config { .. })` pattern.
+- No new dependencies or helper functions needed beyond the existing `with_env_vars`.
+
+## Dependencies
+- Blocked by: "Add embedding model configuration to `OrchestratorConfig`" (the fields being tested do not exist yet)
+- Blocking: Nothing (non-blocking)
+
+## Risks & Edge Cases
+- **Float precision**: Parsing `"0.85"` from a string should yield exactly `0.85_f64` since `f64::from_str("0.85")` is deterministic, but tests should be written to tolerate minor floating-point issues if needed.
+- **Env var leakage between tests**: The existing `ENV_LOCK` mutex and `with_env_vars` restore mechanism prevent this. New tests must include all embedding env vars in their `with_env_vars` call (setting unused ones to `None`) to avoid inheriting state from a prior test that crashed before cleanup.
+- **serde default behavior**: The `OrchestratorConfig` fields must use `#[serde(default)]` or be `Option<T>` for YAML backward compatibility. Tests in this spec validate that serde handles the missing-field case correctly.
+- **`SIMILARITY_THRESHOLD` as empty string**: An empty string for a float env var could parse as `None` or error depending on implementation. The spec does not require a test for this edge case, but implementers should be aware.
+
+## Verification
+- `cargo test --package orchestrator --test config_test` passes with all new and existing tests green.
+- `cargo clippy --package orchestrator` reports no new warnings in the test file.
+- All seven new test functions appear in the test output and pass.
+- Existing tests (`yaml_config_parses_correctly`, `empty_agents_list_is_valid`, `malformed_yaml_returns_error`, `env_config_parses_agent_endpoints`, `missing_env_var_returns_error`) continue to pass unchanged.

--- a/.claude/specs/issue-16/write-unit-tests-for-semantic-router.md
+++ b/.claude/specs/issue-16/write-unit-tests-for-semantic-router.md
@@ -1,0 +1,327 @@
+# Spec: Write unit tests for `SemanticRouter`
+
+> From: .claude/tasks/issue-16.md
+
+## Objective
+
+Create an integration test file that exercises all public methods of `SemanticRouter` (`new`, `route`, `register`) using a deterministic mock `EmbeddingModel`. These tests verify the two-phase routing logic (exact intent match, then cosine similarity fallback), error conditions, and edge cases without requiring a real embedding API provider. This is the primary correctness validation for the core semantic routing algorithm.
+
+## Current State
+
+- **`SemanticRouter` does not exist yet.** It will be implemented in `crates/orchestrator/src/semantic_router.rs` by the prerequisite task "Implement `SemanticRouter` struct with two-phase routing." The spec for that task (`implement-semantic-router-struct-with-two-phase-routing.md`) defines the public API:
+  - `async fn new<M: EmbeddingModel>(model: &M, agents: Vec<(String, String)>, threshold: f64) -> Result<Self, OrchestratorError>`
+  - `async fn route<M: EmbeddingModel>(&self, model: &M, request: &AgentRequest) -> Result<String, OrchestratorError>`
+  - `async fn register<M: EmbeddingModel>(&mut self, model: &M, name: String, description: String) -> Result<(), OrchestratorError>`
+
+- **`OrchestratorError`** (in `crates/orchestrator/src/error.rs`): Currently has `NoRoute { input: String }`, `AgentUnavailable`, `EscalationFailed`, `HttpError`, and `Config` variants. A prerequisite task will add `EmbeddingError { reason: String }`.
+
+- **`AgentRequest`** (in `crates/agent-sdk/src/agent_request.rs`): Has fields `id: Uuid`, `input: String`, `context: Option<serde_json::Value>`, `caller: Option<String>`. Has a `new(input: String)` constructor.
+
+- **rig-core 0.32 `EmbeddingModel` trait:**
+  ```rust
+  pub trait EmbeddingModel: Send + Sync {
+      const MAX_DOCUMENTS: usize;
+      type Client;
+      fn make(client: &Self::Client, model: impl Into<String>, dims: Option<usize>) -> Self;
+      fn ndims(&self) -> usize;
+      fn embed_texts(
+          &self,
+          texts: impl IntoIterator<Item = String> + Send,
+      ) -> impl Future<Output = Result<Vec<Embedding>, EmbeddingError>> + Send;
+      fn embed_text(
+          &self,
+          text: &str,
+      ) -> impl Future<Output = Result<Embedding, EmbeddingError>> + Send { /* default impl */ }
+  }
+  ```
+  `Embedding` struct: `{ document: String, vec: Vec<f64> }`.
+
+- **rig-core `VectorDistance` trait** (implemented for `Embedding`): Provides `cosine_similarity(&self, other: &Self, normalized: bool) -> f64`. With `normalized: false`, computes `dot_product / (magnitude1 * magnitude2)`.
+
+- **Existing test patterns** (from `orchestrator_test.rs`, `error_test.rs`, `config_test.rs`):
+  - Integration tests live in `crates/orchestrator/tests/`.
+  - Async tests use `#[tokio::test]` with `tokio` in dev-dependencies (features: `macros`, `rt`, `net`).
+  - Tests construct types directly and assert on return values.
+  - Error matching uses `match` or `matches!()` with pattern destructuring.
+  - No mocking framework -- mocks are hand-written structs.
+  - Assertion messages provide context via custom `panic!` messages or `assert!` with format strings.
+
+- **Orchestrator `Cargo.toml` dev-dependencies:**
+  ```toml
+  [dev-dependencies]
+  tokio = { version = "1", features = ["macros", "rt", "net"] }
+  axum = "0.8"
+  uuid = { version = "1", features = ["v4"] }
+  ```
+  After the prerequisite tasks complete, `rig-core` will be in `[dependencies]`, making it available in integration tests.
+
+## Requirements
+
+### 1. `MockEmbeddingModel` struct
+
+Create a `MockEmbeddingModel` struct in the test file that implements rig-core's `EmbeddingModel` trait. It must:
+
+- Store a `HashMap<String, Vec<f64>>` mapping known input strings to fixed embedding vectors.
+- In `embed_text`/`embed_texts`, look up the input string in the map. If found, return the corresponding vector as an `Embedding`. If not found, return a default "unknown" vector (e.g., `[0.0, 0.0, 0.0]`) rather than an error -- this keeps test setup simpler.
+- Be `Send + Sync` (required by `EmbeddingModel`). Using `HashMap` is fine since the mock is immutable after construction.
+- Implement all required associated items: `MAX_DOCUMENTS`, `type Client`, `make()`, `ndims()`, and `embed_texts()`. The `make()` and `Client` type are not used in tests but must exist for trait satisfaction.
+
+### 2. Deterministic embedding vectors
+
+Use 3-dimensional embedding vectors for simplicity. The mock maps these known strings to fixed vectors:
+
+| String | Vector | Purpose |
+|--------|--------|---------|
+| `"Handles financial queries"` | `[1.0, 0.0, 0.0]` | Finance agent description |
+| `"Handles weather forecasts"` | `[0.0, 1.0, 0.0]` | Weather agent description |
+| `"Handles travel bookings"` | `[0.0, 0.0, 1.0]` | Travel agent description (for multi-agent test) |
+| `"What are my expenses?"` | `[0.9, 0.1, 0.0]` | Input with high similarity to finance |
+| `"Will it rain tomorrow?"` | `[0.1, 0.9, 0.0]` | Input with high similarity to weather |
+| `"random gibberish"` | `[0.33, 0.33, 0.33]` | Input with low similarity to all agents |
+| `"Book a flight to Paris"` | `[0.05, 0.05, 0.95]` | Input with high similarity to travel |
+| `"Handles sports news"` | `[0.5, 0.5, 0.0]` | New agent description (for register test) |
+| `"Latest soccer scores"` | `[0.45, 0.55, 0.0]` | Input with high similarity to sports (for register test) |
+
+**Cosine similarity verification** (to confirm test vectors produce expected routing):
+- `cos([0.9, 0.1, 0.0], [1.0, 0.0, 0.0])` = 0.9 / (sqrt(0.82) * 1.0) = 0.9 / 0.9055 ~ 0.9939 (well above 0.7 threshold)
+- `cos([0.33, 0.33, 0.33], [1.0, 0.0, 0.0])` = 0.33 / (sqrt(0.3267) * 1.0) = 0.33 / 0.5716 ~ 0.5774 (below 0.7 threshold)
+- `cos([0.33, 0.33, 0.33], [0.0, 1.0, 0.0])` = 0.33 / 0.5716 ~ 0.5774 (below 0.7 threshold)
+- `cos([0.9, 0.1, 0.0], [0.0, 1.0, 0.0])` = 0.1 / 0.9055 ~ 0.1104 (correctly low)
+
+### 3. Test case: exact intent match
+
+Test name: `route_by_exact_intent_match`
+- Create a `SemanticRouter` with two agents: `("finance-agent", "Handles financial queries")` and `("weather-agent", "Handles weather forecasts")`.
+- Build an `AgentRequest` with `context: Some(json!({"intent": "finance-agent"}))` and any input text.
+- Call `router.route(&mock_model, &request).await`.
+- Assert the result is `Ok("finance-agent")`.
+- This exercises Phase 1 (intent match). The input text does not matter because intent match short-circuits.
+
+### 4. Test case: semantic fallback via cosine similarity
+
+Test name: `route_by_semantic_similarity`
+- Create a `SemanticRouter` with the same two agents.
+- Build an `AgentRequest` with no `context` (or context without `"intent"`) and input `"What are my expenses?"`.
+- Call `router.route(&mock_model, &request).await`.
+- Assert the result is `Ok("finance-agent")`.
+- This exercises Phase 2. The input embedding `[0.9, 0.1, 0.0]` has highest cosine similarity to the finance agent's `[1.0, 0.0, 0.0]`.
+
+### 5. Test case: no match below threshold
+
+Test name: `route_returns_no_route_below_threshold`
+- Create a `SemanticRouter` with the two agents and threshold `0.7`.
+- Build an `AgentRequest` with input `"random gibberish"` and no intent context.
+- Call `router.route(&mock_model, &request).await`.
+- Assert the result is `Err(OrchestratorError::NoRoute { .. })`.
+- The embedding `[0.33, 0.33, 0.33]` has cosine similarity ~0.577 to all agents, below 0.7.
+
+### 6. Test case: multiple agents routes to highest scorer
+
+Test name: `route_selects_highest_scoring_agent`
+- Create a `SemanticRouter` with three agents: `finance-agent`, `weather-agent`, and `travel-agent`.
+- Build an `AgentRequest` with input `"Book a flight to Paris"` and no intent context.
+- Call `router.route(&mock_model, &request).await`.
+- Assert the result is `Ok("travel-agent")`.
+- The embedding `[0.05, 0.05, 0.95]` has highest similarity to travel's `[0.0, 0.0, 1.0]`, not to finance or weather.
+
+### 7. Test case: empty agents list returns NoRoute
+
+Test name: `route_returns_no_route_for_empty_agents`
+- Create a `SemanticRouter` with an empty agents vec.
+- Build an `AgentRequest` with any input and no intent context.
+- Call `router.route(&mock_model, &request).await`.
+- Assert the result is `Err(OrchestratorError::NoRoute { .. })`.
+
+### 8. Test case: register adds a routable agent
+
+Test name: `register_makes_agent_routable`
+- Create a `SemanticRouter` with an empty agents vec.
+- Call `router.register(&mock_model, "sports-agent".into(), "Handles sports news".into()).await`.
+- Assert the result is `Ok(())`.
+- Build an `AgentRequest` with input `"Latest soccer scores"` and no intent.
+- Call `router.route(&mock_model, &request).await`.
+- Assert the result is `Ok("sports-agent")`.
+
+### 9. Test case: case-insensitive intent matching
+
+Test name: `route_intent_matching_is_case_insensitive`
+- Create a `SemanticRouter` with `("finance-agent", "Handles financial queries")`.
+- Build an `AgentRequest` with `context: Some(json!({"intent": "Finance-Agent"}))` (mixed case).
+- Call `router.route(&mock_model, &request).await`.
+- Assert the result is `Ok("finance-agent")` (returns the original-case name from the profile, not the lowercased intent).
+
+## Implementation Details
+
+### File to create
+
+**`crates/orchestrator/tests/semantic_router_test.rs`**
+
+### Imports
+
+```rust
+use std::collections::HashMap;
+
+use agent_sdk::AgentRequest;
+use orchestrator::error::OrchestratorError;
+use orchestrator::semantic_router::SemanticRouter;
+use rig::embeddings::embedding::{Embedding, EmbeddingError, EmbeddingModel};
+use serde_json::json;
+```
+
+Note on rig-core import paths: The exact paths must be verified at implementation time. rig-core is imported as `rig-core` in `Cargo.toml` but the crate name in Rust is `rig` (based on `agent-runtime/src/provider.rs` using `use rig::...`). The `Embedding`, `EmbeddingModel`, and `EmbeddingError` types are in `rig::embeddings::embedding`. The `VectorDistance` trait (used internally by `SemanticRouter`, not by the tests) is in `rig::embeddings::distance`.
+
+### `MockEmbeddingModel` definition
+
+```rust
+struct MockEmbeddingModel {
+    embeddings: HashMap<String, Vec<f64>>,
+    ndims: usize,
+}
+
+impl MockEmbeddingModel {
+    fn new(embeddings: HashMap<String, Vec<f64>>, ndims: usize) -> Self {
+        Self { embeddings, ndims }
+    }
+}
+
+impl EmbeddingModel for MockEmbeddingModel {
+    const MAX_DOCUMENTS: usize = 100;
+    type Client = ();
+
+    fn make(_client: &Self::Client, _model: impl Into<String>, _dims: Option<usize>) -> Self {
+        panic!("MockEmbeddingModel::make is not used in tests")
+    }
+
+    fn ndims(&self) -> usize {
+        self.ndims
+    }
+
+    async fn embed_texts(
+        &self,
+        texts: impl IntoIterator<Item = String> + Send,
+    ) -> Result<Vec<Embedding>, EmbeddingError> {
+        let results = texts
+            .into_iter()
+            .map(|text| {
+                let vec = self
+                    .embeddings
+                    .get(&text)
+                    .cloned()
+                    .unwrap_or_else(|| vec![0.0; self.ndims]);
+                Embedding {
+                    document: text,
+                    vec,
+                }
+            })
+            .collect();
+        Ok(results)
+    }
+}
+```
+
+Key design decisions for the mock:
+- Unknown strings return a zero vector rather than an error. This avoids needing to pre-register every possible input string and makes test setup more forgiving. The zero vector has cosine similarity of `NaN` (0 / 0) with non-zero vectors, which evaluates to `false` in `>` comparisons, so it will never match. (Actually, rig-core's cosine_similarity with a zero-magnitude vector: magnitude is 0.0, so division by zero produces `NaN` or `inf`. The `>` comparison with `NaN` is always `false`, so no route will match, which is safe.)
+- The `make()` method panics because it is never called in these tests (the mock is constructed directly).
+- The mock is `Send + Sync` because `HashMap` is `Send + Sync` when keys and values are.
+
+### Helper function for building the mock
+
+```rust
+fn build_test_model() -> MockEmbeddingModel {
+    let mut embeddings = HashMap::new();
+    embeddings.insert("Handles financial queries".into(), vec![1.0, 0.0, 0.0]);
+    embeddings.insert("Handles weather forecasts".into(), vec![0.0, 1.0, 0.0]);
+    embeddings.insert("Handles travel bookings".into(), vec![0.0, 0.0, 1.0]);
+    embeddings.insert("What are my expenses?".into(), vec![0.9, 0.1, 0.0]);
+    embeddings.insert("Will it rain tomorrow?".into(), vec![0.1, 0.9, 0.0]);
+    embeddings.insert("random gibberish".into(), vec![0.33, 0.33, 0.33]);
+    embeddings.insert("Book a flight to Paris".into(), vec![0.05, 0.05, 0.95]);
+    embeddings.insert("Handles sports news".into(), vec![0.5, 0.5, 0.0]);
+    embeddings.insert("Latest soccer scores".into(), vec![0.45, 0.55, 0.0]);
+    MockEmbeddingModel::new(embeddings, 3)
+}
+```
+
+### Helper function for building requests
+
+```rust
+fn build_request(input: &str, context: Option<serde_json::Value>) -> AgentRequest {
+    AgentRequest {
+        id: uuid::Uuid::new_v4(),
+        input: input.to_string(),
+        context,
+        caller: None,
+    }
+}
+```
+
+### Test function signatures
+
+All tests are `#[tokio::test] async fn`. Each test constructs the mock model via `build_test_model()`, builds a `SemanticRouter` via `SemanticRouter::new(&model, agents, threshold).await.unwrap()`, then exercises `route()` or `register()`.
+
+Error assertions use `match` with pattern destructuring (consistent with `orchestrator_test.rs` style):
+```rust
+match result.unwrap_err() {
+    OrchestratorError::NoRoute { .. } => {}
+    other => panic!("expected NoRoute, got: {:?}", other),
+}
+```
+
+### No changes to other files
+
+This task only creates the new test file. It does not modify `Cargo.toml` (rig-core will already be in dependencies and the existing dev-dependencies are sufficient), `lib.rs`, or any source files.
+
+## Dependencies
+
+- **Blocked by:**
+  - "Implement `SemanticRouter` struct with two-phase routing" -- the `SemanticRouter` type, its `new()`, `route()`, and `register()` methods must exist for the tests to compile.
+  - "Add `rig-core` dependency to orchestrator `Cargo.toml`" -- the test file imports `rig::embeddings::embedding::{Embedding, EmbeddingError, EmbeddingModel}`, which requires rig-core in dependencies.
+  - "Add `EmbeddingError` variant to `OrchestratorError`" -- the no-route tests assert against `OrchestratorError::NoRoute` and some tests may produce `OrchestratorError::EmbeddingError`.
+  - The `semantic_router` module must be declared as `pub mod semantic_router;` in `crates/orchestrator/src/lib.rs` (done by the integration task) so that `orchestrator::semantic_router::SemanticRouter` is accessible from integration tests.
+- **Blocking:**
+  - "Run verification suite" -- the verification task depends on all tests existing and passing.
+
+## Risks & Edge Cases
+
+1. **rig-core import paths.** The exact Rust import paths for `Embedding`, `EmbeddingModel`, and `EmbeddingError` may differ from what is shown. rig-core re-exports types through its module hierarchy, and the crate name resolves to `rig` (not `rig_core`) based on how `agent-runtime` uses it. The implementer must verify paths by checking compilation or `cargo doc` output. Likely alternatives: `rig::embeddings::Embedding`, `rig::embeddings::EmbeddingModel`, `rig::embeddings::EmbeddingError`.
+
+2. **`EmbeddingModel` trait associated types.** The `EmbeddingModel` trait has `type Client` and `fn make(client: &Self::Client, ...)`. The mock must provide both, but they are never called in tests. Using `type Client = ()` and a panicking `make()` is sufficient.
+
+3. **`embed_texts` return type.** The `embed_texts` method receives `impl IntoIterator<Item = String> + Send`. The mock's implementation must handle this generic parameter. Using `.into_iter()` to iterate and collect into `Vec<Embedding>` is straightforward.
+
+4. **`async fn` in trait impl.** rig-core 0.32's `EmbeddingModel` trait declares `embed_texts` as returning `impl Future<...>`. In Rust 2024 edition (which the orchestrator crate uses per `edition = "2024"` in Cargo.toml), `async fn` in trait impls is stabilized, so the mock can use `async fn embed_texts(...)` directly. If the rig-core trait uses `impl Future` return syntax instead of `async fn`, the implementer should verify that `async fn` in the impl block satisfies the trait bound.
+
+5. **Zero-vector cosine similarity.** If an unknown input string is embedded (returning `[0.0, 0.0, 0.0]`), the cosine similarity computation will involve division by zero. In rig-core's implementation, `magnitude1` will be `0.0`, producing `NaN`. The comparison `NaN > threshold` is `false`, so no agent will match and `NoRoute` will be returned. This is safe behavior.
+
+6. **Floating-point precision.** The test vectors are chosen so that similarity scores are clearly above or below the 0.7 threshold, avoiding boundary precision issues. The closest to the boundary is `cos([0.33, 0.33, 0.33], [1.0, 0.0, 0.0]) ~ 0.577`, which has a comfortable margin below 0.7.
+
+7. **Threshold comparison strictness.** The `SemanticRouter` uses strict `>` (not `>=`) for threshold comparison. Test vectors are designed with this in mind -- no test relies on a score being exactly equal to the threshold.
+
+8. **`pub mod semantic_router` visibility.** The test file imports `orchestrator::semantic_router::SemanticRouter`. This requires `semantic_router` to be declared as a `pub mod` in `crates/orchestrator/src/lib.rs`. If the integration task that adds this module declaration is not yet complete, the test file will fail to compile. The dependency graph ensures the integration task completes first, but the implementer should be aware of this ordering requirement.
+
+9. **Mock returns original case for intent match.** The case-insensitive intent test asserts that the returned name is the original `"finance-agent"` (as stored in the `AgentProfile`), not the lowercased version from the request context. This verifies that the router preserves the canonical agent name.
+
+## Verification
+
+After implementation (and after all blocking prerequisite tasks are complete), run:
+
+```bash
+cargo test -p orchestrator --test semantic_router_test
+cargo clippy -p orchestrator --tests
+```
+
+Specifically, confirm these 7 tests exist and pass:
+
+- `semantic_router_test::route_by_exact_intent_match`
+- `semantic_router_test::route_by_semantic_similarity`
+- `semantic_router_test::route_returns_no_route_below_threshold`
+- `semantic_router_test::route_selects_highest_scoring_agent`
+- `semantic_router_test::route_returns_no_route_for_empty_agents`
+- `semantic_router_test::register_makes_agent_routable`
+- `semantic_router_test::route_intent_matching_is_case_insensitive`
+
+Additionally verify:
+- The `MockEmbeddingModel` compiles and satisfies the `EmbeddingModel` trait bound.
+- No warnings from `cargo clippy`.
+- No commented-out code or debug statements in the test file.
+- All existing orchestrator tests (`orchestrator_test`, `error_test`, `config_test`, `agent_endpoint_test`) still pass -- no regressions.

--- a/.claude/specs/issue-17/add-cycle-detection-test.md
+++ b/.claude/specs/issue-17/add-cycle-detection-test.md
@@ -1,0 +1,96 @@
+# Spec: Add cycle detection test
+> From: .claude/tasks/issue-17.md
+
+## Objective
+Add an integration test `dispatch_returns_escalation_failed_on_cycle` to `crates/orchestrator/tests/orchestrator_test.rs` that verifies the orchestrator detects and rejects escalation cycles (agent A escalates to agent B, agent B escalates back to agent A).
+
+## Current State
+- The orchestrator already implements cycle detection in `Orchestrator::validate_no_cycle` (`crates/orchestrator/src/orchestrator.rs`, lines 231-243). It checks whether `target_name` already exists in the escalation `chain` and returns `OrchestratorError::EscalationFailed` with a reason containing `"cycle detected"`.
+- The existing test `dispatch_returns_escalation_failed_on_depth` (lines 323-380 in the test file) validates the *depth* limit using the same `EscalationFailed` variant but with `"max escalation depth"` in the reason string. The new test is structurally similar but exercises the *cycle* guard instead.
+- Helper functions `create_mock_endpoint`, `build_escalation_response`, `build_success_response`, `build_test_manifest`, and the `MockAgentConfig` / `start_mock_agent` infrastructure are already available in the test file.
+
+## Requirements
+1. Create a `#[tokio::test]` named `dispatch_returns_escalation_failed_on_cycle`.
+2. Stand up two mock agents:
+   - `"agent-a"` -- returns an escalation response targeting `"agent-b"`.
+   - `"agent-b"` -- returns an escalation response targeting `"agent-a"`.
+3. Construct an `Orchestrator` with both agents (no semantic router).
+4. Build an `AgentRequest` with `context: Some(json!({"target_agent": "agent-a"}))` so routing sends the initial request to agent-a.
+5. Call `orchestrator.dispatch(request).await` and assert the result is `Err`.
+6. Pattern-match on `OrchestratorError::EscalationFailed { chain, reason }` and assert:
+   - `reason` contains the substring `"cycle detected"` (matching the format string in `validate_no_cycle`).
+   - `chain` contains `"agent-a"` (the originator that was already visited when agent-b tries to escalate back).
+7. Panic with a descriptive message on any other error variant.
+
+## Implementation Details
+- Use the same request-id pattern as other tests: `let request_id = uuid::Uuid::new_v4();`.
+- Both agents should be `HealthStatus::Healthy` so the health check does not short-circuit.
+- Place the new test in the "Tests" section of the file, after `dispatch_returns_escalation_failed_on_depth` and before `register_adds_dispatchable_agent`, to keep escalation-related tests grouped together.
+- No new helpers, dependencies, or modules are needed.
+
+### Suggested test body (reference, not prescriptive):
+```rust
+#[tokio::test]
+async fn dispatch_returns_escalation_failed_on_cycle() {
+    let request_id = uuid::Uuid::new_v4();
+
+    // Agent A escalates to agent-b
+    let agent_a = create_mock_endpoint(
+        "agent-a",
+        "alpha agent",
+        HealthStatus::Healthy,
+        build_escalation_response(request_id, "agent-b"),
+    )
+    .await;
+
+    // Agent B escalates back to agent-a, creating a cycle
+    let agent_b = create_mock_endpoint(
+        "agent-b",
+        "beta agent",
+        HealthStatus::Healthy,
+        build_escalation_response(request_id, "agent-a"),
+    )
+    .await;
+
+    let orchestrator = Orchestrator::new(build_test_manifest(), vec![agent_a, agent_b], None);
+
+    let request = AgentRequest {
+        id: request_id,
+        input: "trigger cycle".to_string(),
+        context: Some(json!({"target_agent": "agent-a"})),
+        caller: None,
+    };
+
+    let result = orchestrator.dispatch(request).await;
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        OrchestratorError::EscalationFailed { chain, reason } => {
+            assert!(
+                reason.contains("cycle detected"),
+                "reason was: {}",
+                reason
+            );
+            assert!(
+                chain.contains(&"agent-a".to_string()),
+                "chain was: {:?}",
+                chain
+            );
+        }
+        other => panic!("expected EscalationFailed, got: {:?}", other),
+    }
+}
+```
+
+## Dependencies
+- **Blocked by:** "Add structured tracing to escalation path" -- tracing instrumentation may change the escalation flow or add span fields that affect how the chain is built. This test should be implemented after that work lands to avoid conflicts.
+- **No new crate dependencies** are required.
+
+## Risks & Edge Cases
+- **Reason string coupling:** The assertion checks for the substring `"cycle detected"`, which is coupled to the format string in `validate_no_cycle` (`"cycle detected: '{}' already in chain"`). If that message changes, the test will break. This is intentional -- it validates the user-facing error message.
+- **Chain contents:** The escalation flow is: dispatch routes to agent-a (chain = `["agent-a"]`), agent-a escalates to agent-b, `validate_no_cycle` passes (agent-b not in chain), agent-b is invoked (chain becomes `["agent-a", "agent-b"]`), agent-b escalates to agent-a, `validate_no_cycle` fails because `"agent-a"` is already in the chain. The chain in the error will be `["agent-a", "agent-b"]`.
+- **No flakiness risk:** The mock servers are deterministic and always return the same escalation response, so there is no timing sensitivity.
+
+## Verification
+1. `cargo test -p orchestrator dispatch_returns_escalation_failed_on_cycle` -- the new test passes.
+2. `cargo test -p orchestrator` -- all existing tests continue to pass.
+3. `cargo clippy -p orchestrator --tests` -- no new warnings.

--- a/.claude/specs/issue-17/add-escalated-with-no-target-test.md
+++ b/.claude/specs/issue-17/add-escalated-with-no-target-test.md
@@ -1,0 +1,88 @@
+# Spec: Add escalated-with-no-target test
+> From: .claude/tasks/issue-17.md
+
+## Objective
+Add a test `dispatch_returns_response_when_escalated_without_target` that verifies the orchestrator gracefully handles the case where an agent returns `escalated: true` but `escalate_to: None`. The test must assert that `dispatch()` returns `Ok(response)` containing the original response as-is, rather than erroring or attempting further routing.
+
+## Current State
+The `handle_escalation` method in `crates/orchestrator/src/orchestrator.rs` (lines 180-213) already handles this case correctly. When `current_response.escalated` is `true` but `escalate_to` is `None`, the loop at line 194-197 matches `None` and returns `Ok(current_response)` immediately. However, there is no test exercising this specific branch.
+
+Existing escalation tests cover:
+- `dispatch_handles_escalation` -- agent A escalates to agent B with an explicit target (happy path)
+- `dispatch_returns_escalation_failed_on_depth` -- chain exceeds `MAX_ESCALATION_DEPTH`
+
+Neither test covers the `escalated: true` + `escalate_to: None` combination.
+
+## Requirements
+1. Add a new `#[tokio::test]` named `dispatch_returns_response_when_escalated_without_target` to `crates/orchestrator/tests/orchestrator_test.rs`.
+2. The test must register a single agent ("agent-a") that returns an `AgentResponse` with `escalated: true` and `escalate_to: None`.
+3. Route to "agent-a" via `context: Some(json!({"target_agent": "agent-a"}))`.
+4. Assert `dispatch()` returns `Ok(response)`.
+5. Assert the returned response matches the original response from agent-a (same `id`, `output`, `confidence`, `escalated`, `escalate_to`, `tool_calls`).
+6. Follow existing test conventions: use `create_mock_endpoint`, `build_test_manifest`, `Orchestrator::new`, and the same assertion style already in the file.
+
+## Implementation Details
+
+### New helper function
+Add a builder alongside `build_success_response` and `build_escalation_response`:
+
+```rust
+/// Builds an `AgentResponse` with `escalated: true` but no escalation target.
+fn build_escalated_no_target_response(request_id: uuid::Uuid, output_msg: &str) -> AgentResponse {
+    AgentResponse {
+        id: request_id,
+        output: json!({"result": output_msg}),
+        confidence: 0.5,
+        escalated: true,
+        escalate_to: None,
+        tool_calls: vec![],
+    }
+}
+```
+
+### Test function
+```rust
+#[tokio::test]
+async fn dispatch_returns_response_when_escalated_without_target() {
+    let request_id = uuid::Uuid::new_v4();
+
+    let agent_a = create_mock_endpoint(
+        "agent-a",
+        "agent that escalates without target",
+        HealthStatus::Healthy,
+        build_escalated_no_target_response(request_id, "no-target-escalation"),
+    )
+    .await;
+
+    let orchestrator = Orchestrator::new(build_test_manifest(), vec![agent_a], None);
+
+    let request = AgentRequest {
+        id: request_id,
+        input: "test escalation without target".to_string(),
+        context: Some(json!({"target_agent": "agent-a"})),
+        caller: None,
+    };
+
+    let response = orchestrator.dispatch(request).await.unwrap();
+    assert_eq!(response.output, json!({"result": "no-target-escalation"}));
+    assert!(response.escalated);
+    assert!(response.escalate_to.is_none());
+}
+```
+
+### Placement
+Insert the new helper after `build_escalation_response` (after line 126). Insert the new test after `dispatch_returns_escalation_failed_on_depth` (after line 380), keeping escalation-related tests grouped together.
+
+## Dependencies
+- **Blocked by:** "Add structured tracing to escalation path" -- that task may add tracing instrumentation to `handle_escalation`. This test should be written after that work lands to avoid merge conflicts in the same code region.
+- **No new crate dependencies required.** The test uses only existing imports and helpers.
+
+## Risks & Edge Cases
+- **Low risk.** The code path under test (`escalate_to: None` branch at line 196-197) is straightforward and already implemented.
+- **Edge case covered by this test:** An agent might legitimately set `escalated: true` to signal that it could not fully handle the request, but leave `escalate_to: None` because it does not know which agent should handle it. The orchestrator must not panic, error, or loop -- it returns the response as-is, letting the caller decide.
+- **No regression risk:** This is a purely additive test; no production code changes are needed.
+
+## Verification
+1. `cargo test --package orchestrator dispatch_returns_response_when_escalated_without_target` -- the new test passes.
+2. `cargo test --package orchestrator` -- all existing orchestrator tests continue to pass.
+3. `cargo clippy --package orchestrator --tests` -- no new warnings.

--- a/.claude/specs/issue-17/add-escalation-via-semantic-routing-test.md
+++ b/.claude/specs/issue-17/add-escalation-via-semantic-routing-test.md
@@ -1,0 +1,137 @@
+# Spec: Add escalation-via-semantic-routing test
+
+> From: .claude/tasks/issue-17.md
+
+## Objective
+
+Add a test `dispatch_with_model_handles_escalation` to `crates/orchestrator/tests/orchestrator_test.rs` that verifies the escalation path works correctly when dispatch is initiated via semantic routing (`dispatch_with_model()`). This confirms that escalation behavior is identical regardless of whether the initial agent was selected by context-based routing (`dispatch()`) or by semantic similarity routing (`dispatch_with_model()`).
+
+## Current State
+
+### Existing escalation test: `dispatch_handles_escalation`
+
+The file already contains a test at line 289 that exercises escalation through the context-based `dispatch()` path:
+- Agent A is routed to via `context: {"target_agent": "agent-a"}`.
+- Agent A returns an escalation response pointing to `"agent-b"`.
+- Agent B returns a success response.
+- The test asserts that `dispatch()` returns Agent B's success response.
+
+This test only covers escalation when the initial route was determined by `target_agent` context. It does not cover the case where the initial agent was selected via semantic similarity.
+
+### Existing semantic routing tests
+
+Four semantic routing tests exist (lines 477-645), all using `dispatch_with_model()`:
+- `dispatch_with_semantic_router_routes_by_intent` -- routes via `context.intent`.
+- `dispatch_with_semantic_router_routes_by_similarity` -- routes via cosine similarity of input embedding.
+- `dispatch_with_semantic_router_returns_no_route` -- verifies `NoRoute` when similarity is below threshold.
+- `dispatch_with_semantic_router_prefers_target_agent_over_intent` -- verifies `target_agent` priority.
+
+None of these tests exercise escalation after semantic routing. They all use `build_success_response()`.
+
+### Relevant test infrastructure already in place
+
+- `MockEmbeddingModel` (line 134): Maps known strings to fixed 3D vectors. Key mappings: `"Handles financial queries"` -> `[1.0, 0.0, 0.0]`, `"What are my expenses?"` -> `[0.9, 0.1, 0.0]`.
+- `build_semantic_router()` (line 179): Builds a `SemanticRouter` with `"finance-agent"` and `"weather-agent"` using threshold `0.7`.
+- `build_escalation_response()` (line 114): Creates an `AgentResponse` with `escalated: true` and a named `escalate_to` target.
+- `create_mock_endpoint()` (line 61): Spins up a mock HTTP agent with canned responses.
+
+### How `dispatch_with_model()` handles escalation
+
+In `orchestrator.rs` (line 124), `dispatch_with_model()` calls `route_with_model()` to find the initial endpoint, invokes it via `try_invoke()`, then delegates to `handle_escalation()` -- the exact same escalation handler used by `dispatch()`. The escalation path itself does not use the embedding model; it resolves targets by name from the registry. This means the code path is shared, but it has never been tested end-to-end through `dispatch_with_model()`.
+
+## Requirements
+
+1. **Test name**: `dispatch_with_model_handles_escalation`.
+
+2. **Semantic routing to initial agent**: The test must route the request to the initial agent via semantic similarity (not `target_agent` context), confirming that the entry point is through the semantic routing path. The input must produce an embedding with cosine similarity above 0.7 against the initial agent's description embedding.
+
+3. **Escalation to second agent**: The initial agent must return an escalation response (using `build_escalation_response()`) pointing to a second agent registered in the orchestrator. The second agent must return a success response (using `build_success_response()`).
+
+4. **Assertion**: `dispatch_with_model()` must return `Ok` with the second agent's success response, confirming that the full chain (semantic route -> invoke -> escalate -> invoke) works end-to-end.
+
+5. **Follow existing patterns**: Use `MockEmbeddingModel`, `build_semantic_router()`, `create_mock_endpoint()`, and `Orchestrator::new()` with `Some(router)` exactly as the existing semantic routing tests do.
+
+## Implementation Details
+
+### File to modify: `crates/orchestrator/tests/orchestrator_test.rs`
+
+### MockEmbeddingModel vector addition
+
+The `MockEmbeddingModel::vector_for()` method (line 137) needs a new entry for the escalation target agent's description. The escalation target does not need to be in the `SemanticRouter` (escalation resolves by name, not by embedding), but it does need to be registered in the orchestrator's `AgentEndpoint` registry. No new vectors are required unless the escalation target's description happens to be one of the strings passed to `embed_texts` during `SemanticRouter::new()`. Since `build_semantic_router()` only registers `"finance-agent"` and `"weather-agent"`, the escalation target can be a third agent (e.g., `"escalation-handler"`) whose description does not need an embedding mapping.
+
+**Option A (recommended)**: Register the escalation target only in the orchestrator's endpoint registry (via `Orchestrator::new()`), not in the `SemanticRouter`. This mirrors the real-world pattern where an escalation target may not be semantically routable. No changes to `MockEmbeddingModel` are needed.
+
+**Option B**: Add the escalation target to both the `SemanticRouter` and the orchestrator registry. This would require adding a vector mapping for the target's description in `MockEmbeddingModel::vector_for()`. This is unnecessary complexity for this test.
+
+### Test structure
+
+```
+Test: dispatch_with_model_handles_escalation
+
+Setup:
+  - model = MockEmbeddingModel
+  - router = build_semantic_router(&model) -- registers finance-agent and weather-agent
+  - finance_agent = create_mock_endpoint(
+      "finance-agent",
+      "Handles financial queries",
+      Healthy,
+      build_escalation_response(request_id, "escalation-handler")
+    )
+  - weather_agent = create_mock_endpoint(
+      "weather-agent",
+      "Handles weather forecasts",
+      Healthy,
+      build_success_response(request_id, "from-weather")  -- not expected to be called
+    )
+  - escalation_handler = create_mock_endpoint(
+      "escalation-handler",
+      "Handles escalated requests",
+      Healthy,
+      build_success_response(request_id, "handled-by-escalation")
+    )
+  - orchestrator = Orchestrator::new(
+      build_test_manifest(),
+      vec![finance_agent, weather_agent, escalation_handler],
+      Some(router)
+    )
+
+Request:
+  - input: "What are my expenses?"  -- embeds to [0.9, 0.1, 0.0], similar to finance [1.0, 0.0, 0.0]
+  - context: None  -- no target_agent, no intent; forces semantic similarity routing
+  - caller: None
+
+Execution:
+  - orchestrator.dispatch_with_model(request, &model).await
+
+Assertions:
+  - Result is Ok
+  - response.output == json!({"result": "handled-by-escalation"})
+```
+
+### Placement in the test file
+
+Add the test after the existing semantic routing tests (after line 645), within the "Semantic routing tests" section. The test logically belongs with the semantic routing tests because it validates behavior initiated through `dispatch_with_model()`.
+
+### No helper function changes needed
+
+The existing `build_semantic_router()` helper builds a router with `finance-agent` and `weather-agent`. The test can reuse this directly. The escalation target (`escalation-handler`) is only added to the orchestrator's endpoint registry, not to the semantic router.
+
+## Dependencies
+
+- **Blocked by**: "Add structured tracing to escalation path" -- the task description explicitly states this dependency. The tracing additions to `handle_escalation()` must land first so that the test exercises the instrumented code path.
+- **Blocking**: Nothing (non-blocking task).
+- **Requires**: The existing `MockEmbeddingModel`, `build_semantic_router()`, `create_mock_endpoint()`, `build_escalation_response()`, `build_success_response()`, and `build_test_manifest()` helpers. All are already present in the test file.
+
+## Risks & Edge Cases
+
+- **Escalation target description embedding**: The escalation target's description (`"Handles escalated requests"`) will be passed to `MockEmbeddingModel::vector_for()` only if it is registered in the `SemanticRouter`. Since the recommended approach registers it only in the orchestrator's endpoint registry (not the semantic router), no embedding lookup occurs for this description. If for some reason the `SemanticRouter` constructor or the escalation path triggers an embedding for the target's description, the `MockEmbeddingModel` will return `[0.0, 0.0, 0.0]` (the default for unknown strings), which is safe.
+- **Shared escalation handler**: The `handle_escalation()` method (line 180 of `orchestrator.rs`) is the same code path for both `dispatch()` and `dispatch_with_model()`. This test's value is confirming the end-to-end integration, not testing new escalation logic. If `handle_escalation()` is refactored, this test still provides a valid integration check.
+- **Mock HTTP server response is static**: The mock agent always returns the same canned response regardless of the request. The escalation handler's response includes `escalated: false`, so the escalation loop terminates after one hop. No risk of infinite loops.
+- **Test independence**: The test creates its own mock servers on random ports, its own `MockEmbeddingModel` (zero-allocation struct), and its own `Orchestrator`. No shared state with other tests.
+
+## Verification
+
+- `cargo test -p orchestrator dispatch_with_model_handles_escalation` passes.
+- `cargo test -p orchestrator` passes with all existing tests and the new test green.
+- `cargo clippy -p orchestrator` produces no new warnings.
+- The test confirms that `dispatch_with_model()` returns the escalation target's response (not the initial agent's escalation response), verifying the full semantic-route-then-escalate path.

--- a/.claude/specs/issue-17/add-missing-escalation-target-test.md
+++ b/.claude/specs/issue-17/add-missing-escalation-target-test.md
@@ -1,0 +1,52 @@
+# Spec: Add missing escalation target test
+> From: .claude/tasks/issue-17.md
+
+## Objective
+Add a test `dispatch_returns_escalation_failed_on_missing_target` that verifies the orchestrator returns `OrchestratorError::EscalationFailed` when an agent escalates to a target that does not exist in the registry.
+
+## Current State
+The test file `crates/orchestrator/tests/orchestrator_test.rs` already covers several escalation scenarios:
+- `dispatch_handles_escalation` -- successful escalation from agent-a to agent-b (line 289)
+- `dispatch_returns_escalation_failed_on_depth` -- escalation chain exceeding `MAX_ESCALATION_DEPTH` (line 324)
+
+The missing coverage is the case where `escalate_to` names an agent that is not registered. The `lookup_escalation_target` method in `crates/orchestrator/src/orchestrator.rs` (line 245) handles this by returning `OrchestratorError::EscalationFailed` with a reason of `"escalation target '<name>' not found in registry"`, but no test exercises this path.
+
+## Requirements
+1. Add a single `#[tokio::test]` named `dispatch_returns_escalation_failed_on_missing_target`.
+2. Register one agent (agent-a) that returns an escalation response pointing to `"nonexistent-agent"`.
+3. Do **not** register any agent named `"nonexistent-agent"` in the orchestrator.
+4. Dispatch a request targeting agent-a via `context.target_agent`.
+5. Assert the result is `Err(OrchestratorError::EscalationFailed { chain, reason })`.
+6. Assert `reason` contains `"not found in registry"`.
+7. Assert `chain` contains `"agent-a"` (the agent that initiated the escalation).
+
+## Implementation Details
+- Place the test in the `// Tests` section of `crates/orchestrator/tests/orchestrator_test.rs`, after the existing `dispatch_returns_escalation_failed_on_depth` test (after line 380).
+- Use the existing helpers:
+  - `create_mock_endpoint` to create agent-a with `HealthStatus::Healthy` and a response from `build_escalation_response(request_id, "nonexistent-agent")`.
+  - `build_test_manifest()` for the orchestrator manifest.
+- Construct the orchestrator with `Orchestrator::new(build_test_manifest(), vec![agent_a], None)` -- only agent-a in the registry, no `"nonexistent-agent"`.
+- Build the request with `context: Some(json!({"target_agent": "agent-a"}))` so routing succeeds and reaches agent-a.
+- Match on the error variant using the same pattern as `dispatch_returns_escalation_failed_on_depth`:
+  ```rust
+  match result.unwrap_err() {
+      OrchestratorError::EscalationFailed { chain, reason } => {
+          assert!(reason.contains("not found in registry"), "reason was: {}", reason);
+          assert!(chain.contains(&"agent-a".to_string()), "chain was: {:?}", chain);
+      }
+      other => panic!("expected EscalationFailed, got: {:?}", other),
+  }
+  ```
+- No new imports, helpers, or dependencies are needed.
+
+## Dependencies
+- **Blocked by**: "Add structured tracing to escalation path" -- that task may modify the escalation code path. The test itself does not depend on tracing, but if the escalation logic or error format changes, this test must be updated to match.
+
+## Risks & Edge Cases
+- If the `lookup_escalation_target` error message wording changes (currently `"escalation target '{}' not found in registry"`), the substring assertion `"not found in registry"` will break. This is an acceptable coupling since the test is specifically validating that error message.
+- The `chain` vector at the point of failure contains only `["agent-a"]` because the target agent is looked up before being appended to the chain (see `handle_escalation` at line 211 in orchestrator.rs where `current_chain.push(target_name)` happens after `lookup_escalation_target`). The assertion should reflect this.
+
+## Verification
+1. `cargo test -p orchestrator dispatch_returns_escalation_failed_on_missing_target` -- the new test passes.
+2. `cargo test -p orchestrator` -- all existing orchestrator tests continue to pass.
+3. `cargo clippy -p orchestrator --tests` -- no new warnings.

--- a/.claude/specs/issue-17/add-structured-tracing-to-escalation-path.md
+++ b/.claude/specs/issue-17/add-structured-tracing-to-escalation-path.md
@@ -1,0 +1,137 @@
+# Spec: Add structured tracing to escalation path
+
+> From: .claude/tasks/issue-17.md
+
+## Objective
+
+Add structured `tracing` instrumentation to the escalation logic in `orchestrator.rs` so that escalation events, warnings, and errors are observable at runtime. Currently, escalation decisions happen silently -- a request can chain through multiple agents, hit cycle detection, exceed depth limits, or silently return when `escalate_to` is `None`, all without emitting a single log line. This task makes escalation fully observable by following the structured tracing pattern already established in `semantic_router.rs`.
+
+## Current State
+
+### Escalation functions in `crates/orchestrator/src/orchestrator.rs`
+
+- **`handle_escalation()`** (line 180): Loops through escalation hops. When `escalated` is `true` and `escalate_to` is `Some(name)`, it validates depth/cycle, looks up the target, builds a new request, and invokes. When `escalated` is `false`, it returns silently. When `escalated` is `true` but `escalate_to` is `None`, it also returns silently -- this is a suspicious state that should be warned about.
+
+- **`validate_escalation_depth()`** (line 215): Returns `OrchestratorError::EscalationFailed` when `chain.len() >= MAX_ESCALATION_DEPTH` (5). No log is emitted before the error.
+
+- **`validate_no_cycle()`** (line 231): Returns `OrchestratorError::EscalationFailed` when the target agent is already present in the chain. No log is emitted before the error.
+
+- **`lookup_escalation_target()`** (line 245): Returns `OrchestratorError::EscalationFailed` when the target is not in the registry. No log is emitted.
+
+### Existing tracing pattern in `crates/orchestrator/src/semantic_router.rs`
+
+```rust
+tracing::debug!(agent = %agent_name, "routed via intent match");
+tracing::debug!(agent = %agent_name, "routed via semantic similarity");
+```
+
+The crate already depends on `tracing = "0.1"` in `crates/orchestrator/Cargo.toml` (line 15).
+
+### `AgentResponse` fields available for structured logging
+
+- `confidence: f32`
+- `escalated: bool`
+- `escalate_to: Option<String>`
+
+## Requirements
+
+1. **`tracing::info!` on each escalation hop** -- Inside the `handle_escalation()` loop, when an escalation is about to be dispatched, emit a structured `info` event with fields: `source_agent` (last agent in chain), `target_agent` (the escalation target), `confidence` (from the current response), `depth` (current chain length), and `chain` (the full escalation chain formatted as a debug string, e.g. `"[a -> b -> c]"`).
+
+2. **`tracing::warn!` on escalated-with-no-target** -- When `response.escalated == true` but `response.escalate_to` is `None`, emit a structured `warn` event with fields: `source_agent` (last agent in chain), `confidence`, and `chain`. The message should indicate the agent signaled escalation but provided no target.
+
+3. **`tracing::error!` on depth exceeded** -- In `validate_escalation_depth()`, before returning the error, emit a structured `error` event with fields: `depth` (current chain length), `max_depth` (the `MAX_ESCALATION_DEPTH` constant), and `chain`.
+
+4. **`tracing::error!` on cycle detection** -- In `validate_no_cycle()`, before returning the error, emit a structured `error` event with fields: `target_agent`, `chain`.
+
+5. **No new dependencies** -- The `tracing` crate is already a dependency. No additional crates are needed.
+
+6. **Follow the existing pattern** -- Use `%` for Display formatting of string fields (e.g., `agent = %agent_name`), `?` for Debug formatting of collections (e.g., `chain = ?chain`). Use bare string literals for the event message.
+
+## Implementation Details
+
+### File to modify
+
+**`crates/orchestrator/src/orchestrator.rs`**
+
+#### Changes to `handle_escalation()`
+
+- After the `if !current_response.escalated` early return (line 190-192), no change needed (this is the normal non-escalation path).
+
+- In the `None` arm of `current_response.escalate_to` match (line 195-197), before `return Ok(current_response)`, add:
+
+  ```rust
+  tracing::warn!(
+      source_agent = %current_chain.last().unwrap_or(&"unknown".to_string()),
+      confidence = current_response.confidence,
+      chain = ?current_chain,
+      "agent signaled escalation but provided no target"
+  );
+  ```
+
+- After `build_escalation_request()` and before `try_invoke()` (between lines 208 and 210), add:
+
+  ```rust
+  tracing::info!(
+      source_agent = %current_chain.last().unwrap_or(&"unknown".to_string()),
+      target_agent = %target_name,
+      confidence = current_response.confidence,
+      depth = current_chain.len(),
+      chain = ?current_chain,
+      "escalating request to next agent"
+  );
+  ```
+
+#### Changes to `validate_escalation_depth()`
+
+- Before the `return Err(...)` on line 220, add:
+
+  ```rust
+  tracing::error!(
+      depth = chain.len(),
+      max_depth = MAX_ESCALATION_DEPTH,
+      chain = ?chain,
+      "escalation depth exceeded"
+  );
+  ```
+
+#### Changes to `validate_no_cycle()`
+
+- Before the `return Err(...)` on line 237, add:
+
+  ```rust
+  tracing::error!(
+      target_agent = %target_name,
+      chain = ?chain,
+      "escalation cycle detected"
+  );
+  ```
+
+### No changes to other files
+
+- `Cargo.toml` already has `tracing = "0.1"`.
+- `semantic_router.rs` is untouched; it serves only as the reference pattern.
+- No new modules, structs, or traits are introduced.
+
+## Dependencies
+
+- Blocked by: none
+- Blocking: "Add cycle detection test", "Add missing escalation target test", "Add escalated-with-no-target test", "Add successful multi-hop escalation chain test", "Add escalation-via-semantic-routing test"
+
+## Risks & Edge Cases
+
+- **`unwrap_or` on empty chain**: `current_chain.last()` could theoretically be `None` if the chain is empty. The implementation uses `unwrap_or` with a fallback `"unknown"` string to avoid panics. In practice, the chain always has at least one entry by the time `handle_escalation` is called (populated in `dispatch()` and `dispatch_with_model()`), but the defensive fallback is still warranted.
+
+- **Performance**: `tracing` macros are zero-cost when no subscriber is attached. Structured field formatting only runs when a subscriber is active and the level is enabled. There is no measurable overhead in production unless a subscriber collects these events.
+
+- **Chain formatting**: Using `?chain` (Debug format) for `Vec<String>` produces `["a", "b", "c"]` output, which is adequate for log consumers. If a more opinionated format like `"a -> b -> c"` is preferred, a small formatting helper would be needed, but Debug format is consistent with how the error messages already format chains and avoids adding code.
+
+## Verification
+
+1. `cargo check -p orchestrator` passes with no errors or warnings.
+2. `cargo clippy -p orchestrator` passes with no warnings.
+3. `cargo test -p orchestrator` passes (existing tests remain green).
+4. Manual review confirms:
+   - Each `tracing` call uses structured fields, not string interpolation in the message.
+   - Log levels match the semantics: `info` for normal escalation flow, `warn` for the suspicious no-target case, `error` for validation failures.
+   - The field names (`source_agent`, `target_agent`, `confidence`, `depth`, `chain`, `max_depth`) are consistent and machine-parseable.
+5. No new dependencies were added.

--- a/.claude/specs/issue-17/add-successful-multi-hop-escalation-chain-test.md
+++ b/.claude/specs/issue-17/add-successful-multi-hop-escalation-chain-test.md
@@ -1,0 +1,69 @@
+# Spec: Add successful multi-hop escalation chain test
+> From: .claude/tasks/issue-17.md
+
+## Objective
+Add a test `dispatch_handles_multi_hop_escalation` to validate that the orchestrator's escalation loop correctly follows a chain of multiple hops (A -> B -> C) and returns the final successful response from agent C. The existing `dispatch_handles_escalation` test only covers a single-hop escalation (A -> B); this test ensures the full loop logic works for chains longer than one hop.
+
+## Current State
+- `crates/orchestrator/tests/orchestrator_test.rs` contains a single-hop escalation test (`dispatch_handles_escalation`) that creates two agents: A escalates to B, B returns success. This validates only the first iteration of the escalation loop.
+- `crates/orchestrator/tests/orchestrator_test.rs` also contains a max-depth test (`dispatch_returns_escalation_failed_on_depth`) that creates a chain of 7 agents all escalating, but it tests the failure path, not a successful multi-hop chain.
+- The `handle_escalation` method in `crates/orchestrator/src/orchestrator.rs` (line 180) uses a `loop` that iterates through escalations until either: (a) a non-escalated response is returned, (b) max depth is exceeded, or (c) a cycle is detected. The multi-hop success path (iterating the loop more than once and then returning `Ok`) has no dedicated test coverage.
+
+## Requirements
+1. Create a test function named `dispatch_handles_multi_hop_escalation` in `crates/orchestrator/tests/orchestrator_test.rs`.
+2. Create three mock agents:
+   - **agent-a**: healthy, returns an escalation response targeting `agent-b`.
+   - **agent-b**: healthy, returns an escalation response targeting `agent-c`.
+   - **agent-c**: healthy, returns a successful response (e.g., output `"handled-by-c"`).
+3. Construct an `Orchestrator` with all three agents registered (no semantic router needed).
+4. Build an `AgentRequest` with `context: {"target_agent": "agent-a"}` to initiate dispatch at agent-a.
+5. Call `orchestrator.dispatch(request).await` and assert:
+   - The result is `Ok`.
+   - The response output matches agent-c's success output (`{"result": "handled-by-c"}`).
+   - The response `escalated` field is `false` (agent-c did not escalate).
+
+## Implementation Details
+- Follow the established test patterns exactly: use `create_mock_endpoint`, `build_escalation_response`, `build_success_response`, `build_test_manifest`, and `Orchestrator::new`.
+- Use a single shared `request_id` (`uuid::Uuid::new_v4()`) for all agents and the request, matching the pattern in existing tests.
+- Place the test in the `// Tests` section of the file, after `dispatch_handles_escalation` and before `dispatch_returns_escalation_failed_on_depth` for logical grouping.
+- The test is `#[tokio::test] async fn`.
+- No new helper functions, imports, or dependencies are needed; all required utilities already exist.
+
+### Test structure (pseudocode):
+```
+#[tokio::test]
+async fn dispatch_handles_multi_hop_escalation() {
+    let request_id = uuid::Uuid::new_v4();
+
+    // agent-a escalates to agent-b
+    let agent_a = create_mock_endpoint("agent-a", ..., build_escalation_response(request_id, "agent-b"));
+
+    // agent-b escalates to agent-c
+    let agent_b = create_mock_endpoint("agent-b", ..., build_escalation_response(request_id, "agent-c"));
+
+    // agent-c returns success
+    let agent_c = create_mock_endpoint("agent-c", ..., build_success_response(request_id, "handled-by-c"));
+
+    let orchestrator = Orchestrator::new(build_test_manifest(), vec![agent_a, agent_b, agent_c], None);
+
+    let request = AgentRequest { ..., context: Some(json!({"target_agent": "agent-a"})), ... };
+
+    let response = orchestrator.dispatch(request).await.unwrap();
+    assert_eq!(response.output, json!({"result": "handled-by-c"}));
+    assert!(!response.escalated);
+}
+```
+
+## Dependencies
+- **Blocked by**: "Add structured tracing to escalation path" -- the tracing task may modify the `handle_escalation` method signature or add tracing instrumentation. This test should be implemented after that work is merged to avoid conflicts and to verify the tracing changes do not break multi-hop behavior.
+- **No new crate dependencies** are required.
+
+## Risks & Edge Cases
+- **Mock server statefulness**: Each mock agent always returns the same fixed response regardless of request content. This is fine for this test because the escalation loop replays the request with a new `target_agent` context, and routing is done by the orchestrator registry, not by the mock servers.
+- **Request ID consistency**: The same `request_id` is used across all agents and the request. This is consistent with the existing test pattern and works because the mock servers ignore the request body details.
+- **Chain length is well under MAX_ESCALATION_DEPTH (5)**: A 3-agent chain (A -> B -> C) produces a chain vector of length 3, which is safely below the limit. No depth-limit error should occur.
+
+## Verification
+1. Run `cargo test dispatch_handles_multi_hop_escalation` -- the new test must pass.
+2. Run `cargo test --package orchestrator` -- all existing orchestrator tests must continue to pass.
+3. Run `cargo clippy --package orchestrator --tests` -- no new warnings.

--- a/.claude/specs/issue-17/run-verification-suite.md
+++ b/.claude/specs/issue-17/run-verification-suite.md
@@ -1,0 +1,33 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-17.md
+
+## Objective
+Run the full verification suite to confirm all changes compile, pass linting, and all tests (new and existing) pass without regressions.
+
+## Current State
+The workspace contains multiple crates: agent-sdk, agent-runtime, orchestrator, skill-loader, tool-registry. All currently pass cargo check, cargo clippy, and cargo test.
+
+## Requirements
+1. `cargo check` must succeed with no errors across the full workspace
+2. `cargo clippy` must produce no new warnings
+3. `cargo test` must pass all tests including new escalation tests
+4. No regressions in existing crates
+
+## Implementation Details
+This is a verification-only task. No code changes. Run:
+- `cargo check`
+- `cargo clippy`
+- `cargo test`
+
+## Dependencies
+- Blocked by: All other tasks in issue-17 (structured tracing, cycle detection test, missing target test, escalated-with-no-target test, multi-hop escalation test, escalation-via-semantic-routing test)
+- Blocking: Nothing
+
+## Risks & Edge Cases
+- Tracing additions could introduce unused import warnings if not done carefully
+- New tests could have flaky behavior with mock HTTP servers on random ports
+- Adding `tracing` as a dependency to the orchestrator crate could cause version conflicts with other crates in the workspace
+
+## Verification
+All three commands pass with zero errors and zero warnings.

--- a/.claude/tasks/issue-17.md
+++ b/.claude/tasks/issue-17.md
@@ -1,0 +1,55 @@
+# Task Breakdown: Implement escalation handling
+
+> Add structured tracing to the existing escalation logic and expand test coverage for cycle detection, missing targets, no-target escalation, and multi-hop chains.
+
+## Group 1 — Escalation observability logging
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Add structured tracing to escalation path** `[S]`
+      Add `tracing::info!` calls inside `handle_escalation()` in `orchestrator.rs` to log each escalation event with structured fields: `source_agent`, `target_agent`, `confidence`, `depth`, and the escalation chain. Also add `tracing::warn!` when `escalated=true` but `escalate_to` is `None` (the code currently returns the response silently). Add `tracing::error!` in the cycle-detection and depth-exceeded error paths in `validate_escalation_depth()` and `validate_no_cycle()`. Follow the pattern already established in `semantic_router.rs` (e.g., `tracing::debug!(agent = %agent_name, "routed via intent match")`).
+      Files: `crates/orchestrator/src/orchestrator.rs`
+      Blocking: "Add cycle detection test", "Add missing escalation target test", "Add escalated-with-no-target test", "Add successful multi-hop escalation chain test", "Add escalation-via-semantic-routing test"
+
+## Group 2 — Escalation edge-case tests
+
+_Depends on: Group 1._
+
+- [x] **Add cycle detection test** `[S]`
+      Add a test `dispatch_returns_escalation_failed_on_cycle` that creates two mock agents where A escalates to B and B escalates to A. Assert that `dispatch()` returns `OrchestratorError::EscalationFailed` with a reason containing "cycle detected". Follow the existing mock-server pattern in `orchestrator_test.rs` using `create_mock_endpoint` and `build_escalation_response`.
+      Files: `crates/orchestrator/tests/orchestrator_test.rs`
+      Blocked by: "Add structured tracing to escalation path"
+      Non-blocking
+
+- [x] **Add missing escalation target test** `[S]`
+      Add a test `dispatch_returns_escalation_failed_on_missing_target` where agent A escalates to "nonexistent-agent" which is not in the registry. Assert that `dispatch()` returns `OrchestratorError::EscalationFailed` with a reason containing "not found in registry".
+      Files: `crates/orchestrator/tests/orchestrator_test.rs`
+      Blocked by: "Add structured tracing to escalation path"
+      Non-blocking
+
+- [x] **Add escalated-with-no-target test** `[S]`
+      Add a test `dispatch_returns_response_when_escalated_without_target` where agent A returns `escalated: true` but `escalate_to: None`. Assert that `dispatch()` returns `Ok(response)` with the original response (the code gracefully handles this case by returning the response as-is).
+      Files: `crates/orchestrator/tests/orchestrator_test.rs`
+      Blocked by: "Add structured tracing to escalation path"
+      Non-blocking
+
+- [x] **Add successful multi-hop escalation chain test** `[S]`
+      Add a test `dispatch_handles_multi_hop_escalation` that creates three mock agents: A escalates to B, B escalates to C, C returns success. Assert that `dispatch()` returns the successful response from C. This validates the full chain-following loop, not just single-hop.
+      Files: `crates/orchestrator/tests/orchestrator_test.rs`
+      Blocked by: "Add structured tracing to escalation path"
+      Non-blocking
+
+- [x] **Add escalation-via-semantic-routing test** `[S]`
+      Add a test `dispatch_with_model_handles_escalation` that uses `dispatch_with_model()` with the `MockEmbeddingModel` and `SemanticRouter` to route to an agent that escalates. Verifies that the escalation path works identically whether dispatch was initiated by context-based or semantic routing.
+      Files: `crates/orchestrator/tests/orchestrator_test.rs`
+      Blocked by: "Add structured tracing to escalation path"
+      Non-blocking
+
+## Group 3 — Verification
+
+_Depends on: Group 2._
+
+- [x] **Run verification suite** `[S]`
+      Run `cargo check`, `cargo clippy`, and `cargo test` across the full workspace. Verify no regressions in existing crates. Verify all new and existing orchestrator tests pass.
+      Files: (none — command-line verification only)
+      Blocked by: All other tasks

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -193,7 +193,15 @@ impl Orchestrator {
 
             let target_name = match current_response.escalate_to {
                 Some(ref name) => name.clone(),
-                None => return Ok(current_response),
+                None => {
+                    tracing::warn!(
+                        source_agent = %current_chain.last().unwrap_or(&"unknown".to_string()),
+                        confidence = current_response.confidence,
+                        chain = ?current_chain,
+                        "agent signaled escalation but provided no target"
+                    );
+                    return Ok(current_response);
+                }
             };
 
             self.validate_escalation_depth(&current_chain)?;
@@ -207,6 +215,15 @@ impl Orchestrator {
                 &current_chain,
             );
 
+            tracing::info!(
+                source_agent = %current_chain.last().unwrap_or(&"unknown".to_string()),
+                target_agent = %target_name,
+                confidence = current_response.confidence,
+                depth = current_chain.len(),
+                chain = ?current_chain,
+                "escalating request to next agent"
+            );
+
             current_response = self.try_invoke(endpoint, &new_request).await?;
             current_chain.push(target_name);
         }
@@ -217,6 +234,12 @@ impl Orchestrator {
         chain: &[String],
     ) -> Result<(), OrchestratorError> {
         if chain.len() >= MAX_ESCALATION_DEPTH {
+            tracing::error!(
+                depth = chain.len(),
+                max_depth = MAX_ESCALATION_DEPTH,
+                chain = ?chain,
+                "escalation depth exceeded"
+            );
             return Err(OrchestratorError::EscalationFailed {
                 chain: chain.to_vec(),
                 reason: format!(
@@ -234,6 +257,11 @@ impl Orchestrator {
         target_name: &str,
     ) -> Result<(), OrchestratorError> {
         if chain.contains(&target_name.to_string()) {
+            tracing::error!(
+                target_agent = %target_name,
+                chain = ?chain,
+                "escalation cycle detected"
+            );
             return Err(OrchestratorError::EscalationFailed {
                 chain: chain.to_vec(),
                 reason: format!("cycle detected: '{}' already in chain", target_name),

--- a/crates/orchestrator/tests/orchestrator_test.rs
+++ b/crates/orchestrator/tests/orchestrator_test.rs
@@ -125,6 +125,18 @@ fn build_escalation_response(
     }
 }
 
+/// Builds an `AgentResponse` with `escalated: true` but no escalation target.
+fn build_escalated_no_target_response(request_id: uuid::Uuid, output_msg: &str) -> AgentResponse {
+    AgentResponse {
+        id: request_id,
+        output: json!({"result": output_msg}),
+        confidence: 0.5,
+        escalated: true,
+        escalate_to: None,
+        tool_calls: vec![],
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Mock embedding model
 // ---------------------------------------------------------------------------
@@ -321,6 +333,52 @@ async fn dispatch_handles_escalation() {
 }
 
 #[tokio::test]
+async fn dispatch_handles_multi_hop_escalation() {
+    let request_id = uuid::Uuid::new_v4();
+
+    // Agent A escalates to agent-b
+    let agent_a = create_mock_endpoint(
+        "agent-a",
+        "first responder",
+        HealthStatus::Healthy,
+        build_escalation_response(request_id, "agent-b"),
+    )
+    .await;
+
+    // Agent B escalates to agent-c
+    let agent_b = create_mock_endpoint(
+        "agent-b",
+        "second responder",
+        HealthStatus::Healthy,
+        build_escalation_response(request_id, "agent-c"),
+    )
+    .await;
+
+    // Agent C returns a successful response
+    let agent_c = create_mock_endpoint(
+        "agent-c",
+        "final handler",
+        HealthStatus::Healthy,
+        build_success_response(request_id, "handled-by-c"),
+    )
+    .await;
+
+    let orchestrator =
+        Orchestrator::new(build_test_manifest(), vec![agent_a, agent_b, agent_c], None);
+
+    let request = AgentRequest {
+        id: request_id,
+        input: "need help".to_string(),
+        context: Some(json!({"target_agent": "agent-a"})),
+        caller: None,
+    };
+
+    let response = orchestrator.dispatch(request).await.unwrap();
+    assert_eq!(response.output, json!({"result": "handled-by-c"}));
+    assert!(!response.escalated);
+}
+
+#[tokio::test]
 async fn dispatch_returns_escalation_failed_on_depth() {
     let request_id = uuid::Uuid::new_v4();
 
@@ -377,6 +435,117 @@ async fn dispatch_returns_escalation_failed_on_depth() {
         }
         other => panic!("expected EscalationFailed, got: {:?}", other),
     }
+}
+
+#[tokio::test]
+async fn dispatch_returns_escalation_failed_on_cycle() {
+    let request_id = uuid::Uuid::new_v4();
+
+    // Agent A escalates to agent-b
+    let agent_a = create_mock_endpoint(
+        "agent-a",
+        "alpha agent",
+        HealthStatus::Healthy,
+        build_escalation_response(request_id, "agent-b"),
+    )
+    .await;
+
+    // Agent B escalates back to agent-a, creating a cycle
+    let agent_b = create_mock_endpoint(
+        "agent-b",
+        "beta agent",
+        HealthStatus::Healthy,
+        build_escalation_response(request_id, "agent-a"),
+    )
+    .await;
+
+    let orchestrator = Orchestrator::new(build_test_manifest(), vec![agent_a, agent_b], None);
+
+    let request = AgentRequest {
+        id: request_id,
+        input: "trigger cycle".to_string(),
+        context: Some(json!({"target_agent": "agent-a"})),
+        caller: None,
+    };
+
+    let result = orchestrator.dispatch(request).await;
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        OrchestratorError::EscalationFailed { chain, reason } => {
+            assert!(
+                reason.contains("cycle detected"),
+                "reason was: {}",
+                reason
+            );
+            assert!(
+                chain.contains(&"agent-a".to_string()),
+                "chain was: {:?}",
+                chain
+            );
+        }
+        other => panic!("expected EscalationFailed, got: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn dispatch_returns_escalation_failed_on_missing_target() {
+    let request_id = uuid::Uuid::new_v4();
+
+    // Agent A escalates to "nonexistent-agent" which is NOT registered
+    let agent_a = create_mock_endpoint(
+        "agent-a",
+        "first responder",
+        HealthStatus::Healthy,
+        build_escalation_response(request_id, "nonexistent-agent"),
+    )
+    .await;
+
+    // Only register agent-a; "nonexistent-agent" is deliberately absent
+    let orchestrator = Orchestrator::new(build_test_manifest(), vec![agent_a], None);
+
+    let request = AgentRequest {
+        id: request_id,
+        input: "escalate to missing".to_string(),
+        context: Some(json!({"target_agent": "agent-a"})),
+        caller: None,
+    };
+
+    let result = orchestrator.dispatch(request).await;
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        OrchestratorError::EscalationFailed { chain, reason } => {
+            assert!(reason.contains("not found in registry"), "reason was: {}", reason);
+            assert!(chain.contains(&"agent-a".to_string()), "chain was: {:?}", chain);
+        }
+        other => panic!("expected EscalationFailed, got: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn dispatch_returns_response_when_escalated_without_target() {
+    let request_id = uuid::Uuid::new_v4();
+
+    let agent_a = create_mock_endpoint(
+        "agent-a",
+        "agent that escalates without target",
+        HealthStatus::Healthy,
+        build_escalated_no_target_response(request_id, "no-target-escalation"),
+    )
+    .await;
+
+    let orchestrator = Orchestrator::new(build_test_manifest(), vec![agent_a], None);
+
+    let request = AgentRequest {
+        id: request_id,
+        input: "test escalation without target".to_string(),
+        context: Some(json!({"target_agent": "agent-a"})),
+        caller: None,
+    };
+
+    let response = orchestrator.dispatch(request).await.unwrap();
+    assert_eq!(response.output, json!({"result": "no-target-escalation"}));
+    assert!(response.escalated);
+    assert!(response.escalate_to.is_none());
 }
 
 #[tokio::test]
@@ -642,4 +811,63 @@ async fn dispatch_with_semantic_router_prefers_target_agent_over_intent() {
 
     let response = orchestrator.dispatch_with_model(request, &model).await.unwrap();
     assert_eq!(response.output, json!({"result": "from-weather"}));
+}
+
+#[tokio::test]
+async fn dispatch_with_model_handles_escalation() {
+    let request_id = uuid::Uuid::new_v4();
+    let model = MockEmbeddingModel;
+
+    // finance-agent escalates to escalation-handler
+    let finance_agent = create_mock_endpoint(
+        "finance-agent",
+        "Handles financial queries",
+        HealthStatus::Healthy,
+        build_escalation_response(request_id, "escalation-handler"),
+    )
+    .await;
+
+    let weather_agent = create_mock_endpoint(
+        "weather-agent",
+        "Handles weather forecasts",
+        HealthStatus::Healthy,
+        build_success_response(request_id, "from-weather"),
+    )
+    .await;
+
+    // escalation-handler is registered in the orchestrator but NOT in the
+    // semantic router -- it is only reachable via escalation.
+    let escalation_handler = create_mock_endpoint(
+        "escalation-handler",
+        "Handles escalated requests",
+        HealthStatus::Healthy,
+        build_success_response(request_id, "handled-by-escalation"),
+    )
+    .await;
+
+    let router = build_semantic_router(&model).await;
+    let orchestrator = Orchestrator::new(
+        build_test_manifest(),
+        vec![finance_agent, weather_agent, escalation_handler],
+        Some(router),
+    );
+
+    // No target_agent, no intent -- routes via cosine similarity.
+    // "What are my expenses?" [0.9, 0.1, 0.0] is close to finance [1.0, 0.0, 0.0].
+    // finance-agent escalates to escalation-handler, which returns success.
+    let request = AgentRequest {
+        id: request_id,
+        input: "What are my expenses?".to_string(),
+        context: None,
+        caller: None,
+    };
+
+    let response = orchestrator
+        .dispatch_with_model(request, &model)
+        .await
+        .unwrap();
+    assert_eq!(
+        response.output,
+        json!({"result": "handled-by-escalation"})
+    );
 }


### PR DESCRIPTION
## Summary

Add structured tracing to the orchestrator's escalation logic for runtime observability, and expand test coverage with 5 new edge-case tests covering cycle detection, missing targets, no-target escalation, multi-hop chains, and escalation via semantic routing.

## Changes

### Group 1 — Escalation observability logging
- ✅ Add structured tracing to escalation path

### Group 2 — Escalation edge-case tests
- ✅ Add cycle detection test
- ✅ Add missing escalation target test
- ✅ Add escalated-with-no-target test
- ✅ Add successful multi-hop escalation chain test
- ✅ Add escalation-via-semantic-routing test

### Group 3 — Verification
- ✅ Run verification suite

## Test plan

- `cargo check` — all crates compile cleanly
- `cargo clippy` — no lint warnings
- `cargo test` — all 190 tests pass (5 new escalation tests)
- Verify no regressions in existing crates (agent-sdk, agent-runtime, skill-loader, tool-registry)

## Issue

Closes #17