### PR TITLE
feat(read-file): implement read_file MCP tool (#44)

### DIFF
--- a/.claude/tasks/issue-44.md
+++ b/.claude/tasks/issue-44.md
@@ -1,0 +1,77 @@
+# Task Breakdown: Implement read_file MCP tool
+
+> Implement `read_file` as a standalone Rust MCP server binary that reads file contents from disk, following the `echo-tool` reference pattern exactly.
+
+## Group 1 — Scaffold the crate
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Create `tools/read-file/Cargo.toml`** `[S]`
+      Copy and adapt `tools/echo-tool/Cargo.toml`. Change `name = "read-file"`. Keep the same dependencies: `rmcp` with `transport-io`, `server`, `macros` features; `tokio` with `macros`, `rt`, `io-std`; `serde` with `derive`; `serde_json`; `tracing`; `tracing-subscriber` with `env-filter`. Add the same `[dev-dependencies]` block with `tokio` `rt-multi-thread`, `rmcp` with `client` and `transport-child-process`, and `serde_json` — these are needed for the integration test.
+      Files: `tools/read-file/Cargo.toml`
+      Blocking: "Implement `ReadFileTool` struct and handler", "Write `main.rs`", "Write integration test"
+
+- [x] **Add `"tools/read-file"` to workspace `Cargo.toml`** `[S]`
+      Add `"tools/read-file"` to the `members` list in the root `Cargo.toml`, following the same pattern as `"tools/echo-tool"`. This makes `cargo build -p read-file` and `cargo test -p read-file` work.
+      Files: `Cargo.toml`
+      Blocking: "Run verification suite"
+
+## Group 2 — Core implementation
+
+_Depends on: Group 1_
+
+- [x] **Implement `ReadFileTool` struct and handler in `src/read_file.rs`** `[M]`
+      Create `tools/read-file/src/read_file.rs`. Define `ReadFileRequest { path: String }` with `#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]` and a doc comment `/// The path to the file to read (absolute or relative)`. Define `ReadFileTool { tool_router: ToolRouter<Self> }` with `new()` calling `Self::tool_router()`. Annotate the `impl` block with `#[tool_router]` and add a `read_file` method with `#[tool(description = "Read the contents of a file from disk and return them as a string")]`. The method signature is `fn read_file(&self, Parameters(request): Parameters<ReadFileRequest>) -> String`. Implementation: call `std::fs::read_to_string(&request.path)` and return the content on success; on `Err`, return a descriptive error string like `format!("Error reading '{}': {}", request.path, e)`. Keep the method under 15 lines by keeping error formatting inline. Annotate `impl ServerHandler for ReadFileTool` with `#[tool_handler]` and implement `get_info()` returning `ServerInfo::new(ServerCapabilities::builder().enable_tools().build())`. Add `#[cfg(test)] mod tests` with unit tests: (1) `read_file_returns_content` — write a temp file using `std::fs::write`, call the tool, assert the content matches; (2) `read_file_returns_error_for_missing_file` — call with a nonexistent path, assert the returned string contains "Error"; (3) `read_file_returns_error_for_directory` — call with a directory path (e.g., `/tmp`), assert the returned string contains "Error". Use `std::env::temp_dir()` for portable temp file paths.
+      Files: `tools/read-file/src/read_file.rs`
+      Blocked by: "Create `tools/read-file/Cargo.toml`"
+      Blocking: "Write `main.rs`", "Write integration test"
+
+- [x] **Write `src/main.rs`** `[S]`
+      Create `tools/read-file/src/main.rs`. Mirror `tools/echo-tool/src/main.rs` exactly, but change module name to `read_file`, struct name to `ReadFileTool`, and the log line to `"Starting read-file MCP server"`. The file should be under 25 lines.
+      Files: `tools/read-file/src/main.rs`
+      Blocked by: "Implement `ReadFileTool` struct and handler in `src/read_file.rs`"
+      Blocking: "Write integration test"
+
+## Group 3 — Integration test
+
+_Depends on: Group 2_
+
+- [x] **Write integration test in `tests/read_file_server_test.rs`** `[M]`
+      Create `tools/read-file/tests/read_file_server_test.rs`. Mirror `tools/echo-tool/tests/echo_server_test.rs`. Use `env!("CARGO_BIN_EXE_read-file")` to spawn the binary as a child process via `TokioChildProcess`. Write these tests (each annotated `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`): (1) `tools_list_returns_read_file_tool` — assert `tools_result.tools.len() == 1` and `tools[0].name == "read_file"`; (2) `tools_list_read_file_has_correct_description` — assert description contains `"Read the contents of a file"`; (3) `tools_list_read_file_has_path_parameter` — assert `input_schema` properties contain `"path"`; (4) `tools_call_read_file_returns_content` — write a temp file with `std::fs::write`, call the tool with the path, assert the response text matches the written content; (5) `tools_call_read_file_returns_error_for_missing_file` — call the tool with a nonexistent path, assert the response text contains `"Error"`.
+      Files: `tools/read-file/tests/read_file_server_test.rs`
+      Blocked by: "Write `main.rs`"
+      Blocking: "Write `README.md`"
+
+## Group 4 — Documentation and registration
+
+_Depends on: Group 3_
+
+- [x] **Write `README.md`** `[S]`
+      Create `tools/read-file/README.md`. Model it after `tools/echo-tool/README.md`. Include sections: build command (`cargo build -p read-file`), run command (`cargo run -p read-file`), description of stdio transport, MCP Inspector test command (`npx @modelcontextprotocol/inspector cargo run -p read-file`), input/output description (`path` input, file contents or error string as output). Keep it short (under 40 lines).
+      Files: `tools/read-file/README.md`
+      Blocked by: "Write integration test in `tests/read_file_server_test.rs`"
+      Blocking: "Run verification suite"
+
+## Group 5 — Verification
+
+_Depends on: Groups 1–4_
+
+- [x] **Run verification suite** `[S]`
+      Run `cargo build -p read-file`, then `cargo test -p read-file`, then `cargo clippy -p read-file`, then `cargo check` (workspace-wide) to confirm no regressions. All four acceptance criteria from the issue must pass: build succeeds, tests pass, `tools/list` and `tools/call` work over stdio (verified by integration tests), and the tool name in `tools/list` is `read_file`.
+      Files: (none — command-line verification only)
+      Blocked by: All previous tasks
+      Blocking: None
+
+---
+
+## Implementation Notes
+
+1. **No new dependencies**: All dependencies (`rmcp`, `tokio`, `serde`, `serde_json`, `tracing`, `tracing-subscriber`) already appear in `tools/echo-tool/Cargo.toml`. No third-party crates need to be added.
+
+2. **Error handling returns a string**: The `rmcp` `#[tool_router]` macro expects the tool method to return `String`. Errors are surfaced as descriptive error strings (not `Result`), consistent with how simple tools communicate failure over MCP text content type.
+
+3. **Binary name**: The `[package] name = "read-file"` means the binary is `read-file` and the env macro is `CARGO_BIN_EXE_read-file`. The MCP tool name exposed over the protocol is `read_file` (snake_case method name).
+
+4. **File size guard**: The issue does not specify a size limit. A size guard can be added as a follow-up; it should not block this issue.
+
+5. **Registry is environment-driven**: The `agent-runtime` reads `TOOL_ENDPOINTS` env var. No code changes to the registry are needed — operators configure `read_file=mcp://localhost:<port>` to register the tool at runtime.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,6 +1392,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-file"
+version = "0.1.0"
+dependencies = [
+ "rmcp 1.2.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/agent-runtime",
     "crates/orchestrator",
     "tools/echo-tool",
+    "tools/read-file",
 ]
 
 [profile.release]

--- a/tools/read-file/Cargo.toml
+++ b/tools/read-file/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "read-file"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
+tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+rmcp = { version = "1", features = ["client", "transport-child-process"] }
+serde_json = "1"

--- a/tools/read-file/README.md
+++ b/tools/read-file/README.md
@@ -1,0 +1,37 @@
+# read-file
+
+An MCP tool server that reads the contents of a file from disk and returns them as a string.
+
+## Build
+
+```sh
+cargo build -p read-file
+```
+
+## Run
+
+```sh
+cargo run -p read-file
+```
+
+The server uses stdio transport: it reads MCP messages from stdin and writes responses to stdout. All logging output is directed to stderr so it does not interfere with the MCP protocol stream.
+
+## Test with MCP Inspector
+
+```sh
+npx @modelcontextprotocol/inspector cargo run -p read-file
+```
+
+This launches the MCP Inspector, which connects to the read-file server and provides an interactive UI for sending requests and viewing responses. Use it to verify that the tool advertises its capabilities and handles calls correctly.
+
+## Tool
+
+### `read_file`
+
+Reads the contents of a file from disk and returns them as a string.
+
+| Input | Type   | Description                              |
+|-------|--------|------------------------------------------|
+| path  | string | Path to the file (absolute or relative)  |
+
+On success, returns the full text content of the file. On failure, returns an error string starting with `"Error"` that includes the path and a description of the problem.

--- a/tools/read-file/src/main.rs
+++ b/tools/read-file/src/main.rs
@@ -1,0 +1,24 @@
+use rmcp::ServiceExt;
+use tracing_subscriber::{self, EnvFilter};
+
+mod read_file;
+use read_file::ReadFileTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::DEBUG.into()))
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    tracing::info!("Starting read-file MCP server");
+
+    let service = ReadFileTool::new()
+        .serve(rmcp::transport::stdio())
+        .await
+        .inspect_err(|e| tracing::error!("serving error: {:?}", e))?;
+
+    service.waiting().await?;
+    Ok(())
+}

