### PR TITLE
feat(tools): implement docker_build MCP tool (#48)

### DIFF
--- a/.claude/commands/address-pr-comments.md
+++ b/.claude/commands/address-pr-comments.md
@@ -1,0 +1,17 @@
+# Address PR Comments
+
+Fetch, analyze, and address code review comments from a GitHub pull request.
+
+## Steps
+
+1. **Fetch PR info** — Run `gh pr view --json number,headRefName,headRepository` to get the current PR number and repo.
+2. **Fetch comments** — Run both:
+   - `gh api /repos/{owner}/{repo}/issues/{number}/comments` for PR-level comments
+   - `gh api /repos/{owner}/{repo}/pulls/{number}/comments` for inline review comments
+3. **Display comments** — Format and show all comments to the user, including diff hunks and file/line context for inline comments. Ignore bot comments (e.g. gemini-code-assist, dependabot).
+4. **Analyze validity** — For each code review comment that suggests a change:
+   - Read the referenced file and line to understand the current code
+   - Evaluate whether the suggestion is valid (correct, improves quality, fixes a real bug)
+   - Classify as: valid, partially valid, or not applicable
+5. **Present findings** — Show the user a summary of which comments are valid and which are not, with reasoning.
+6. **Plan fixes** — For all valid issues, enter plan mode and create a plan to address them. Present the plan to the user for approval before making any changes.

--- a/.claude/commands/reset.md
+++ b/.claude/commands/reset.md
@@ -1,0 +1,10 @@
+# Reset Workspace
+
+Reset the workspace by checking out the default branch and pulling latest changes.
+
+## Steps
+
+1. Detect the default branch by running `git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'`. If that fails, fall back to checking if `main` or `master` exists.
+2. Run `git checkout <default-branch>`.
+3. Run `git pull`.
+4. Report the current branch and latest commit.

--- a/.claude/tasks/issue-48.md
+++ b/.claude/tasks/issue-48.md
@@ -1,0 +1,107 @@
+# Task Breakdown: Implement docker_build MCP tool
+
+> Implement `docker_build` as a standalone Rust MCP server binary that builds Docker images from a Dockerfile and context directory, following the established tool pattern (cargo-build, echo-tool).
+
+## Group 1 — Scaffold the crate
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Create `tools/docker-build/Cargo.toml`** `[S]`
+      Copy `tools/cargo-build/Cargo.toml` and change `name = "docker-build"`. Keep the same dependency set: `mcp-tool-harness` (path), `rmcp` with `transport-io`/`server`/`macros`, `tokio` with `macros`/`rt`/`io-std`, `serde` with `derive`, `serde_json`. Dev-dependencies: `mcp-test-utils` (path), `tokio` with `rt-multi-thread`, `rmcp` with `client`/`transport-child-process`, `serde_json`.
+      Files: `tools/docker-build/Cargo.toml`
+      Blocking: "Implement `DockerBuildTool` struct and handler", "Write `main.rs`", "Write integration tests"
+
+- [x] **Add `"tools/docker-build"` to workspace `Cargo.toml`** `[S]`
+      Add `"tools/docker-build"` to the `members` list in the root `Cargo.toml`, after the existing `"tools/cargo-build"` entry.
+      Files: `Cargo.toml`
+      Blocking: "Run verification suite"
+
+## Group 2 — Core implementation
+
+_Depends on: Group 1_
+
+- [x] **Implement `DockerBuildTool` struct and handler in `src/docker_build.rs`** `[M]`
+      Create `tools/docker-build/src/docker_build.rs`. Define `DockerBuildRequest` with `#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]` containing four fields:
+      - `context: String` — build context path (required)
+      - `tag: String` — image tag (required)
+      - `build_args: Option<std::collections::HashMap<String, String>>` — optional build arguments
+      - `dockerfile: Option<String>` — optional Dockerfile path
+
+      Define `DockerBuildTool { tool_router: ToolRouter<Self> }` with `new()` calling `Self::tool_router()`.
+
+      **Input validation (security-critical):**
+      - Validate `context` path: canonicalize it and verify it exists and is within the current working directory (or a configured project root) to prevent building from arbitrary paths. Reject paths containing `..` segments before canonicalization as an extra safeguard.
+      - Validate `tag`: only allow `[a-zA-Z0-9._:/-]` characters to prevent injection through the tag argument.
+      - Validate `dockerfile` (if provided): same path traversal checks as `context`.
+      - Validate `build_args` keys and values: reject any containing shell metacharacters or newlines.
+
+      **Execution:** Use `std::process::Command::new("docker")` with args `["build", "-t", &tag, &context]`. If `dockerfile` is provided, prepend `["-f", &dockerfile]`. For each entry in `build_args`, append `["--build-arg", &format!("{key}={value}")]`. Capture output with `.output()`.
+
+      **Output parsing:** After a successful `docker build`, extract the image ID from the build output (parse the line matching `Successfully built <id>` or `writing image sha256:<id>`). Return JSON with `success` (bool), `image_id` (string), `tag` (string), `build_log` (string from combined stdout/stderr). On failure, return JSON with `success: false` and the error in `build_log`.
+
+      Implement `ServerHandler` with `#[tool_handler]` returning tools-enabled capabilities.
+
+      **Unit tests** in `#[cfg(test)] mod tests`:
+      1. `rejects_context_with_path_traversal` — call with `context: "../../etc"`, assert validation error
+      2. `rejects_tag_with_shell_metacharacters` — call with `tag: "foo;rm -rf /"`, assert validation error
+      3. `rejects_invalid_build_arg_keys` — call with a build arg key containing `;`, assert validation error
+      4. `validates_clean_inputs` — call with valid inputs, assert the command is attempted (will fail if Docker is not installed, but the JSON output structure should still be correct with `success: false` and a meaningful error)
+
+      Files: `tools/docker-build/src/docker_build.rs`
+      Blocked by: "Create `tools/docker-build/Cargo.toml`"
+      Blocking: "Write `main.rs`", "Write integration tests"
+
+- [x] **Write `src/main.rs`** `[S]`
+      Create `tools/docker-build/src/main.rs`. Mirror `tools/cargo-build/src/main.rs`: declare `mod docker_build;`, use `DockerBuildTool`, call `mcp_tool_harness::serve_stdio_tool(DockerBuildTool::new(), "docker-build").await`. Under 10 lines.
+      Files: `tools/docker-build/src/main.rs`
+      Blocked by: "Implement `DockerBuildTool` struct and handler"
+      Blocking: "Write integration tests"
+
+## Group 3 — Integration tests and documentation
+
+_Depends on: Group 2_
+
+- [x] **Write integration tests in `tests/docker_build_server_test.rs`** `[M]`
+      Create `tools/docker-build/tests/docker_build_server_test.rs`. Use `spawn_mcp_client!(env!("CARGO_BIN_EXE_docker-build"))` pattern from `mcp-test-utils`.
+
+      Tests (each `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`):
+      1. `tools_list_returns_docker_build_tool` — use `mcp_test_utils::assert_single_tool` to verify tool name is `"docker_build"`, description contains `"Docker image"`, and parameters include `["context", "tag", "build_args", "dockerfile"]`.
+      2. `tools_call_rejects_path_traversal` — call with `{"context": "../../etc", "tag": "test:latest"}`, parse response, assert `success` is `false` and the output indicates a validation error.
+      3. `tools_call_rejects_invalid_tag` — call with `{"context": ".", "tag": "test;evil"}`, assert `success` is `false`.
+      4. `tools_call_returns_error_when_docker_unavailable` — call with valid inputs `{"context": ".", "tag": "test:latest"}`; if Docker is not installed in CI, assert the response is valid JSON with `success: false` and a meaningful error message (graceful degradation).
+
+      Files: `tools/docker-build/tests/docker_build_server_test.rs`
+      Blocked by: "Write `main.rs`"
+      Blocking: None
+
+- [x] **Write `README.md`** `[S]`
+      Create `tools/docker-build/README.md` following the pattern from `tools/echo-tool/README.md`. Include: description, build/run/test commands, input parameters, output format, security considerations (path validation, no shell execution), and Docker-in-Docker caveat.
+      Files: `tools/docker-build/README.md`
+      Non-blocking
+
+## Group 4 — Verification
+
+_Depends on: Groups 1-3_
+
+- [x] **Run verification suite** `[S]`
+      Run `cargo build -p docker-build`, `cargo test -p docker-build`, `cargo clippy -p docker-build`, and `cargo check` (workspace-wide). Verify all acceptance criteria: build succeeds, tests pass, tool is named `docker_build` in MCP tools/list, returns structured JSON on both success and failure, input validation prevents command injection.
+      Files: (none — command-line verification only)
+      Blocked by: All previous tasks
+      Blocking: None
+
+## Implementation Notes
+
+1. **No new dependencies**: All dependencies (`rmcp`, `tokio`, `serde`, `serde_json`, `mcp-tool-harness`) are already used by `tools/cargo-build`. The `std::collections::HashMap` needed for `build_args` is in the standard library.
+
+2. **Security is the primary concern**: Unlike `cargo_build` which only validates a package name, `docker_build` accepts filesystem paths and arbitrary key-value pairs. Path traversal prevention (canonicalize and check prefix) and input sanitization are essential. The command is invoked via `std::process::Command` (not through a shell), which prevents shell injection, but argument injection through `--build-arg` values must still be guarded against.
+
+3. **Image ID extraction**: Docker build output format varies between Docker versions (legacy builder vs BuildKit). The implementation should try to parse both `Successfully built <short-id>` (legacy) and `writing image sha256:<full-id>` (BuildKit). If neither pattern matches, return `"unknown"` for `image_id` rather than failing.
+
+4. **Docker availability in CI**: Docker may not be available in all test environments. Integration tests that actually invoke Docker should handle the "docker not found" case gracefully. Unit tests should focus on input validation which does not require Docker.
+
+5. **`build_args` as `HashMap<String, String>`**: The issue specifies `build_args` as an "object". Using `Option<HashMap<String, String>>` with serde will correctly deserialize a JSON object like `{"FOO": "bar"}`. The `schemars::JsonSchema` derive handles this type natively.
+
+6. **Reference files**:
+   - `tools/cargo-build/src/cargo_build.rs` — Closest reference pattern for struct, macros, validation, unit tests
+   - `tools/cargo-build/Cargo.toml` — Template for dependencies
+   - `crates/mcp-test-utils/src/lib.rs` — Test utilities (`spawn_mcp_client!`, `assert_single_tool`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker-build"
+version = "0.1.0"
+dependencies = [
+ "mcp-test-utils",
+ "mcp-tool-harness",
+ "rmcp 1.2.0",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "tools/write-file",
     "tools/validate-skill",
     "tools/cargo-build",
+    "tools/docker-build",
 ]
 
 [profile.release]

--- a/tools/docker-build/Cargo.toml
+++ b/tools/docker-build/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "docker-build"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }
+rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
+tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+rmcp = { version = "1", features = ["client", "transport-child-process"] }
+serde_json = "1"

--- a/tools/docker-build/README.md
+++ b/tools/docker-build/README.md
@@ -1,0 +1,83 @@
+# docker-build
+
+An MCP tool server that builds Docker images from a Dockerfile and context directory. It validates all inputs, invokes `docker build`, and returns a JSON result containing the image ID and build log.
+
+## Build
+
+```sh
+cargo build -p docker-build
+```
+
+## Run
+
+```sh
+cargo run -p docker-build
+```
+
+The server uses stdio transport: it reads MCP messages from stdin and writes responses to stdout. All logging output is directed to stderr so it does not interfere with the MCP protocol stream.
+
+## Test with MCP Inspector
+
+```sh
+npx @modelcontextprotocol/inspector cargo run -p docker-build
+```
+
+This launches the MCP Inspector, which connects to the docker-build server and provides an interactive UI for sending requests and viewing responses. Use it to verify that the tool advertises its capabilities and handles calls correctly.
+
+## Test
+
+```sh
+cargo test -p docker-build
+```
+
+## Parameters
+
+| Name         | Type              | Required | Description                                          |
+|--------------|-------------------|----------|------------------------------------------------------|
+| `context`    | string            | yes      | Build context path (must be within working directory) |
+| `tag`        | string            | yes      | Image tag (e.g. `my-app:latest`)                     |
+| `build_args` | map<string,string> | no       | Optional build arguments passed via `--build-arg`    |
+| `dockerfile` | string            | no       | Optional path to Dockerfile (must be within working directory) |
+
+## Output
+
+The tool returns a JSON response with the following fields:
+
+| Field       | Type    | Description                                           |
+|-------------|---------|-------------------------------------------------------|
+| `success`   | boolean | Whether the Docker build completed successfully       |
+| `image_id`  | string  | Built image ID (may be empty if ID cannot be parsed)  |
+| `tag`       | string  | The tag applied to the built image                    |
+| `build_log` | string  | Combined stdout and stderr output from Docker         |
+
+### Success example
+
+```json
+{
+  "success": true,
+  "image_id": "sha256:abc123def456",
+  "tag": "my-app:latest",
+  "build_log": "Step 1/3 : FROM alpine\n..."
+}
+```
+
+### Failure example
+
+```json
+{
+  "success": false,
+  "build_log": "Invalid context path: path traversal not allowed"
+}
+```
+
+## Security Considerations
+
+- **Path validation** -- Context and Dockerfile paths are canonicalized and verified to stay within the current working directory. Path traversal (`..`) is rejected.
+- **Tag validation** -- Tags are restricted to alphanumeric characters and `._:/-`. Shell metacharacters are rejected.
+- **Build-arg sanitization** -- Both keys and values of build arguments are checked for shell metacharacters (`;&|$` and others). Invalid arguments are rejected before invoking Docker.
+- **No shell execution** -- The tool invokes `docker` directly via `std::process::Command` without spawning a shell, preventing shell injection attacks.
+
+## Notes
+
+- **Docker-in-Docker** -- When running inside a container, the host Docker socket must be mounted (e.g. `-v /var/run/docker.sock:/var/run/docker.sock`) for builds to work.
+- **Image ID parsing** -- The `image_id` field may be empty if the build output does not contain a recognizable image ID. This can happen with certain BuildKit output configurations.

--- a/tools/docker-build/src/docker_build.rs
+++ b/tools/docker-build/src/docker_build.rs
@@ -81,35 +81,25 @@ fn validate_build_args(args: &HashMap<String, String>) -> Result<(), String> {
 }
 
 fn extract_image_id(output: &str) -> String {
-    // Legacy format: "Successfully built <id>"
-    if let Some(line) = output.lines().find(|l| l.contains("Successfully built "))
-        && let Some(id) = line.split("Successfully built ").nth(1)
-    {
-        let id = id.trim();
-        if !id.is_empty() {
-            return id.to_string();
+    for line in output.lines() {
+        // Legacy format: "Successfully built <id>"
+        if let Some(id) = line.split("Successfully built ").nth(1) {
+            let id = id.trim();
+            if !id.is_empty() {
+                return id.to_string();
+            }
         }
-    }
 
-    // BuildKit format: "writing image sha256:<id>"
-    if let Some(line) = output.lines().find(|l| l.contains("writing image sha256:"))
-        && let Some(rest) = line.split("writing image sha256:").nth(1)
-    {
-        let id = rest.split_whitespace().next().unwrap_or("").trim();
-        if !id.is_empty() {
-            return format!("sha256:{id}");
+        // BuildKit format: "writing image sha256:<id>"
+        if let Some(rest) = line.split("writing image sha256:").nth(1) {
+            let id = rest.split_whitespace().next().unwrap_or("").trim();
+            if !id.is_empty() {
+                return format!("sha256:{id}");
+            }
         }
     }
 
     String::new()
-}
-
-fn build_error(message: &str) -> String {
-    serde_json::json!({
-        "success": false,
-        "build_log": message,
-    })
-    .to_string()
 }
 
 fn execute_docker_build(
@@ -162,24 +152,34 @@ fn execute_docker_build(
 impl DockerBuildTool {
     #[tool(description = "Run docker build and return the result with image ID")]
     fn docker_build(&self, Parameters(request): Parameters<DockerBuildRequest>) -> String {
+        let error_response = |message: String| -> String {
+            serde_json::json!({
+                "success": false,
+                "image_id": "",
+                "tag": &request.tag,
+                "build_log": message,
+            })
+            .to_string()
+        };
+
         if let Err(msg) = validate_path(&request.context, "context path") {
-            return build_error(&msg);
+            return error_response(msg);
         }
 
         if !validate_tag(&request.tag) {
-            return build_error(&format!("Invalid tag: {}", request.tag));
+            return error_response(format!("Invalid tag: {}", request.tag));
         }
 
         if let Some(ref df) = request.dockerfile
             && let Err(msg) = validate_path(df, "dockerfile path")
         {
-            return build_error(&msg);
+            return error_response(msg);
         }
 
         if let Some(ref args) = request.build_args
             && let Err(msg) = validate_build_args(args)
         {
-            return build_error(&msg);
+            return error_response(msg);
         }
 
         execute_docker_build(

--- a/tools/docker-build/src/docker_build.rs
+++ b/tools/docker-build/src/docker_build.rs
@@ -1,0 +1,299 @@
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+use std::collections::HashMap;
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct DockerBuildRequest {
+    /// Build context path (required)
+    pub context: String,
+    /// Image tag (required)
+    pub tag: String,
+    /// Optional build arguments
+    pub build_args: Option<HashMap<String, String>>,
+    /// Optional Dockerfile path
+    pub dockerfile: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DockerBuildTool {
+    tool_router: ToolRouter<Self>,
+}
+
+impl DockerBuildTool {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+fn validate_path(path: &str, label: &str) -> Result<std::path::PathBuf, String> {
+    let path_obj = std::path::Path::new(path);
+    for component in path_obj.components() {
+        if let std::path::Component::ParentDir = component {
+            return Err(format!("Invalid {label}: path traversal not allowed"));
+        }
+    }
+
+    let canonical = std::fs::canonicalize(path).map_err(|e| format!("Invalid {label}: {e}"))?;
+
+    let cwd = std::env::current_dir()
+        .map_err(|e| format!("Invalid {label}: cannot determine working directory: {e}"))?;
+
+    if !canonical.starts_with(&cwd) {
+        return Err(format!("Invalid {label}: path escapes working directory"));
+    }
+
+    Ok(canonical)
+}
+
+fn validate_tag(tag: &str) -> bool {
+    !tag.is_empty()
+        && tag
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || "._:/-".contains(ch))
+}
+
+fn has_shell_metacharacters(s: &str) -> bool {
+    s.chars().any(|ch| ";&|$`\n\r(){}<>'\"\\".contains(ch))
+}
+
+fn validate_build_args(args: &HashMap<String, String>) -> Result<(), String> {
+    for (key, value) in args {
+        if key.is_empty() {
+            return Err("Invalid build argument: key must not be empty".to_string());
+        }
+        if has_shell_metacharacters(key) {
+            return Err(format!(
+                "Invalid build argument: key contains forbidden characters: {key}"
+            ));
+        }
+        if has_shell_metacharacters(value) {
+            return Err(format!(
+                "Invalid build argument: value contains forbidden characters for key: {key}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn extract_image_id(output: &str) -> String {
+    // Legacy format: "Successfully built <id>"
+    if let Some(line) = output.lines().find(|l| l.contains("Successfully built "))
+        && let Some(id) = line.split("Successfully built ").nth(1)
+    {
+        let id = id.trim();
+        if !id.is_empty() {
+            return id.to_string();
+        }
+    }
+
+    // BuildKit format: "writing image sha256:<id>"
+    if let Some(line) = output.lines().find(|l| l.contains("writing image sha256:"))
+        && let Some(rest) = line.split("writing image sha256:").nth(1)
+    {
+        let id = rest.split_whitespace().next().unwrap_or("").trim();
+        if !id.is_empty() {
+            return format!("sha256:{id}");
+        }
+    }
+
+    String::new()
+}
+
+fn build_error(message: &str) -> String {
+    serde_json::json!({
+        "success": false,
+        "build_log": message,
+    })
+    .to_string()
+}
+
+fn execute_docker_build(
+    context: &str,
+    tag: &str,
+    dockerfile: Option<&str>,
+    build_args: Option<&HashMap<String, String>>,
+) -> String {
+    let mut cmd = std::process::Command::new("docker");
+    cmd.args(["build", "-t", tag]);
+
+    if let Some(df) = dockerfile {
+        cmd.args(["-f", df]);
+    }
+
+    if let Some(args) = build_args {
+        for (key, value) in args {
+            cmd.args(["--build-arg", &format!("{key}={value}")]);
+        }
+    }
+
+    cmd.arg(context);
+
+    match cmd.output() {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let build_log = format!("{stdout}{stderr}");
+            let image_id = extract_image_id(&build_log);
+
+            serde_json::json!({
+                "success": output.status.success(),
+                "image_id": image_id,
+                "tag": tag,
+                "build_log": build_log,
+            })
+            .to_string()
+        }
+        Err(e) => serde_json::json!({
+            "success": false,
+            "image_id": "",
+            "tag": tag,
+            "build_log": format!("Failed to execute docker: {e}"),
+        })
+        .to_string(),
+    }
+}
+
+#[tool_router]
+impl DockerBuildTool {
+    #[tool(description = "Run docker build and return the result with image ID")]
+    fn docker_build(&self, Parameters(request): Parameters<DockerBuildRequest>) -> String {
+        if let Err(msg) = validate_path(&request.context, "context path") {
+            return build_error(&msg);
+        }
+
+        if !validate_tag(&request.tag) {
+            return build_error(&format!("Invalid tag: {}", request.tag));
+        }
+
+        if let Some(ref df) = request.dockerfile
+            && let Err(msg) = validate_path(df, "dockerfile path")
+        {
+            return build_error(&msg);
+        }
+
+        if let Some(ref args) = request.build_args
+            && let Err(msg) = validate_build_args(args)
+        {
+            return build_error(&msg);
+        }
+
+        execute_docker_build(
+            &request.context,
+            &request.tag,
+            request.dockerfile.as_deref(),
+            request.build_args.as_ref(),
+        )
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for DockerBuildTool {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call_docker_build(
+        tool: &DockerBuildTool,
+        context: &str,
+        tag: &str,
+        build_args: Option<HashMap<String, String>>,
+        dockerfile: Option<&str>,
+    ) -> String {
+        tool.docker_build(Parameters(DockerBuildRequest {
+            context: context.to_string(),
+            tag: tag.to_string(),
+            build_args,
+            dockerfile: dockerfile.map(|s| s.to_string()),
+        }))
+    }
+
+    #[test]
+    fn rejects_context_with_path_traversal() {
+        let tool = DockerBuildTool::new();
+        let result = call_docker_build(&tool, "../../etc", "test:latest", None, None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+    }
+
+    #[test]
+    fn rejects_tag_with_shell_metacharacters() {
+        let tool = DockerBuildTool::new();
+        let result = call_docker_build(&tool, ".", "foo;rm -rf /", None, None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+    }
+
+    #[test]
+    fn rejects_invalid_build_arg_keys() {
+        let tool = DockerBuildTool::new();
+        let mut args = HashMap::new();
+        args.insert(";bad".to_string(), "value".to_string());
+        let result = call_docker_build(&tool, ".", "test:latest", Some(args), None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+    }
+
+    #[test]
+    fn validates_clean_inputs() {
+        let tool = DockerBuildTool::new();
+        let result = call_docker_build(&tool, ".", "test:latest", None, None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(json.get("success").is_some());
+        assert!(json.get("image_id").is_some());
+        assert!(json.get("tag").is_some());
+        assert!(json.get("build_log").is_some());
+    }
+
+    #[test]
+    fn extract_image_id_legacy_format() {
+        let output = "Step 1/3 : FROM alpine\nSuccessfully built abc123def456\n";
+        assert_eq!(extract_image_id(output), "abc123def456");
+    }
+
+    #[test]
+    fn extract_image_id_buildkit_format() {
+        let output = "writing image sha256:abc123def456 done\n";
+        assert_eq!(extract_image_id(output), "sha256:abc123def456");
+    }
+
+    #[test]
+    fn extract_image_id_no_match() {
+        let output = "some random docker output\n";
+        assert_eq!(extract_image_id(output), "");
+    }
+
+    #[test]
+    fn validate_tag_accepts_valid() {
+        assert!(validate_tag("my-app:v1.0"));
+        assert!(validate_tag("registry/my-app:latest"));
+    }
+
+    #[test]
+    fn validate_tag_rejects_empty() {
+        assert!(!validate_tag(""));
+    }
+
+    #[test]
+    fn validate_tag_rejects_metacharacters() {
+        assert!(!validate_tag("foo;bar"));
+        assert!(!validate_tag("foo bar"));
+    }
+
+    #[test]
+    fn has_shell_metacharacters_detects_them() {
+        assert!(has_shell_metacharacters("hello;world"));
+        assert!(has_shell_metacharacters("$(cmd)"));
+        assert!(has_shell_metacharacters("foo\nbar"));
+        assert!(!has_shell_metacharacters("clean-value_123"));
+    }
+}

--- a/tools/docker-build/src/main.rs
+++ b/tools/docker-build/src/main.rs
@@ -1,0 +1,7 @@
+mod docker_build;
+use docker_build::DockerBuildTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(DockerBuildTool::new(), "docker-build").await
+}

--- a/tools/docker-build/tests/docker_build_server_test.rs
+++ b/tools/docker-build/tests/docker_build_server_test.rs
@@ -1,0 +1,108 @@
+use rmcp::model::CallToolRequestParams;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_returns_docker_build_tool() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_docker-build")).await;
+    mcp_test_utils::assert_single_tool(
+        &client,
+        "docker_build",
+        "docker build",
+        &["context", "tag", "build_args", "dockerfile"],
+    )
+    .await;
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_rejects_path_traversal() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_docker-build")).await;
+
+    let params = CallToolRequestParams::new("docker_build").with_arguments(
+        serde_json::json!({ "context": "../../etc", "tag": "test:latest" })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
+    assert_eq!(json["success"], false, "path traversal should be rejected");
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_rejects_invalid_tag() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_docker-build")).await;
+
+    let params = CallToolRequestParams::new("docker_build").with_arguments(
+        serde_json::json!({ "context": ".", "tag": "test;evil" })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
+    assert_eq!(json["success"], false, "invalid tag should be rejected");
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_returns_error_when_docker_unavailable() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_docker-build")).await;
+
+    let params = CallToolRequestParams::new("docker_build").with_arguments(
+        serde_json::json!({ "context": ".", "tag": "test:latest" })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
+    assert!(
+        json.get("success").is_some(),
+        "response should contain a success field"
+    );
+    if json["success"] == false {
+        let build_log = json["build_log"].as_str().unwrap_or("");
+        assert!(
+            !build_log.is_empty(),
+            "build_log should be non-empty when success is false"
+        );
+    }
+
+    client.cancel().await.expect("failed to cancel client");
+}

--- a/tools/docker-build/tests/docker_build_server_test.rs
+++ b/tools/docker-build/tests/docker_build_server_test.rs
@@ -37,6 +37,11 @@ async fn tools_call_rejects_path_traversal() {
         .expect("first content should be text");
     let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
     assert_eq!(json["success"], false, "path traversal should be rejected");
+    assert_eq!(json["tag"], "test:latest");
+    assert!(json["build_log"]
+        .as_str()
+        .unwrap()
+        .contains("path traversal"));
 
     client.cancel().await.expect("failed to cancel client");
 }
@@ -65,6 +70,11 @@ async fn tools_call_rejects_invalid_tag() {
         .expect("first content should be text");
     let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
     assert_eq!(json["success"], false, "invalid tag should be rejected");
+    assert_eq!(json["tag"], "test;evil");
+    assert!(json["build_log"]
+        .as_str()
+        .unwrap()
+        .contains("Invalid tag"));
 
     client.cancel().await.expect("failed to cancel client");
 }


### PR DESCRIPTION
## Summary

Implements the `docker_build` MCP tool as a standalone Rust binary that builds Docker images from a Dockerfile and context directory. Follows the established tool pattern (cargo-build, echo-tool) with security-critical input validation.

## Changes

### Group 1 — Scaffold the crate
- ✅ Create `tools/docker-build/Cargo.toml`
- ✅ Add `"tools/docker-build"` to workspace `Cargo.toml`

### Group 2 — Core implementation
- ✅ Implement `DockerBuildTool` struct and handler in `src/docker_build.rs`
- ✅ Write `src/main.rs`

### Group 3 — Integration tests and documentation
- ✅ Write integration tests in `tests/docker_build_server_test.rs`
- ✅ Write `README.md`

### Group 4 — Verification
- ✅ Run verification suite

## Test plan

- `cargo build -p docker-build` — builds cleanly
- `cargo test -p docker-build` — 15 tests pass (11 unit + 4 integration)
- `cargo clippy -p docker-build` — no warnings
- `cargo check` — workspace-wide check passes

## Issue

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)