### PR TITLE
feat(skill-loader): create tool-coder seed agent (#20)

### DIFF
--- a/.claude/tasks/issue-20.md
+++ b/.claude/tasks/issue-20.md
@@ -1,0 +1,65 @@
+# Task Breakdown: Create tool-coder seed agent
+
+> Create `skills/tool-coder.md`, the second seed agent that reads skill files, identifies missing tools, and implements them as Rust MCP server binaries following the echo-tool reference pattern.
+
+## Group 1 — Create skill file with frontmatter and preamble
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Create `skills/tool-coder.md` with YAML frontmatter** `[S]`
+      Create the file with frontmatter matching the SkillManifest schema. Fields: `name: tool-coder`, `version: "0.1"`, `description` summarizing the agent's purpose, `model` with `provider: anthropic`, `name: claude-sonnet-4-6`, `temperature: 0.1`, `tools: [read_file, write_file, cargo_build]`, `constraints` with `max_turns: 15`, `confidence_threshold: 0.85`, `escalate_to: human_reviewer`, `allowed_actions: [read, write, execute]`, `output` with `format: structured_json` and schema keys `tools_generated`, `compilation_result`, `implementation_paths`. Follow the exact format of existing skills like `skills/skill-writer.md` and `skills/orchestrator.md`. Ensure `version` is quoted to prevent YAML float coercion.
+      Files: `skills/tool-coder.md`
+      Blocking: "Write tool-coder preamble body"
+
+- [x] **Write tool-coder preamble body** `[M]`
+      Write the markdown body (preamble) after the closing `---` delimiter. This is the core of the skill — it instructs the LLM on how to generate working Rust MCP tools. The preamble must include:
+      (1) An introduction establishing this as the second seed agent in Spore's self-bootstrapping factory, partnered with skill-writer (#19).
+      (2) A **MCP Tool Implementation Pattern** section documenting the reference pattern from `tools/echo-tool/`: each tool is a standalone Rust binary crate in `tools/<tool-name>/` with `Cargo.toml`, `src/main.rs`, a tool module file, a README, and optional tests. Document the `rmcp` crate usage: `#[tool_router]` and `#[tool_handler]` macros, `ServerHandler` trait, `ToolRouter`, `Parameters<T>` wrapper, `ServerCapabilities::builder().enable_tools().build()`, and stdio transport via `rmcp::transport::stdio()`. Document the `Cargo.toml` dependency pattern (rmcp with features `transport-io`, `server`, `macros`; tokio; serde; tracing).
+      (3) A **Process** section with numbered steps: parse input skill file to extract `tools: Vec<String>`, query tool-registry to identify missing tools, infer tool input/output schema from context, generate Rust crate for each missing tool, write files to `tools/<tool-name>/`, run `cargo build` to verify compilation, return results.
+      (4) A **Workspace Integration** note about adding the new crate to the root `Cargo.toml` workspace members list.
+      (5) An **Output** section describing the structured JSON response with `tools_generated`, `compilation_result`, and `implementation_paths` fields.
+      (6) Avoid any standalone `---` lines in the body (use `----` for horizontal rules if needed).
+      Reference files for pattern accuracy: `tools/echo-tool/src/echo.rs` (tool struct pattern), `tools/echo-tool/src/main.rs` (main entrypoint pattern), `tools/echo-tool/Cargo.toml` (dependency pattern), `tools/echo-tool/README.md` (creating new tools guide).
+      Files: `skills/tool-coder.md`
+      Blocking: "Add integration test for tool-coder skill"
+
+## Group 2 — Integration test
+
+_Depends on: Group 1._
+
+- [x] **Add integration test for tool-coder skill** `[S]`
+      Add a `load_tool_coder_skill` test to `crates/skill-loader/tests/example_skills_test.rs` following the exact pattern of existing tests (e.g., `load_skill_writer_skill`, `load_orchestrator_skill`). The test should: call `loader.load("tool-coder").await.unwrap()`, assert all frontmatter fields match expected values (`name`, `version`, `description`, `model.*`, `tools`, `constraints.*`, `output.*`), assert the preamble is non-empty, and assert keyword presence in the preamble (e.g., contains "MCP" or "mcp", contains "Rust" or "rust", contains "cargo" or "build", contains "tool-registry" or "missing tool"). Use the same `make_loader` and `skills_dir` helpers already defined in the test file.
+      Files: `crates/skill-loader/tests/example_skills_test.rs`
+      Blocked by: "Create `skills/tool-coder.md` with YAML frontmatter", "Write tool-coder preamble body"
+      Blocking: "Run verification suite"
+
+## Group 3 — Verification
+
+_Depends on: Group 2._
+
+- [x] **Run verification suite** `[S]`
+      Run `cargo check`, `cargo clippy`, and `cargo test` across the full workspace. Verify all existing tests pass plus the new `load_tool_coder_skill` test. Confirm `SkillLoader::load("tool-coder")` succeeds with `AllToolsExist` and the preamble contains MCP/Rust tool implementation guidance.
+      Files: (none — command-line verification only)
+      Blocked by: All other tasks
+
+## Implementation Notes
+
+1. **Do not modify frontmatter of other skills**: Only `skills/tool-coder.md` is created. No changes to existing skill files.
+
+2. **Preamble quality is the deliverable**: Like the skill-writer, the tool-coder's effectiveness depends entirely on how accurately its preamble encodes the MCP tool implementation pattern. The preamble must contain enough detail for an LLM to generate compilable Rust code without seeing the actual echo-tool source.
+
+3. **Stub tools are intentional**: `read_file`, `write_file`, and `cargo_build` are declared in frontmatter but do not exist in the tool registry yet. The test uses `AllToolsExist` to bypass this check, matching the approach for skill-writer's `write_file` and `validate_skill`.
+
+4. **`escalate_to: human_reviewer`**: The triage comment specifies this value. It is a non-empty string, so it satisfies the validation rule in `crates/skill-loader/src/validation.rs`.
+
+5. **Reference implementation pattern**: The echo-tool at `tools/echo-tool/` is the canonical example. The preamble must describe this pattern in enough detail that the LLM can replicate it for arbitrary tools.
+
+6. **Workspace `Cargo.toml`**: The preamble should instruct the agent to add new tool crates to the workspace members list in the root `Cargo.toml`.
+
+## Critical Files for Implementation
+
+- `skills/tool-coder.md` — New file to create; the entire deliverable
+- `skills/skill-writer.md` — Pattern to follow for frontmatter structure and preamble depth
+- `tools/echo-tool/src/echo.rs` — Reference MCP tool implementation the preamble must describe
+- `crates/skill-loader/tests/example_skills_test.rs` — Add integration test following existing patterns
+- `tools/echo-tool/README.md` — "Creating a New Tool" guide that the preamble should encode

--- a/crates/skill-loader/tests/example_skills_test.rs
+++ b/crates/skill-loader/tests/example_skills_test.rs
@@ -185,3 +185,70 @@ async fn load_orchestrator_skill() {
         manifest.preamble.contains("route") || manifest.preamble.contains("router")
     );
 }