--- a/tools/read-file/src/read_file.rs
+++ b/tools/read-file/src/read_file.rs
@@ -1,0 +1,79 @@
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ReadFileRequest {
+    /// The path to the file to read (absolute or relative)
+    pub path: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReadFileTool {
+    tool_router: ToolRouter<Self>,
+}
+
+impl ReadFileTool {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_router]
+impl ReadFileTool {
+    #[tool(description = "Read the contents of a file from disk and return them as a string")]
+    fn read_file(&self, Parameters(request): Parameters<ReadFileRequest>) -> String {
+        match std::fs::read_to_string(&request.path) {
+            Ok(content) => content,
+            Err(e) => format!("Error reading '{}': {}", request.path, e),
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for ReadFileTool {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn read_file_returns_content() {
+        let path = std::env::temp_dir().join("read_file_test_content.txt");
+        std::fs::write(&path, "hello from file").unwrap();
+        let tool = ReadFileTool::new();
+        let result = tool.read_file(Parameters(ReadFileRequest {
+            path: path.to_string_lossy().to_string(),
+        }));
+        assert_eq!(result, "hello from file");
+    }
+
+    #[tokio::test]
+    async fn read_file_returns_error_for_missing_file() {
+        let tool = ReadFileTool::new();
+        let result = tool.read_file(Parameters(ReadFileRequest {
+            path: std::env::temp_dir()
+                .join("read_file_nonexistent_abc123.txt")
+                .to_string_lossy()
+                .to_string(),
+        }));
+        assert!(result.contains("Error"));
+    }
+
+    #[tokio::test]
+    async fn read_file_returns_error_for_directory() {
+        let tool = ReadFileTool::new();
+        let result = tool.read_file(Parameters(ReadFileRequest {
+            path: std::env::temp_dir().to_string_lossy().to_string(),
+        }));
+        assert!(result.contains("Error"));
+    }
+}

--- a/tools/read-file/tests/read_file_server_test.rs
+++ b/tools/read-file/tests/read_file_server_test.rs
@@ -1,0 +1,135 @@
+use rmcp::{
+    model::CallToolRequestParams,
+    service::RunningService,
+    transport::TokioChildProcess,
+    RoleClient, ServiceExt,
+};
+use tokio::process::Command;
+
+/// Spawn the read-file binary as a child process and connect an MCP client.
+async fn spawn_read_file_client() -> RunningService<RoleClient, ()> {
+    let transport = TokioChildProcess::new(Command::new(env!("CARGO_BIN_EXE_read-file")))
+        .expect("failed to spawn read-file");
+
+    ().serve(transport)
+        .await
+        .expect("failed to connect to read-file server")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_returns_read_file_tool() {
+    let client = spawn_read_file_client().await;
+
+    let tools_result = client.peer().list_tools(None).await.expect("list_tools");
+    assert_eq!(tools_result.tools.len(), 1, "expected exactly 1 tool");
+    assert_eq!(
+        tools_result.tools[0].name, "read_file",
+        "expected tool named 'read_file'"
+    );
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_read_file_has_correct_description() {
+    let client = spawn_read_file_client().await;
+
+    let tools_result = client.peer().list_tools(None).await.expect("list_tools");
+    let tool = &tools_result.tools[0];
+    let description = tool
+        .description
+        .as_deref()
+        .expect("read_file tool should have a description");
+    assert!(
+        description.contains("Read the contents of a file"),
+        "unexpected description: {description}"
+    );
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_read_file_has_path_parameter() {
+    let client = spawn_read_file_client().await;
+
+    let tools_result = client.peer().list_tools(None).await.expect("list_tools");
+    let tool = &tools_result.tools[0];
+    let properties = tool
+        .input_schema
+        .get("properties")
+        .expect("input_schema should have properties");
+    assert!(
+        properties.get("path").is_some(),
+        "input_schema properties should contain 'path'"
+    );
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_read_file_returns_content() {
+    let client = spawn_read_file_client().await;
+
+    let temp_path = std::env::temp_dir().join("read_file_integration_test_content.txt");
+    let expected_content = "integration test file content";
+    std::fs::write(&temp_path, expected_content).expect("failed to write temp file");
+    let path_str = temp_path.to_string_lossy().to_string();
+
+    let params = CallToolRequestParams::new("read_file").with_arguments(
+        serde_json::json!({ "path": path_str })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    assert!(!result.content.is_empty(), "response content should not be empty");
+    let text = result.content[0]
+        .as_text()
+        .expect("first content should be text");
+    assert!(
+        text.text.contains(expected_content),
+        "response should contain file contents, got: {}",
+        text.text
+    );
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_read_file_returns_error_for_missing_file() {
+    let client = spawn_read_file_client().await;
+
+    let nonexistent_path = std::env::temp_dir()
+        .join("read_file_integration_nonexistent_xyz987.txt")
+        .to_string_lossy()
+        .to_string();
+
+    let params = CallToolRequestParams::new("read_file").with_arguments(
+        serde_json::json!({ "path": nonexistent_path })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    assert!(!result.content.is_empty(), "response content should not be empty");
+    let text = result.content[0]
+        .as_text()
+        .expect("first content should be text");
+    assert!(
+        text.text.contains("Error"),
+        "response should contain 'Error' for missing file, got: {}",
+        text.text
+    );
+
+    client.cancel().await.expect("failed to cancel client");
+}


### PR DESCRIPTION
## Summary

This PR implements the `read_file` MCP tool as a new crate under `tools/read-file/`. The server exposes a single `read_file` tool via the MCP `tools/list` and `tools/call` protocol over stdio transport. It accepts a `path` parameter (absolute or relative) and returns the file contents on success, or a descriptive error string on failure. Follows the `echo-tool` reference pattern exactly.

## Changes

### Group 1 — Scaffold the crate
- ✅ Create `tools/read-file/Cargo.toml`
- ✅ Add `"tools/read-file"` to workspace `Cargo.toml`

### Group 2 — Core implementation
- ✅ Implement `ReadFileTool` struct and handler in `src/read_file.rs`
- ✅ Write `src/main.rs`

### Group 3 — Integration test
- ✅ Write integration test in `tests/read_file_server_test.rs`

### Group 4 — Documentation
- ✅ Write `README.md`

### Group 5 — Verification
- ✅ Run verification suite

## Test plan

- `cargo build -p read-file` — binary builds cleanly
- `cargo test -p read-file` — all 8 tests pass (3 unit + 5 integration)
- `cargo clippy -p read-file` — no warnings
- `cargo check` — no workspace-wide regressions
- Integration tests confirm `tools/list` returns `read_file` and `tools/call` returns file contents over stdio

Closes #44