### PR TITLE
feat(skill-loader): build deploy-agent using the factory (#21)

### DIFF
--- a/.claude/tasks/issue-21.md
+++ b/.claude/tasks/issue-21.md
@@ -1,0 +1,74 @@
+# Task Breakdown: Build deploy-agent using the factory
+
+> Create `skills/deploy-agent.md`, the third agent and first factory-produced agent, which packages a runtime binary and skill file into a minimal Docker image, pushes it to a registry, and registers the new agent endpoint with the orchestrator.
+
+## Group 1 — Create skill file with frontmatter and preamble
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Create `skills/deploy-agent.md` with YAML frontmatter** `[S]`
+      Create the file with frontmatter matching the SkillManifest schema. Fields: `name: deploy-agent`, `version: "0.1"`, `description` summarizing the agent's purpose (packages a runtime binary and skill file into a minimal Docker image, pushes to a registry, and registers the agent with the orchestrator), `model` with `provider: anthropic`, `name: claude-sonnet-4-6`, `temperature: 0.1`, `tools: [docker_build, docker_push, register_agent]`, `constraints` with `max_turns: 10`, `confidence_threshold: 0.9`, `escalate_to: human_reviewer`, `allowed_actions: [read, execute, deploy]`, `output` with `format: structured_json` and schema keys `image_uri: string`, `endpoint_url: string`, `health_check: string`. Follow the exact format of existing skills like `skills/skill-writer.md` and `skills/tool-coder.md`. Ensure `version` is quoted to prevent YAML float coercion.
+      Files: `skills/deploy-agent.md`
+      Blocking: "Write deploy-agent preamble body"
+
+- [x] **Write deploy-agent preamble body** `[M]`
+      Write the markdown body (preamble) after the closing `---` delimiter. This is the core of the skill — it instructs the LLM on how to build, push, and register agent containers. The preamble must include:
+      (1) An introduction establishing this as the third agent in Spore's self-bootstrapping factory and the first agent produced BY the factory (skill-writer + tool-coder). Explain that this closes the self-extension loop: from this point, new agents are described, written, tooled, and deployed entirely within the system.
+      (2) A **Docker Build Process** section documenting the build pattern from the project `Dockerfile`: multi-stage build, compile with `cargo build --release --target x86_64-unknown-linux-musl` for a fully static binary, `FROM scratch` final stage, copy the agent-runtime binary and skill file, copy CA certificates for TLS, expose port 8080, run as non-root user 1000. Reference that images should be 1-5MB.
+      (3) An **Image Tagging Convention** section: tag images as `spore-{agent-name}:{version}` derived from the skill manifest's `name` and `version` fields (from `SkillManifest` in `crates/agent-sdk/src/skill_manifest.rs`).
+      (4) A **Registry Push** section: push the built image to the configured container registry (sourced from environment variable or configuration).
+      (5) An **Orchestrator Registration** section: call the orchestrator's agent registry API to register the new agent's HTTP endpoint so it becomes discoverable and routable. Reference that the orchestrator uses `list_agents` and `route_to_agent` tools (from `skills/orchestrator.md`).
+      (6) A **Health Verification** section: after deployment, call `/health` on the new agent endpoint to verify it started correctly before reporting success.
+      (7) A **Process** section with numbered steps: receive the skill name and version, locate the compiled agent-runtime binary and skill file, build the Docker image following the scratch-based pattern, tag it with the naming convention, push to the registry, register the endpoint with the orchestrator, verify health, return results.
+      (8) An **Output** section describing the structured JSON response with `image_uri` (registry path of the pushed image), `endpoint_url` (HTTP endpoint where the agent is reachable), and `health_check` (result of the post-deployment health verification).
+      (9) Avoid any standalone `---` lines in the body (use `----` for horizontal rules if needed).
+      Reference files for accuracy: `Dockerfile` (Docker build pattern), `crates/agent-sdk/src/skill_manifest.rs` (manifest fields for tagging), `crates/agent-runtime/src/main.rs` (the binary being packaged), `skills/orchestrator.md` (registration target), `README.md` lines 109-118 (self-bootstrapping factory description).
+      Files: `skills/deploy-agent.md`
+      Blocking: "Add integration test for deploy-agent skill"
+
+## Group 2 — Integration test
+
+_Depends on: Group 1._
+
+- [x] **Add integration test for deploy-agent skill** `[S]`
+      Add a `load_deploy_agent_skill` test to `crates/skill-loader/tests/example_skills_test.rs` following the exact pattern of existing tests (e.g., `load_tool_coder_skill`, `load_skill_writer_skill`). The test should: call `loader.load("deploy-agent").await.unwrap()`, assert all frontmatter fields match expected values (`name: "deploy-agent"`, `version: "0.1"`, `description` contains "Docker" or "deploy", `model.provider: "anthropic"`, `model.name: "claude-sonnet-4-6"`, `model.temperature: 0.1`, `tools: ["docker_build", "docker_push", "register_agent"]`, `constraints.max_turns: 10`, `constraints.confidence_threshold: 0.9`, `constraints.escalate_to: Some("human_reviewer")`, `constraints.allowed_actions: ["read", "execute", "deploy"]`, `output.format: "structured_json"`, `output.schema` has 3 keys: `image_uri`, `endpoint_url`, `health_check`). Assert the preamble is non-empty and contains keyword presence checks: "Docker" or "docker" or "container", "registry" or "push", "orchestrator" or "register", "health" or "verify", "scratch" or "minimal". Use the same `make_loader` and `skills_dir` helpers already defined in the test file.
+      Files: `crates/skill-loader/tests/example_skills_test.rs`
+      Blocked by: "Create `skills/deploy-agent.md` with YAML frontmatter", "Write deploy-agent preamble body"
+      Blocking: "Run verification suite"
+
+## Group 3 — Verification
+
+_Depends on: Group 2._
+
+- [x] **Run verification suite** `[S]`
+      Run `cargo check`, `cargo clippy`, and `cargo test` across the full workspace. Verify all existing tests pass plus the new `load_deploy_agent_skill` test. Confirm `SkillLoader::load("deploy-agent")` succeeds with `AllToolsExist` and the preamble contains Docker deployment guidance.
+      Files: (none — command-line verification only)
+      Blocked by: All other tasks
+
+## Implementation Notes
+
+1. **Do not modify frontmatter of other skills**: Only `skills/deploy-agent.md` is created. No changes to existing skill files.
+
+2. **Preamble quality is the deliverable**: Like skill-writer and tool-coder, the deploy-agent's effectiveness depends on how thoroughly its preamble encodes the deployment process. The preamble must contain enough detail for an LLM to orchestrate Docker builds, registry pushes, and orchestrator registration without seeing the actual Dockerfile or runtime source.
+
+3. **Stub tools are intentional**: `docker_build`, `docker_push`, and `register_agent` are declared in frontmatter but do not exist in the tool registry yet. They will be implemented by the tool-coder agent or manually via the tool-registry (issue #8). The test uses `AllToolsExist` to bypass this check, matching the approach used for skill-writer and tool-coder.
+
+4. **`escalate_to: human_reviewer`**: The triage comment specifies this value. It is a non-empty string, so it satisfies the validation rule in `crates/skill-loader/src/validation.rs`.
+
+5. **`deploy` is a new action category**: The `allowed_actions` list includes `deploy` alongside `read` and `execute`. This is a new action type not used by other skills. The validation layer does not restrict action names to a fixed set, so this is valid.
+
+6. **Heavy infrastructure dependencies at runtime**: The deploy-agent skill file can be created and tested now (it is just a markdown file with YAML frontmatter), but it cannot be functionally exercised until Docker tooling, a container registry, and the orchestrator registration API are implemented (issues #8-15). This issue is specifically about the skill file, not the tools.
+
+7. **Docker-in-Docker consideration**: The preamble should note that if the deploy-agent runs inside a container itself, it needs Docker access (socket mounting or remote builder). This is a deployment concern to document but not solve in this issue.
+
+8. **Reference the existing Dockerfile pattern**: The project already has a well-structured `Dockerfile` with dependency caching, musl static linking, `FROM scratch`, CA certificate copying, and non-root user. The preamble should describe this exact pattern rather than inventing a new one.
+
+## Critical Files for Implementation
+
+- `skills/deploy-agent.md` — New file to create; the primary deliverable
+- `skills/tool-coder.md` — Pattern to follow for frontmatter structure and preamble depth
+- `Dockerfile` — Reference for the Docker build pattern the preamble must describe
+- `crates/agent-sdk/src/skill_manifest.rs` — SkillManifest struct for image tagging convention
+- `crates/agent-runtime/src/main.rs` — The binary being packaged
+- `skills/orchestrator.md` — Registration target reference
+- `crates/skill-loader/tests/example_skills_test.rs` — Add integration test following existing patterns

--- a/crates/skill-loader/tests/example_skills_test.rs
+++ b/crates/skill-loader/tests/example_skills_test.rs
@@ -252,3 +252,74 @@ async fn load_tool_coder_skill() {
         "preamble should reference tool-registry or missing tool"
     );
 }
+
+#[tokio::test]
+async fn load_deploy_agent_skill() {
+    let dir = skills_dir();
+    let loader = make_loader(&dir);
+    let manifest = loader.load("deploy-agent").await.unwrap();
+
+    assert_eq!(manifest.name, "deploy-agent");
+    assert_eq!(manifest.version, "0.1");
+    assert_eq!(
+        manifest.description,
+        "Packages a runtime binary and skill file into a minimal Docker image, pushes to a registry, and registers the agent with the orchestrator"
+    );
+
+    assert_eq!(manifest.model.provider, "anthropic");
+    assert_eq!(manifest.model.name, "claude-sonnet-4-6");
+    assert!((manifest.model.temperature - 0.1).abs() < f64::EPSILON);
+
+    assert_eq!(
+        manifest.tools,
+        vec!["docker_build", "docker_push", "register_agent"]
+    );
+
+    assert_eq!(manifest.constraints.max_turns, 10);
+    assert!((manifest.constraints.confidence_threshold - 0.9).abs() < f64::EPSILON);
+    assert_eq!(
+        manifest.constraints.escalate_to,
+        Some("human_reviewer".to_string())
+    );
+    assert_eq!(
+        manifest.constraints.allowed_actions,
+        vec!["read", "execute", "deploy"]
+    );
+
+    assert_eq!(manifest.output.format, "structured_json");
+    assert_eq!(manifest.output.schema.len(), 3);
+    assert_eq!(
+        manifest.output.schema.get("image_uri").unwrap(),
+        "string"
+    );
+    assert_eq!(
+        manifest.output.schema.get("endpoint_url").unwrap(),
+        "string"
+    );
+    assert_eq!(
+        manifest.output.schema.get("health_check").unwrap(),
+        "string"
+    );
+
+    assert!(!manifest.preamble.is_empty());
+    assert!(
+        manifest.preamble.contains("Docker") || manifest.preamble.contains("docker") || manifest.preamble.contains("container"),
+        "preamble should reference Docker or containerization"
+    );
+    assert!(
+        manifest.preamble.contains("registry") || manifest.preamble.contains("push"),
+        "preamble should reference pushing to a registry"
+    );
+    assert!(
+        manifest.preamble.contains("orchestrator") || manifest.preamble.contains("register"),
+        "preamble should reference registering with the orchestrator"
+    );
+    assert!(
+        manifest.preamble.contains("health") || manifest.preamble.contains("verify"),
+        "preamble should reference health checks or verification"
+    );
+    assert!(
+        manifest.preamble.contains("scratch") || manifest.preamble.contains("minimal"),
+        "preamble should reference minimal/scratch-based images"
+    );
+}

--- a/skills/deploy-agent.md
+++ b/skills/deploy-agent.md
@@ -1,0 +1,154 @@
+---
+name: deploy-agent
+version: "0.1"
+description: Packages a runtime binary and skill file into a minimal Docker image, pushes to a registry, and registers the agent with the orchestrator
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+  temperature: 0.1
+tools:
+  - docker_build
+  - docker_push
+  - register_agent
+constraints:
+  max_turns: 10
+  confidence_threshold: 0.9
+  escalate_to: human_reviewer
+  allowed_actions:
+    - read
+    - execute
+    - deploy
+output:
+  format: structured_json
+  schema:
+    image_uri: string
+    endpoint_url: string
+    health_check: string
+---
+You are the deploy-agent, the third agent in Spore's self-bootstrapping factory and the first agent produced BY the factory itself. The skill-writer agent authors skill files, the tool-coder agent implements the tools those skill files declare, and you package the result into a deployable container. With your existence, the self-extension loop closes: Spore can now describe a new capability in plain language, generate its skill file, implement its tools, build a Docker image, push it to a registry, and register the new agent with the orchestrator, all without human intervention.
+
+## Docker Build Process
+
+Every agent image uses a two-stage Dockerfile pattern that produces a minimal, fully static binary with no OS layer.
+
+### Stage 1: Builder
+
+The first stage starts from `rust:latest` and installs `musl-tools` for static linking:
+
+```dockerfile
+FROM rust:latest AS builder
+RUN apt-get update && apt-get install -y musl-tools && rm -rf /var/lib/apt/lists/*
+RUN rustup target add x86_64-unknown-linux-musl
+```
+
+The build command targets musl for a fully static binary:
+
+```sh
+cargo build --release --target x86_64-unknown-linux-musl -p agent-runtime
+```
+
+To maximize Docker layer caching, the builder stage uses a dependency caching strategy: it first copies only `Cargo.toml` and `Cargo.lock` files, creates stub source files (`echo "" > src/lib.rs` or `echo "fn main() {}" > src/main.rs`), and runs the build once to cache all dependency compilation. Then it copies the real source files and rebuilds, so only the project crates are recompiled on source changes. This avoids downloading and compiling the full dependency tree on every build.
+
+The builder stage finishes by verifying that the resulting binary is statically linked using `file` and `grep`.
+
+### Stage 2: Final Image
+
+The second stage starts `FROM scratch`, producing an image with no operating system, no shell, and no utilities. Only three things are copied in:
+
+1. The statically linked `agent-runtime` binary
+2. The skill files directory (`/skills/`)
+3. CA certificates for TLS (`/etc/ssl/certs/ca-certificates.crt`)
+
+```dockerfile
+FROM scratch
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/agent-runtime /agent-runtime
+COPY skills/ /skills/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+```
+
+The image exposes port 8080 and runs as non-root user 1000 for security. Expected image size is 1-5MB, since it contains only a static binary with no OS layer.
+
+### Environment Variables
+
+The following environment variables are baked into the image:
+
+- `SKILL_NAME` — Set via build arg, identifies which skill file the agent loads at startup.
+- `SKILL_DIR=/skills` — Directory where skill markdown files are stored inside the container.
+- `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt` — Path to the CA certificate bundle for outbound TLS connections.
+
+### Docker-in-Docker Caveat
+
+When the deploy-agent itself runs inside a container, building Docker images requires either mounting the host Docker socket (`-v /var/run/docker.sock:/var/run/docker.sock`) or connecting to a remote builder endpoint. Socket mounting is simpler but grants the container full Docker daemon access on the host. For production environments, prefer a remote builder or a dedicated builder service with scoped permissions.
+
+## Image Tagging Convention
+
+Images are tagged using the `name` and `version` fields from the SkillManifest:
+
+```
+spore-{agent-name}:{version}
+```
+
+For example, this agent's skill manifest has `name: deploy-agent` and `version: "0.1"`, so its image tag is:
+
+```
+spore-deploy-agent:0.1
+```
+
+The `name` and `version` fields are extracted directly from the YAML frontmatter of the skill file, which is parsed into a `SkillManifest` struct containing `name: String` and `version: String` among other fields.
+
+## Registry Push
+
+After building and tagging the image, push it to the container registry specified by the `REGISTRY_URL` environment variable. The full image reference combines the registry URL with the standard tag:
+
+```
+{REGISTRY_URL}/spore-{agent-name}:{version}
+```
+
+For example, if `REGISTRY_URL=ghcr.io/spore`, the deploy-agent image would be pushed as:
+
+```
+ghcr.io/spore/spore-deploy-agent:0.1
+```
+
+Authentication to the registry is assumed to be pre-configured via `docker login` or equivalent credential helpers in the environment.
+
+## Orchestrator Registration
+
+Once the container is running, register the agent with the orchestrator so it appears in `list_agents` responses and can be targeted by `route_to_agent`. The registration payload includes:
+
+- **Agent name** — The `name` field from the skill manifest (e.g., `deploy-agent`).
+- **Endpoint URL** — The HTTP address where the agent is reachable (e.g., `http://deploy-agent:8080`).
+- **Capabilities** — The `description` and `tools` fields from the skill manifest, so the orchestrator can match incoming requests to this agent's declared abilities.
+
+Use the `register_agent` tool to submit this information. The orchestrator stores the registration and immediately makes the agent available for routing.
+
+## Health Verification
+
+After registration, verify the agent is healthy and ready to accept requests. Send an HTTP GET request to:
+
+```
+{endpoint_url}/health
+```
+
+Expect a `200 OK` response. If the container is still starting, the health endpoint may not respond immediately. Retry with exponential backoff (starting at 1 second, doubling up to 30 seconds) until the health check succeeds or the maximum retry count is exhausted.
+
+Do not mark the deployment as successful until the health check returns 200.
+
+## Process
+
+1. Receive the skill name and version identifying the agent to deploy.
+2. Locate the compiled `agent-runtime` binary and the corresponding skill file in the `skills/` directory.
+3. Build the Docker image using the two-stage Dockerfile pattern, passing `SKILL_NAME` as a build argument.
+4. Tag the image as `spore-{agent-name}:{version}` using the name and version from the skill manifest.
+5. Push the tagged image to the container registry at `{REGISTRY_URL}/spore-{agent-name}:{version}`.
+6. Register the agent with the orchestrator via `register_agent`, providing the agent name, endpoint URL, and capabilities.
+7. Verify the agent is healthy by polling `{endpoint_url}/health` until a 200 OK response is received.
+8. Return the structured JSON result with the image URI, endpoint URL, and health check status.
+
+## Output
+
+Return structured JSON with the following fields:
+
+- `image_uri`: The full image reference that was pushed to the registry (e.g., `ghcr.io/spore/spore-deploy-agent:0.1`). This is the canonical identifier for retrieving or redeploying this exact image version.
+- `endpoint_url`: The HTTP address where the deployed agent is reachable (e.g., `http://deploy-agent:8080`). Other agents and the orchestrator use this URL to send requests.
+- `health_check`: The result of the post-deployment health verification. Contains `"healthy"` if the agent responded with 200 OK, or an error description if the health check failed after exhausting retries.


### PR DESCRIPTION
## Summary

Create `skills/deploy-agent.md`, the third agent and first factory-produced agent in Spore's self-bootstrapping system. The deploy-agent packages a runtime binary and skill file into a minimal Docker image, pushes it to a container registry, and registers the new agent endpoint with the orchestrator. Includes a full integration test validating all frontmatter fields and preamble content.

## Changes

### Group 1 — Create skill file with frontmatter and preamble
- ✅ Create `skills/deploy-agent.md` with YAML frontmatter
- ✅ Write deploy-agent preamble body

### Group 2 — Integration test
- ✅ Add integration test for deploy-agent skill

### Group 3 — Verification
- ✅ Run verification suite

## Test plan

- `cargo build` — workspace builds cleanly
- `cargo clippy` — no lint warnings
- `cargo test` — all 213 tests pass (including new `load_deploy_agent_skill`)
- `cargo test --test example_skills_test load_deploy_agent_skill` — specifically validates deploy-agent skill loading

## Issue

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)