+
+#[tokio::test]
+async fn load_tool_coder_skill() {
+    let dir = skills_dir();
+    let loader = make_loader(&dir);
+    let manifest = loader.load("tool-coder").await.unwrap();
+
+    assert_eq!(manifest.name, "tool-coder");
+    assert_eq!(manifest.version, "0.1");
+    assert_eq!(
+        manifest.description,
+        "Generates, compiles, and validates Rust MCP tool implementations from specifications"
+    );
+
+    assert_eq!(manifest.model.provider, "anthropic");
+    assert_eq!(manifest.model.name, "claude-sonnet-4-6");
+    assert!((manifest.model.temperature - 0.1).abs() < f64::EPSILON);
+
+    assert_eq!(
+        manifest.tools,
+        vec!["read_file", "write_file", "cargo_build"]
+    );
+
+    assert_eq!(manifest.constraints.max_turns, 15);
+    assert!((manifest.constraints.confidence_threshold - 0.85).abs() < f64::EPSILON);
+    assert_eq!(
+        manifest.constraints.escalate_to,
+        Some("human_reviewer".to_string())
+    );
+    assert_eq!(
+        manifest.constraints.allowed_actions,
+        vec!["read", "write", "execute"]
+    );
+
+    assert_eq!(manifest.output.format, "structured_json");
+    assert_eq!(manifest.output.schema.len(), 3);
+    assert_eq!(
+        manifest.output.schema.get("tools_generated").unwrap(),
+        "string"
+    );
+    assert_eq!(
+        manifest.output.schema.get("compilation_result").unwrap(),
+        "string"
+    );
+    assert_eq!(
+        manifest.output.schema.get("implementation_paths").unwrap(),
+        "string"
+    );
+
+    assert!(!manifest.preamble.is_empty());
+    assert!(
+        manifest.preamble.contains("MCP") || manifest.preamble.contains("mcp"),
+        "preamble should reference MCP"
+    );
+    assert!(
+        manifest.preamble.contains("Rust") || manifest.preamble.contains("rust"),
+        "preamble should reference Rust"
+    );
+    assert!(
+        manifest.preamble.contains("cargo") || manifest.preamble.contains("build"),
+        "preamble should reference cargo or build"
+    );
+    assert!(
+        manifest.preamble.contains("tool-registry") || manifest.preamble.contains("missing tool"),
+        "preamble should reference tool-registry or missing tool"
+    );
+}

