### PR TITLE
feat(orchestrator): create orchestrator skill file (#18)

### DIFF
--- a/.claude/tasks/issue-18.md
+++ b/.claude/tasks/issue-18.md
@@ -1,0 +1,47 @@
+# Task Breakdown: Create orchestrator skill file
+
+> Create `skills/orchestrator.md` -- the orchestrator's skill file that configures it as a pure routing agent with no domain knowledge, proving the system's homogeneity principle.
+
+## Group 1 — Create skill file
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Create `skills/orchestrator.md` routing skill file** `[S]`
+      Create the orchestrator skill file using the established markdown-with-frontmatter format (same as `echo.md`, `cogs-analyst.md`, `skill-writer.md`). The YAML frontmatter must deserialize into `SkillFrontmatter` (which maps to `SkillManifest`). Frontmatter fields: `name: orchestrator`, `version: "1.0"`, `description: Routes incoming requests to the best-matching specialized agent based on intent analysis`, model config (`provider: anthropic`, `name: claude-sonnet-4-6`, `temperature: 0.1`), `tools: [list_agents, route_to_agent]`, constraints (`max_turns: 3`, `confidence_threshold: 0.9`, omit `escalate_to` so it defaults to `None` -- this is the top-level router with no escalation target), `allowed_actions: [route, discover]`, output (`format: structured_json`, schema: `target_agent: string`, `reasoning: string`). The markdown body (preamble) must be concise routing-only instructions: define the agent as a request router, specify rules (never answer domain questions directly, analyze intent, match against available agents, report no-match if confidence insufficient, never speculate). Keep the preamble under 20 lines, focused purely on routing behavior with no domain knowledge. Key validation constraints: `version` must be quoted (`"1.0"`), `confidence_threshold` in [0.0, 1.0], `max_turns > 0`, `format` must be one of `["json", "structured_json", "text"]`, preamble must not be empty.
+      Files: `skills/orchestrator.md`
+      Blocking: "Add integration test for orchestrator skill", "Update orchestrator to load skill file instead of hardcoded manifest"
+
+## Group 2 — Integration test and orchestrator wiring
+
+_Depends on: Group 1._
+
+- [x] **Add integration test for orchestrator skill** `[S]`
+      Add a test case in `crates/skill-loader/tests/example_skills_test.rs` following the exact pattern of `load_echo_skill` and `load_cogs_analyst_skill`. The test function should be named `load_orchestrator_skill`. It should use `skills_dir()` and `make_loader()` helpers already defined in that file. Assert all parsed `SkillManifest` fields match expected values: `name == "orchestrator"`, `version == "1.0"`, `description` matches, `model.provider == "anthropic"`, `model.name == "claude-sonnet-4-6"`, `temperature ~= 0.1`, `tools == ["list_agents", "route_to_agent"]`, `max_turns == 3`, `confidence_threshold ~= 0.9`, `escalate_to == None`, `allowed_actions == ["route", "discover"]`, `output.format == "structured_json"`, `output.schema` has keys `target_agent` and `reasoning` both with value `"string"`. Verify preamble is non-empty and contains key phrases like "router" or "route". Uses `AllToolsExist` since `list_agents` and `route_to_agent` are stub tool names.
+      Files: `crates/skill-loader/tests/example_skills_test.rs`
+      Blocked by: "Create `skills/orchestrator.md` routing skill file"
+      Non-blocking
+
+- [x] **Update orchestrator to load skill file instead of hardcoded manifest** `[M]`
+      Replace the `build_default_manifest()` function in `crates/orchestrator/src/orchestrator.rs` which hardcodes a placeholder `SkillManifest` with empty preamble, `provider: "none"`, and zero tools. Instead, update `from_config` and `from_config_with_model` to accept a `SkillManifest` loaded from the skill file (either passed in as a parameter, or by accepting the skills directory path and loading `orchestrator.md` via `SkillLoader`). This demonstrates the key design principle: the orchestrator is just runtime + skill file, identical to every other agent. The `build_default_manifest` function can be kept as a fallback or removed entirely. Consider adding a `SkillManifest` parameter to `OrchestratorConfig` or to the constructor methods. Update any tests in `crates/orchestrator/` that rely on `build_default_manifest` to use the real skill file or a test fixture.
+      Files: `crates/orchestrator/src/orchestrator.rs`, `crates/orchestrator/src/config.rs`
+      Blocked by: "Create `skills/orchestrator.md` routing skill file"
+      Non-blocking
+
+## Group 3 — Verification
+
+_Depends on: Group 2._
+
+- [x] **Run verification suite** `[S]`
+      Run `cargo check`, `cargo clippy`, and `cargo test` across the full workspace. Verify all existing tests pass including the new orchestrator skill integration test. Verify that `skills/orchestrator.md` loads through `SkillLoader` without validation errors.
+      Files: (none — command-line verification only)
+      Blocked by: All other tasks
+
+## Implementation Notes
+
+1. **`escalate_to` must be omitted, not set to `""`**: The validation rejects empty strings. Since the orchestrator is the top-level router with no escalation target, omit the `escalate_to` field from the frontmatter. The `#[serde(default)]` attribute on `Constraints.escalate_to` will default it to `None`.
+
+2. **Tool names are stubs**: `list_agents` and `route_to_agent` will not resolve in the tool-registry until issues #8-10 are complete. The integration test must use `AllToolsExist` to bypass tool-existence validation.
+
+3. **Filename must match `name` field**: `SkillLoader.load("orchestrator")` constructs path as `{skill_dir}/orchestrator.md`, so the file must be named `orchestrator.md` and have `name: orchestrator` in its frontmatter.
+
+4. **Preamble must reference the structured output format**: The preamble should mention that routing decisions are returned as structured JSON with `target_agent` and `reasoning` fields.

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
 
 use agent_sdk::{
-    async_trait, AgentError, AgentRequest, AgentResponse, Constraints, HealthStatus, MicroAgent,
-    ModelConfig, OutputSchema, SkillManifest,
+    async_trait, AgentError, AgentRequest, AgentResponse, HealthStatus, MicroAgent, SkillManifest,
 };
 use futures::future::join_all;
 use serde_json::json;
@@ -62,7 +61,10 @@ impl Orchestrator {
         self.handle_escalation(response, &request, chain).await
     }
 
-    pub fn from_config(config: OrchestratorConfig) -> Result<Self, OrchestratorError> {
+    pub fn from_config(
+        config: OrchestratorConfig,
+        manifest: SkillManifest,
+    ) -> Result<Self, OrchestratorError> {
         let client = build_shared_client();
         let agents: Vec<AgentEndpoint> = config
             .agents
@@ -70,7 +72,6 @@ impl Orchestrator {
             .map(|ac| AgentEndpoint::new(ac.name, ac.description, ac.url, client.clone()))
             .collect();
 
-        let manifest = build_default_manifest();
         Ok(Self::new(manifest, agents, None))
     }
 
@@ -137,6 +138,7 @@ impl Orchestrator {
     /// descriptions.
     pub async fn from_config_with_model<M: EmbeddingModel>(
         config: OrchestratorConfig,
+        manifest: SkillManifest,
         model: &M,
         similarity_threshold: f64,
     ) -> Result<Self, OrchestratorError> {
@@ -156,7 +158,6 @@ impl Orchestrator {
             .map(|ac| AgentEndpoint::new(ac.name, ac.description, ac.url, client.clone()))
             .collect();
 
-        let manifest = build_default_manifest();
         Ok(Self::new(manifest, agents, Some(router)))
     }
 
@@ -345,31 +346,6 @@ fn build_shared_client() -> reqwest::Client {
         .timeout(std::time::Duration::from_secs(30))
         .build()
         .expect("failed to build HTTP client")
-}
-
-fn build_default_manifest() -> SkillManifest {
-    SkillManifest {
-        name: "orchestrator".to_string(),
-        version: "0.1.0".to_string(),
-        description: "Routes requests to specialized agents".to_string(),
-        model: ModelConfig {
-            provider: "none".into(),
-            name: "none".into(),
-            temperature: 0.0,
-        },
-        preamble: String::new(),
-        tools: vec![],
-        constraints: Constraints {
-            max_turns: 1,
-            confidence_threshold: 0.0,
-            escalate_to: None,
-            allowed_actions: vec![],
-        },
-        output: OutputSchema {
-            format: "json".into(),
-            schema: HashMap::new(),
-        },
-    }
 }
 
 fn build_escalation_request(

--- a/crates/skill-loader/tests/example_skills_test.rs
+++ b/crates/skill-loader/tests/example_skills_test.rs
@@ -122,3 +122,47 @@ async fn load_skill_writer_skill() {
     assert!(!manifest.preamble.is_empty());
     assert!(manifest.preamble.contains('\n'));
 }
+
+#[tokio::test]
+async fn load_orchestrator_skill() {
+    let dir = skills_dir();
+    let loader = make_loader(&dir);
+    let manifest = loader.load("orchestrator").await.unwrap();
+
+    assert_eq!(manifest.name, "orchestrator");
+    assert_eq!(manifest.version, "1.0");
+    assert_eq!(
+        manifest.description,
+        "Routes incoming requests to the best-matching specialized agent based on intent analysis"
+    );
+
+    assert_eq!(manifest.model.provider, "anthropic");
+    assert_eq!(manifest.model.name, "claude-sonnet-4-6");
+    assert!((manifest.model.temperature - 0.1).abs() < f64::EPSILON);
+
+    assert_eq!(manifest.tools, vec!["list_agents", "route_to_agent"]);
+
+    assert_eq!(manifest.constraints.max_turns, 3);
+    assert!((manifest.constraints.confidence_threshold - 0.9).abs() < f64::EPSILON);
+    assert_eq!(manifest.constraints.escalate_to, None);
+    assert_eq!(
+        manifest.constraints.allowed_actions,
+        vec!["route", "discover"]
+    );
+
+    assert_eq!(manifest.output.format, "structured_json");
+    assert_eq!(manifest.output.schema.len(), 2);
+    assert_eq!(
+        manifest.output.schema.get("target_agent").unwrap(),
+        "string"
+    );
+    assert_eq!(
+        manifest.output.schema.get("reasoning").unwrap(),
+        "string"
+    );
+
+    assert!(!manifest.preamble.is_empty());
+    assert!(
+        manifest.preamble.contains("route") || manifest.preamble.contains("router")
+    );
+}

--- a/skills/orchestrator.md
+++ b/skills/orchestrator.md
@@ -1,0 +1,41 @@
+---
+name: orchestrator
+version: "1.0"
+description: Routes incoming requests to the best-matching specialized agent based on intent analysis
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+  temperature: 0.1
+tools:
+  - list_agents
+  - route_to_agent
+constraints:
+  max_turns: 3
+  confidence_threshold: 0.9
+  allowed_actions:
+    - route
+    - discover
+output:
+  format: structured_json
+  schema:
+    target_agent: string
+    reasoning: string
+---
+You are the orchestrator agent. Your sole responsibility is routing incoming requests to the best-matching specialized agent. You must never answer domain questions directly.
+
+## Routing Process
+
+1. Analyze the user's request to determine intent and required capabilities.
+2. Use `list_agents` to discover available agents and their capabilities.
+3. Match the request intent against agent capabilities to select the best target.
+4. Use `route_to_agent` to forward the request to the selected agent.
+
+## Rules
+
+- Never speculate about which agent to use if confidence is insufficient.
+- If no agent matches with sufficient confidence, report a no-match result instead of guessing.
+- Base routing decisions strictly on declared agent capabilities, not assumptions.
+
+## Output
+
+Routing decisions are returned as structured JSON with `target_agent` and `reasoning` fields.


### PR DESCRIPTION
## Summary

Create `skills/orchestrator.md` — the orchestrator's skill file that configures it as a pure routing agent with no domain knowledge, proving the system's homogeneity principle. Replace the hardcoded `build_default_manifest()` placeholder with a `SkillManifest` parameter on `from_config` methods, so the orchestrator loads its behavior from the same skill file format as every other agent.

## Changes

### Group 1 — Create skill file
- ✅ Create `skills/orchestrator.md` routing skill file

### Group 2 — Integration test and orchestrator wiring
- ✅ Add integration test for orchestrator skill
- ✅ Update orchestrator to load skill file instead of hardcoded manifest

### Group 3 — Verification
- ✅ Run verification suite

## Test plan

- `cargo check` — all crates compile cleanly
- `cargo clippy` — no lint warnings
- `cargo test` — all 191 tests pass (1 new skill-loader integration test)
- Verify `skills/orchestrator.md` loads through SkillLoader without validation errors

## Issue

Closes #18