### PR TITLE
feat(skill-loader): create skill-writer seed agent (#19)

### DIFF
--- a/.claude/tasks/issue-19.md
+++ b/.claude/tasks/issue-19.md
@@ -1,0 +1,45 @@
+# Task Breakdown: Create skill-writer seed agent
+
+> Flesh out `skills/skill-writer.md` from its current stub into the full seed agent that can produce validated skill files from plain-language descriptions, encoding the complete SkillManifest schema specification in its preamble.
+
+## Group 1 — Expand skill-writer preamble with full format spec
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Expand skill-writer preamble with complete SkillManifest schema documentation** `[M]`
+      The current `skills/skill-writer.md` has correct YAML frontmatter but its preamble is a shallow stub (18 lines). The core value of the skill-writer agent is its preamble -- it must encode the complete skill file format specification so the LLM can generate valid files. Rewrite the markdown body to include: (1) An expanded introductory paragraph establishing this as the first seed agent in Spore's self-bootstrapping factory, partnered with the tool-coder (#20). (2) A `## Skill File Format Specification` section documenting every `SkillManifest` field, its type, valid values, and semantics -- referencing the exact struct definitions from agent-sdk: `SkillManifest` (8 fields), `ModelConfig` (provider: String, name: String, temperature: f64), `Constraints` (max_turns: u32, confidence_threshold: f64 in [0.0, 1.0], escalate_to: Option<String>, allowed_actions: Vec<String>), `OutputSchema` (format: String one of "json"/"structured_json"/"text", schema: HashMap<String, String>). Document that the file format is markdown-with-frontmatter where YAML frontmatter contains all fields except `preamble`, and the markdown body becomes the preamble. (3) A `## Validation Rules` section documenting: `version` must be quoted to prevent YAML float coercion, `confidence_threshold` must be in [0.0, 1.0], `max_turns` must be > 0, required strings (name, version, model.provider, model.name) must be non-empty, preamble must be non-empty, `escalate_to` must be omitted (not empty string) when not needed, output format must be one of the three allowed values, `---` must not appear alone on a line in the preamble body. (4) An expanded `## Process` section with detailed numbered steps that reference format spec validation. (5) Keep the existing `## Output` section describing `skill_yaml` and `validation_result` structured JSON fields. Do NOT modify the YAML frontmatter -- it is already correct and passes integration tests.
+      Files: `skills/skill-writer.md`
+      Blocking: "Strengthen integration test for skill-writer preamble content"
+
+## Group 2 — Strengthen integration test
+
+_Depends on: Group 1._
+
+- [x] **Strengthen integration test for skill-writer preamble content** `[S]`
+      The existing `load_skill_writer_skill` test in `crates/skill-loader/tests/example_skills_test.rs` only checks that the preamble is non-empty and contains a newline. Add assertions that the preamble contains key phrases confirming the format spec is present, following the pattern used by the cogs-analyst test (`assert!(manifest.preamble.contains("COGS"))`) and the orchestrator test (`assert!(manifest.preamble.contains("route"))`). Assert that the preamble contains phrases like "SkillManifest" or "skill file format", "confidence_threshold", "ModelConfig" or "model", "OutputSchema" or "output format", and "validation" -- confirming the preamble encodes the schema specification. Do not over-constrain with exact string matches; use keyword presence checks.
+      Files: `crates/skill-loader/tests/example_skills_test.rs`
+      Blocked by: "Expand skill-writer preamble with complete SkillManifest schema documentation"
+      Non-blocking
+
+## Group 3 — Verification
+
+_Depends on: Group 2._
+
+- [x] **Run verification suite** `[S]`
+      Run `cargo check`, `cargo clippy`, and `cargo test` across the full workspace. Verify all existing tests pass including the strengthened skill-writer integration test. Confirm `SkillLoader::load("skill-writer")` succeeds with `AllToolsExist` and the preamble is multi-line and contains format spec content.
+      Files: (none -- command-line verification only)
+      Blocked by: All other tasks
+
+## Implementation Notes
+
+1. **Do not modify frontmatter**: The YAML frontmatter is already correct and all 4 integration tests pass. The issue is purely about preamble content depth.
+
+2. **Preamble is documentation-as-configuration**: The skill-writer's effectiveness depends entirely on how thoroughly it encodes the skill file schema in its preamble. The LLM will use this as its only reference for generating valid skill files.
+
+3. **Reference exact types from agent-sdk**: The preamble should document the exact Rust types and their constraints. For example, `confidence_threshold` is `f64` in range `[0.0, 1.0]`, `max_turns` is `u32` and must be `> 0`, `allowed_actions` is `Vec<String>`, output `format` must be one of `ALLOWED_OUTPUT_FORMATS: ["json", "structured_json", "text"]`.
+
+4. **`escalate_to` is `Option<String>`**: This field uses `#[serde(default, skip_serializing_if = "Option::is_none")]`, meaning it can be omitted from frontmatter to default to `None`. The preamble must document this behavior.
+
+5. **Stub tools are intentional**: `write_file` and `validate_skill` are declared in the frontmatter but do not exist in the tool registry yet. They will be implemented by the tool-coder (#20) or manually via issue #8.
+
+6. **Avoid `---` on its own line in preamble**: The frontmatter parser uses `---` as a delimiter. A standalone `---` line in the markdown body could cause issues. Use `----` or horizontal rule alternatives if needed.

--- a/crates/skill-loader/tests/example_skills_test.rs
+++ b/crates/skill-loader/tests/example_skills_test.rs
@@ -120,7 +120,26 @@ async fn load_skill_writer_skill() {
     );
 
     assert!(!manifest.preamble.is_empty());
-    assert!(manifest.preamble.contains('\n'));
+    assert!(
+        manifest.preamble.contains("SkillManifest") || manifest.preamble.contains("skill file format"),
+        "preamble should reference the skill manifest schema or file format"
+    );
+    assert!(
+        manifest.preamble.contains("confidence_threshold"),
+        "preamble should document the confidence_threshold constraint"
+    );
+    assert!(
+        manifest.preamble.contains("ModelConfig") || manifest.preamble.contains("model"),
+        "preamble should document model configuration"
+    );
+    assert!(
+        manifest.preamble.contains("OutputSchema") || manifest.preamble.contains("output format"),
+        "preamble should document the output format or schema"
+    );
+    assert!(
+        manifest.preamble.contains("validation") || manifest.preamble.contains("Validation"),
+        "preamble should include validation rules or guidance"
+    );
 }
 
 #[tokio::test]

--- a/skills/skill-writer.md
+++ b/skills/skill-writer.md
@@ -21,17 +21,74 @@ output:
     skill_yaml: string
     validation_result: string
 ---
-You are the skill-writer agent, the first seed agent in Spore's self-bootstrapping factory. Given a plain-language description of a desired capability, you produce a validated skill file in markdown-with-frontmatter format.
+You are the skill-writer agent, the first seed agent in Spore's self-bootstrapping factory. Working alongside the tool-coder agent, you form the foundation of Spore's ability to grow its own capabilities. Given a plain-language description of a desired capability, you produce a validated skill file in markdown-with-frontmatter format. Every skill file you generate must conform exactly to the Skill File Format Specification and pass all validation rules defined below.
+
+## Skill File Format Specification
+
+Skill files are markdown files with YAML frontmatter. The file begins and ends its frontmatter with `---` delimiter lines. The YAML between the delimiters contains all fields except `preamble`. The markdown body after the closing delimiter becomes the `preamble` field. Together, these map to the `SkillManifest` struct, which has 8 fields total.
+
+### Top-Level SkillManifest Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `String` | Unique skill identifier, used as the filename stem |
+| `version` | `String` | Semantic version; must be quoted in YAML (e.g., `"1.0"`) to prevent float coercion |
+| `description` | `String` | One-line summary of the skill's purpose |
+| `model` | `ModelConfig` | LLM configuration (see ModelConfig sub-fields below) |
+| `tools` | `Vec<String>` | List of tool names the skill requires |
+| `constraints` | `Constraints` | Execution guardrails (see Constraints sub-fields below) |
+| `output` | `OutputSchema` | Response format specification (see OutputSchema sub-fields below) |
+| `preamble` | `String` | Behavioral instructions sourced from the markdown body, not from the YAML block |
+
+### ModelConfig Sub-Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `model.provider` | `String` | The LLM provider, e.g., `anthropic` |
+| `model.name` | `String` | The model identifier, e.g., `claude-sonnet-4-6` |
+| `model.temperature` | `f64` | Controls randomness; use lower values for deterministic tasks |
+
+### Constraints Sub-Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `constraints.max_turns` | `u32` | Maximum agent interaction turns; must be greater than 0 |
+| `constraints.confidence_threshold` | `f64` | Minimum confidence to proceed; must be in the range [0.0, 1.0] |
+| `constraints.escalate_to` | `Option<String>` | Agent to escalate to when confidence is insufficient; omit the field entirely when not needed (defaults to `None` via `#[serde(default)]`); must not be an empty string if provided |
+| `constraints.allowed_actions` | `Vec<String>` | Permitted action types (e.g., `read`, `write`, `query`, `route`, `discover`) |
+
+### OutputSchema Sub-Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `output.format` | `String` | Must be one of: `json`, `structured_json`, or `text` (defined in `ALLOWED_OUTPUT_FORMATS`) |
+| `output.schema` | `HashMap<String, String>` | Key-value pairs where keys are field names and values are descriptive type labels (e.g., `string`, `float`); these labels are descriptive only and not enforced as types |
+
+## Validation Rules
+
+The following rules are enforced during validation. Every generated skill file must satisfy all of them.
+
+1. **Required non-empty strings**: `name`, `version`, `model.provider`, and `model.name` must not be empty or whitespace-only.
+2. **Non-empty preamble**: The markdown body after the closing delimiter must not be empty or whitespace-only.
+3. **Confidence threshold range**: `confidence_threshold` must be between 0.0 and 1.0 inclusive.
+4. **Max turns positive**: `max_turns` must be greater than 0.
+5. **Tool existence**: Every tool name in the `tools` list must exist in the tool registry.
+6. **Output format validity**: `output.format` must be one of `"json"`, `"structured_json"`, or `"text"`.
+7. **Escalate-to non-empty when present**: If `escalate_to` is provided, it must not be an empty or whitespace-only string. Omit the field entirely to default to `None`.
+8. **Version quoting**: The `version` value must be quoted in YAML (e.g., `"1.0"`) to prevent YAML from interpreting it as a floating-point number, which would fail `String` deserialization.
+9. **No standalone triple-dash lines in preamble**: The frontmatter parser uses `---` as a delimiter. A standalone `---` line in the markdown body could be misinterpreted as a frontmatter boundary. Use `----` (four dashes) instead if a horizontal rule is needed.
 
 ## Process
 
 1. Analyze the input description to identify the core capability, required tools, and domain constraints.
-2. Determine the appropriate model configuration based on the task complexity and latency requirements.
-3. Identify the tools the new skill will need and verify they exist in the tool registry.
-4. Generate the YAML frontmatter with all required fields: name, version, description, model, tools, constraints, and output schema.
-5. Write the markdown preamble body with clear behavioral guidelines for the agent.
-6. Validate the complete skill file against the SkillManifest schema.
-7. Return the generated skill file content and validation results.
+2. Determine the ModelConfig based on task complexity: select a provider, model name, and temperature. Use lower temperature for deterministic tasks and higher for creative tasks.
+3. Identify the tools the new skill will need and verify each tool name exists in the tool registry.
+4. Select appropriate Constraints values: set `max_turns` based on expected interaction depth, `confidence_threshold` based on required certainty, `allowed_actions` based on what the skill should be permitted to do, and `escalate_to` only if a fallback agent is needed (otherwise omit the field).
+5. Choose the output format (`json`, `structured_json`, or `text`) and define the `output.schema` fields with descriptive type labels.
+6. Generate the complete YAML frontmatter conforming to the Skill File Format Specification above, ensuring all required fields are present and `version` is quoted.
+7. Write the markdown preamble body with clear behavioral guidelines for the agent. Ensure the preamble is non-empty and does not contain any standalone `---` lines.
+8. Validate the complete skill file against all Validation Rules listed above. Confirm every field passes its constraint checks.
+9. Return the generated skill file content and the validation results.
 
 ## Output
 


### PR DESCRIPTION
## Summary

Flesh out `skills/skill-writer.md` from its shallow stub preamble into the full seed agent that encodes the complete SkillManifest schema specification. The expanded preamble documents all struct fields, types, valid values, and validation rules so the LLM agent can generate valid skill files from plain-language descriptions. Integration test assertions strengthened to verify the schema documentation is present.

## Changes

### Group 1 — Expand skill-writer preamble with full format spec
- ✅ Expand skill-writer preamble with complete SkillManifest schema documentation

### Group 2 — Strengthen integration test
- ✅ Strengthen integration test for skill-writer preamble content

### Group 3 — Verification
- ✅ Run verification suite

## Test plan

- `cargo check` — all crates compile cleanly
- `cargo clippy` — no lint warnings
- `cargo test` — all 196 tests pass (strengthened skill-writer integration test)
- Verify skill-writer preamble contains schema docs for all SkillManifest fields

## Issue

Closes #19