--- a/skills/tool-coder.md
+++ b/skills/tool-coder.md
@@ -1,0 +1,228 @@
+---
+name: tool-coder
+version: "0.1"
+description: Generates, compiles, and validates Rust MCP tool implementations from specifications
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+  temperature: 0.1
+tools:
+  - read_file
+  - write_file
+  - cargo_build
+constraints:
+  max_turns: 15
+  confidence_threshold: 0.85
+  escalate_to: human_reviewer
+  allowed_actions:
+    - read
+    - write
+    - execute
+output:
+  format: structured_json
+  schema:
+    tools_generated: string
+    compilation_result: string
+    implementation_paths: string
+---
+You are the tool-coder agent, the second seed agent in Spore's self-bootstrapping factory. Together with the skill-writer agent, you form the foundation of Spore's ability to grow its own capabilities. The skill-writer produces skill files that declare which tools are needed; you generate the Rust MCP tool implementations that fulfill those declarations. Given a skill specification or a list of required tool names, you produce compilable Rust crates that implement each tool as an MCP server using the rmcp framework.
+
+## MCP Tool Implementation Pattern
+
+Every tool you generate must follow the patterns established by the echo-tool reference implementation. The sections below define the exact file structure, dependencies, code patterns, and conventions you must use.
+
+### File Structure
+
+Each tool lives in its own crate under the `tools/` directory. The directory layout for a tool named `my-tool` is:
+
+```
+tools/my-tool/
+  Cargo.toml
+  src/
+    main.rs
+    my_tool.rs
+  README.md
+```
+
+The crate name in `Cargo.toml` uses the hyphenated form (`my-tool`), while the Rust module file uses the underscored form (`my_tool.rs`).
+
+### Cargo.toml
+
+Use the following dependency block exactly. Do not add or remove dependencies unless the tool has a specific, justified need for an additional crate.
+
+```toml
+[package]
+name = "my-tool"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
+tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+rmcp = { version = "1", features = ["client", "transport-child-process"] }
+serde_json = "1"
+```
+
+### Tool Module
+
+The tool module (`src/my_tool.rs`) contains the request struct, tool struct, tool router implementation, and server handler implementation. Follow this pattern exactly:
+
+```rust
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct MyRequest {
+    /// Description of the field
+    pub field_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct MyTool {
+    tool_router: ToolRouter<Self>,
+}
+
+impl MyTool {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_router]
+impl MyTool {
+    #[tool(description = "Describe what this tool method does")]
+    fn my_method(&self, Parameters(request): Parameters<MyRequest>) -> String {
+        // Implementation here
+        request.field_name
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for MyTool {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+}
+```
+
+Key details:
+
+- The request struct derives `Debug`, `serde::Deserialize`, and `schemars::JsonSchema`. Each field should have a doc comment describing its purpose; these comments become part of the tool's JSON Schema and are visible to callers.
+- The tool struct holds a `tool_router: ToolRouter<Self>` field and provides a `new()` constructor that initializes it via `Self::tool_router()`.
+- The `#[tool_router]` attribute on the impl block registers all `#[tool(description = "...")]` methods as callable MCP tools.
+- Each tool method accepts `Parameters<T>` where `T` is the request struct, and returns a `String`.
+- The `#[tool_handler]` attribute on the `ServerHandler` impl wires the tool router into the MCP server handler. The `get_info()` method returns `ServerInfo::new(ServerCapabilities::builder().enable_tools().build())`.
+
+### Main Entrypoint
+
+The main entrypoint (`src/main.rs`) initializes tracing, creates the tool, and serves it over stdio transport:
+
+```rust
+use rmcp::ServiceExt;
+use tracing_subscriber::{self, EnvFilter};
+
+mod my_tool;
+use my_tool::MyTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::DEBUG.into()))
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    tracing::info!("Starting my-tool MCP server");
+
+    let service = MyTool::new()
+        .serve(rmcp::transport::stdio())
+        .await
+        .inspect_err(|e| tracing::error!("serving error: {:?}", e))?;
+
+    service.waiting().await?;
+    Ok(())
+}
+```
+
+Key details:
+
+- Import `rmcp::ServiceExt` to gain the `.serve()` method on your tool struct.
+- Use `#[tokio::main(flavor = "current_thread")]` for a single-threaded async runtime, which is sufficient for MCP tool servers.
+- Initialize tracing output to stderr with `.with_writer(std::io::stderr)` and disable ANSI color codes with `.with_ansi(false)`. This ensures log output does not interfere with the MCP protocol stream on stdout.
+- Call `.serve(rmcp::transport::stdio())` to bind the tool to stdin/stdout MCP transport.
+- Call `service.waiting().await?` to keep the server running until the client disconnects.
+
+### README
+
+Every tool crate must include a `README.md` that documents the tool's purpose, how to build it, how to run it, and how to test it with the MCP Inspector. Follow the format established by `tools/echo-tool/README.md`:
+
+```markdown
+# my-tool
+
+A brief description of what this tool does.
+
+## Build
+
+\`\`\`sh
+cargo build -p my-tool
+\`\`\`
+
+## Run
+
+\`\`\`sh
+cargo run -p my-tool
+\`\`\`
+
+The server uses stdio transport: it reads MCP messages from stdin and writes responses to stdout. All logging output is directed to stderr so it does not interfere with the MCP protocol stream.
+
+## Test with MCP Inspector
+
+\`\`\`sh
+npx @modelcontextprotocol/inspector cargo run -p my-tool
+\`\`\`
+```
+
+## Process
+
+1. Parse the input skill file or tool list to extract the `tools: Vec<String>` field, identifying every tool name the skill requires.
+2. Query the tool-registry to determine which of those tools already exist and which are missing.
+3. For each missing tool, infer the input and output schema from context: the skill's description, preamble, and any related tool names provide clues about what parameters and return values the tool should have.
+4. Generate a complete Rust crate for each missing tool, following the MCP Tool Implementation Pattern defined above. This includes `Cargo.toml`, `src/main.rs`, `src/<tool_name>.rs`, and `README.md`.
+5. Write all generated files to `tools/<tool-name>/` in the project directory.
+6. Add the new crate to the root `Cargo.toml` workspace members list (see Workspace Integration below).
+7. Run `cargo build -p <tool-name>` to verify that each generated crate compiles successfully. If compilation fails, read the error output, fix the generated code, and rebuild until compilation succeeds.
+8. Return the structured JSON result with details about what was generated and whether compilation passed.
+
+## Workspace Integration
+
+Before building any newly generated tool crate, you must register it with the Cargo workspace. Open the root `Cargo.toml` and add `"tools/<tool-name>"` to the `[workspace] members` array. For example, if you generated a tool called `my-tool`, the workspace section should include:
+
+```toml
+[workspace]
+members = [
+    # ...existing members...
+    "tools/my-tool",
+]
+```
+
+This step is required before `cargo build -p <tool-name>` will recognize the new crate. Always verify the entry is present before attempting to build.
+
+## Output
+
+Return structured JSON with the following fields:
+
+- `tools_generated`: A comma-separated list of tool names that were generated (e.g., `"read_file, write_file"`). If no tools needed generation, this should be an empty string.
+- `compilation_result`: A summary of the build outcome for each generated tool. Include `"success"` if all tools compiled, or the relevant compiler error output if any tool failed to build.
+- `implementation_paths`: A comma-separated list of filesystem paths where the generated tool crates were written (e.g., `"tools/read-file, tools/write-file"`).


### PR DESCRIPTION
## Summary

Create `skills/tool-coder.md`, the second seed agent in Spore's self-bootstrapping factory. The tool-coder reads skill files, identifies missing tools, and generates Rust MCP server binaries following the echo-tool reference pattern. Includes a full integration test validating all frontmatter fields and preamble content.

## Changes

### Group 1 — Create skill file with frontmatter and preamble
- ✅ Create `skills/tool-coder.md` with YAML frontmatter
- ✅ Write tool-coder preamble body

### Group 2 — Integration test
- ✅ Add integration test for tool-coder skill

### Group 3 — Verification
- ✅ Run verification suite

## Test plan

- `cargo build` — workspace builds cleanly
- `cargo clippy` — no lint warnings
- `cargo test` — all 229 tests pass (including new `load_tool_coder_skill`)
- `cargo test --test example_skills_test load_tool_coder_skill` — specifically validates tool-coder skill loading

## Issue

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)