### PR TITLE
feat(tools): implement cargo_build MCP tool (#47)

### DIFF
--- a/.claude/tasks/issue-47.md
+++ b/.claude/tasks/issue-47.md
@@ -1,0 +1,90 @@
+# Task Breakdown: Implement cargo_build MCP tool
+
+> Implement `cargo_build` as a standalone Rust MCP server binary that runs `cargo build` on a specified package and returns structured output, following the echo-tool reference pattern.
+
+## Group 1 — Scaffold the crate
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Create `tools/cargo-build/Cargo.toml`** `[S]`
+      Copy and adapt `tools/echo-tool/Cargo.toml`. Change `name = "cargo-build"`. Keep the same dependencies: `rmcp` with `transport-io`, `server`, `macros` features; `tokio` with `macros`, `rt`, `io-std`; `serde` with `derive`; `serde_json`; `mcp-tool-harness` path dependency. Add the same `[dev-dependencies]` block with `tokio` `rt-multi-thread`, `rmcp` with `client` and `transport-child-process`, `serde_json`, and `mcp-test-utils` path dependency.
+      Files: `tools/cargo-build/Cargo.toml`
+      Blocking: "Implement `CargoBuildTool` struct and handler", "Write `main.rs`", "Write integration test"
+
+- [x] **Add `"tools/cargo-build"` to workspace `Cargo.toml`** `[S]`
+      Add `"tools/cargo-build"` to the `members` list in the root `Cargo.toml`, following the same ordering pattern as the other tool entries.
+      Files: `Cargo.toml`
+      Blocking: "Run verification suite"
+
+## Group 2 — Core implementation
+
+_Depends on: Group 1_
+
+- [x] **Implement `CargoBuildTool` struct and handler in `src/cargo_build.rs`** `[M]`
+      Create `tools/cargo-build/src/cargo_build.rs`. Define `CargoBuildRequest` with `#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]` containing two fields: `package: String` (doc comment: `/// Package name to build (passed as -p <package>)`) and `release: Option<bool>` (doc comment: `/// Whether to build in release mode`). Define `CargoBuildTool { tool_router: ToolRouter<Self> }` with `new()` calling `Self::tool_router()`.
+
+      Before invoking the build, validate the `package` field: it must match `^[a-zA-Z0-9_-]+$` (alphanumeric, hyphens, underscores only) to prevent command injection. Use a simple character check without adding a regex dependency. If validation fails, return a JSON error string immediately.
+
+      Annotate the impl block with `#[tool_router]` and add a `cargo_build` method with `#[tool(description = "Run cargo build on a specified package and return the result")]`. The method uses `std::process::Command::new("cargo")` with args `["build", "-p", &request.package]`, conditionally appending `"--release"` if `request.release == Some(true)`. Capture output with `.output()`. Return a JSON string (via `serde_json::json!`) containing `success` (bool from `status.success()`), `stdout` (String from lossy UTF-8), `stderr` (String from lossy UTF-8), and `exit_code` (i32 from `status.code().unwrap_or(-1)`). On `Command` spawn failure, return a JSON error with `success: false` and the error message in `stderr`.
+
+      Implement `ServerHandler` with `#[tool_handler]` returning tools-enabled capabilities.
+
+      Add `#[cfg(test)] mod tests` with unit tests: (1) `rejects_invalid_package_name` — call with `"foo; rm -rf /"`, assert result contains an error indication; (2) `rejects_package_with_path_separator` — call with `"../evil"`, assert result contains an error; (3) `validates_clean_package_name` — call with `"echo-tool"`, assert the result is valid JSON containing expected fields (this test will actually run cargo build, so it exercises the real path).
+      Files: `tools/cargo-build/src/cargo_build.rs`
+      Blocked by: "Create `tools/cargo-build/Cargo.toml`"
+      Blocking: "Write `main.rs`", "Write integration test"
+
+- [x] **Write `src/main.rs`** `[S]`
+      Create `tools/cargo-build/src/main.rs`. Mirror `tools/echo-tool/src/main.rs` exactly: declare `mod cargo_build;`, use the struct, and call `mcp_tool_harness::serve_stdio_tool(CargoBuildTool::new(), "cargo-build").await`. The file should be under 10 lines.
+      Files: `tools/cargo-build/src/main.rs`
+      Blocked by: "Implement `CargoBuildTool` struct and handler in `src/cargo_build.rs`"
+      Blocking: "Write integration test"
+
+## Group 3 — Integration test
+
+_Depends on: Group 2_
+
+- [x] **Write integration test in `tests/cargo_build_server_test.rs`** `[M]`
+      Create `tools/cargo-build/tests/cargo_build_server_test.rs`. Mirror the pattern from `tools/echo-tool/tests/echo_server_test.rs`. Use `env!("CARGO_BIN_EXE_cargo-build")` to spawn the binary. Write these tests (each `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`):
+
+      (1) `tools_list_returns_cargo_build_tool` — use `mcp_test_utils::assert_single_tool` to verify the tool name is `"cargo_build"`, description contains `"cargo build"`, and parameters include `["package", "release"]`.
+
+      (2) `tools_call_builds_echo_tool_successfully` — call the tool with `{"package": "echo-tool"}`, parse the response text as JSON, assert `success` is `true` and `exit_code` is `0`.
+
+      (3) `tools_call_returns_error_for_nonexistent_package` — call with `{"package": "nonexistent-package-xyz"}`, parse JSON, assert `success` is `false` and `stderr` is non-empty.
+
+      (4) `tools_call_rejects_invalid_package_name` — call with `{"package": "foo;bar"}`, assert the response indicates an error (validation rejection before command execution).
+
+      Files: `tools/cargo-build/tests/cargo_build_server_test.rs`
+      Blocked by: "Write `main.rs`"
+      Blocking: None
+
+## Group 4 — Verification
+
+_Depends on: Groups 1–3_
+
+- [x] **Run verification suite** `[S]`
+      Run `cargo build -p cargo-build`, then `cargo test -p cargo-build`, then `cargo clippy -p cargo-build`, then `cargo check` (workspace-wide) to confirm no regressions. All acceptance criteria from the issue must pass: build succeeds, tests pass, successfully builds a target package with structured output, returns compiler errors in `stderr` on failure, tool is named `cargo_build` in MCP tools/list.
+      Files: (none — command-line verification only)
+      Blocked by: All previous tasks
+      Blocking: None
+
+---
+
+## Implementation Notes
+
+1. **No new dependencies**: All dependencies (`rmcp`, `tokio`, `serde`, `serde_json`, `mcp-tool-harness`) already appear in `tools/echo-tool/Cargo.toml`. No regex crate is needed — use a simple `.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_')` check for package name validation.
+
+2. **Security**: The `package` input is validated to contain only `[a-zA-Z0-9_-]` characters before being passed to `std::process::Command`. This prevents shell injection. The command is invoked directly via `Command::new("cargo")` (not via a shell), which provides an additional layer of safety since arguments are not interpreted by a shell.
+
+3. **Return format**: The tool returns a JSON string (not a Rust `Result`) because the `#[tool_router]` macro expects `String` return type, matching the pattern established by `echo-tool` and `read-file`. The JSON structure (`success`, `stdout`, `stderr`, `exit_code`) provides structured data that calling agents can parse.
+
+4. **Binary vs tool name**: The `[package] name = "cargo-build"` means the binary is `cargo-build` and the env macro is `CARGO_BIN_EXE_cargo-build`. The MCP tool name exposed over the protocol is `cargo_build` (the snake_case method name from the `#[tool_router]` macro).
+
+5. **Integration test uses real cargo**: The test `tools_call_builds_echo_tool_successfully` invokes a real `cargo build -p echo-tool`. This is acceptable because `echo-tool` is a workspace member that is already built during test runs.
+
+6. **Reference files**:
+   - `tools/echo-tool/src/echo.rs` — Reference pattern for tool struct, macros, unit tests
+   - `tools/echo-tool/Cargo.toml` — Template for dependencies
+   - `tools/echo-tool/tests/echo_server_test.rs` — Pattern for integration tests
+   - `crates/mcp-test-utils/src/lib.rs` — Test utilities (spawn_mcp_client, assert_single_tool)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cargo-build-tool"
+version = "0.1.0"
+dependencies = [
+ "mcp-test-utils",
+ "mcp-tool-harness",
+ "rmcp 1.2.0",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cargo-build-tool"
+name = "cargo-build"
 version = "0.1.0"
 dependencies = [
  "mcp-test-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "tools/read-file",
     "tools/write-file",
     "tools/validate-skill",
+    "tools/cargo-build",
 ]
 
 [profile.release]

--- a/tools/cargo-build/Cargo.toml
+++ b/tools/cargo-build/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cargo-build"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }
+rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
+tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+rmcp = { version = "1", features = ["client", "transport-child-process"] }
+serde_json = "1"

--- a/tools/cargo-build/src/cargo_build.rs
+++ b/tools/cargo-build/src/cargo_build.rs
@@ -1,0 +1,117 @@
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CargoBuildRequest {
+    /// Package name to build (passed as -p <package>)
+    pub package: String,
+    /// Whether to build in release mode
+    pub release: Option<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CargoBuildTool {
+    tool_router: ToolRouter<Self>,
+}
+
+impl CargoBuildTool {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+fn validate_package_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+#[tool_router]
+impl CargoBuildTool {
+    #[tool(description = "Run cargo build on a specified package and return the result")]
+    fn cargo_build(&self, Parameters(request): Parameters<CargoBuildRequest>) -> String {
+        if !validate_package_name(&request.package) {
+            return serde_json::json!({
+                "success": false,
+                "stderr": format!("Invalid package name: {}", request.package)
+            })
+            .to_string();
+        }
+
+        let mut cmd = std::process::Command::new("cargo");
+        cmd.args(["build", "-p", &request.package]);
+
+        if request.release == Some(true) {
+            cmd.arg("--release");
+        }
+
+        match cmd.output() {
+            Ok(output) => serde_json::json!({
+                "success": output.status.success(),
+                "stdout": String::from_utf8_lossy(&output.stdout),
+                "stderr": String::from_utf8_lossy(&output.stderr),
+                "exit_code": output.status.code(),
+            })
+            .to_string(),
+            Err(e) => serde_json::json!({
+                "success": false,
+                "stderr": format!("Failed to execute cargo: {e}"),
+            })
+            .to_string(),
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for CargoBuildTool {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call_cargo_build(tool: &CargoBuildTool, package: &str, release: Option<bool>) -> String {
+        tool.cargo_build(Parameters(CargoBuildRequest {
+            package: package.to_string(),
+            release,
+        }))
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_package_name() {
+        let tool = CargoBuildTool::new();
+        let result = call_cargo_build(&tool, "foo; rm -rf /", None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["stderr"].as_str().unwrap().contains("Invalid package name"));
+    }
+
+    #[tokio::test]
+    async fn rejects_package_with_path_separator() {
+        let tool = CargoBuildTool::new();
+        let result = call_cargo_build(&tool, "../evil", None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["stderr"].as_str().unwrap().contains("Invalid package name"));
+    }
+
+    #[tokio::test]
+    async fn validates_clean_package_name() {
+        let tool = CargoBuildTool::new();
+        let result = call_cargo_build(&tool, "echo-tool", None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(json.get("success").is_some());
+        assert!(json.get("stdout").is_some());
+        assert!(json.get("stderr").is_some());
+        assert!(json.get("exit_code").is_some());
+    }
+}

--- a/tools/cargo-build/src/cargo_build.rs
+++ b/tools/cargo-build/src/cargo_build.rs
@@ -56,7 +56,7 @@ impl CargoBuildTool {
                 "success": output.status.success(),
                 "stdout": String::from_utf8_lossy(&output.stdout),
                 "stderr": String::from_utf8_lossy(&output.stderr),
-                "exit_code": output.status.code(),
+                "exit_code": output.status.code().unwrap_or(-1),
             })
             .to_string(),
             Err(e) => serde_json::json!({
@@ -86,26 +86,32 @@ mod tests {
         }))
     }
 
-    #[tokio::test]
-    async fn rejects_invalid_package_name() {
+    #[test]
+    fn rejects_invalid_package_name() {
         let tool = CargoBuildTool::new();
         let result = call_cargo_build(&tool, "foo; rm -rf /", None);
         let json: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert_eq!(json["success"], false);
-        assert!(json["stderr"].as_str().unwrap().contains("Invalid package name"));
+        assert!(json["stderr"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid package name"));
     }
 
-    #[tokio::test]
-    async fn rejects_package_with_path_separator() {
+    #[test]
+    fn rejects_package_with_path_separator() {
         let tool = CargoBuildTool::new();
         let result = call_cargo_build(&tool, "../evil", None);
         let json: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert_eq!(json["success"], false);
-        assert!(json["stderr"].as_str().unwrap().contains("Invalid package name"));
+        assert!(json["stderr"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid package name"));
     }
 
-    #[tokio::test]
-    async fn validates_clean_package_name() {
+    #[test]
+    fn validates_clean_package_name() {
         let tool = CargoBuildTool::new();
         let result = call_cargo_build(&tool, "echo-tool", None);
         let json: serde_json::Value = serde_json::from_str(&result).unwrap();

--- a/tools/cargo-build/src/main.rs
+++ b/tools/cargo-build/src/main.rs
@@ -1,0 +1,7 @@
+mod cargo_build;
+use cargo_build::CargoBuildTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(CargoBuildTool::new(), "cargo-build").await
+}

--- a/tools/cargo-build/tests/cargo_build_server_test.rs
+++ b/tools/cargo-build/tests/cargo_build_server_test.rs
@@ -1,0 +1,105 @@
+use rmcp::model::CallToolRequestParams;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_returns_cargo_build_tool() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_cargo-build")).await;
+    mcp_test_utils::assert_single_tool(&client, "cargo_build", "cargo build", &["package", "release"]).await;
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_builds_echo_tool_successfully() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_cargo-build")).await;
+
+    let params = CallToolRequestParams::new("cargo_build").with_arguments(
+        serde_json::json!({ "package": "echo-tool" })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
+    assert_eq!(json["success"], true, "build should succeed");
+    assert_eq!(json["exit_code"], 0, "exit code should be 0");
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_returns_error_for_nonexistent_package() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_cargo-build")).await;
+
+    let params = CallToolRequestParams::new("cargo_build").with_arguments(
+        serde_json::json!({ "package": "nonexistent-package-xyz" })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
+    assert_eq!(json["success"], false, "build should fail");
+    assert!(
+        !json["stderr"].as_str().unwrap_or("").is_empty(),
+        "stderr should be non-empty"
+    );
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_rejects_invalid_package_name() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_cargo-build")).await;
+
+    let params = CallToolRequestParams::new("cargo_build").with_arguments(
+        serde_json::json!({ "package": "foo;bar" })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
+    assert_eq!(json["success"], false, "build should fail for invalid name");
+    assert!(
+        json["stderr"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Invalid package name"),
+        "stderr should contain 'Invalid package name', got: {}",
+        json["stderr"]
+    );
+
+    client.cancel().await.expect("failed to cancel client");
+}


### PR DESCRIPTION
## Summary

Implement `cargo_build` as a standalone Rust MCP server binary that runs `cargo build` on a specified package and returns structured JSON output with success status, stdout, stderr, and exit code. Follows the established echo-tool reference pattern with input validation to prevent command injection.

## Changes

### Group 1 — Scaffold the crate
- ✅ Create `tools/cargo-build/Cargo.toml` mirroring echo-tool dependencies
- ✅ Add `tools/cargo-build` to workspace members

### Group 2 — Core implementation
- ✅ Implement `CargoBuildTool` struct with package name validation (alphanumeric, hyphens, underscores only)
- ✅ Wire up `main.rs` entry point via `mcp-tool-harness`

### Group 3 — Integration test
- ✅ 4 integration tests: tool listing, successful build, nonexistent package error, invalid name rejection

### Group 4 — Verification
- ✅ All tests pass (3 unit + 4 integration), clean clippy/check/build

## Test plan

- `cargo build -p cargo-build` — compiles cleanly
- `cargo test -p cargo-build` — 3 unit tests + 4 integration tests pass
- `cargo clippy -p cargo-build` — no warnings
- `cargo check` — workspace-wide check passes with no regressions

## Issue

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)