### PR TITLE
feat(docker-push): implement docker_push MCP tool (#49)

### DIFF
--- a/.claude/specs/issue-18/add-integration-test-for-orchestrator-skill.md
+++ b/.claude/specs/issue-18/add-integration-test-for-orchestrator-skill.md
@@ -1,0 +1,58 @@
+# Spec: Add integration test for orchestrator skill
+> From: .claude/tasks/issue-18.md
+
+## Objective
+Add an integration test named `load_orchestrator_skill` to the existing test file `crates/skill-loader/tests/example_skills_test.rs` that verifies the `skills/orchestrator.md` skill file loads correctly and all parsed `SkillManifest` fields match expected values.
+
+## Current State
+The test file already contains three integration tests following a consistent pattern:
+- `load_echo_skill` -- tests `skills/echo.md`
+- `load_cogs_analyst_skill` -- tests `skills/cogs-analyst.md`
+- `load_skill_writer_skill` -- tests `skills/skill-writer.md`
+
+Each test uses shared helpers `skills_dir()` (resolves `../../skills` from `CARGO_MANIFEST_DIR`) and `make_loader()` (creates a `SkillLoader` with `AllToolsExist` tool checker). There is no test yet for the orchestrator skill.
+
+## Requirements
+1. Add a new `#[tokio::test]` async function named `load_orchestrator_skill` at the end of the file.
+2. Use the existing `skills_dir()` and `make_loader()` helpers -- do not duplicate them.
+3. Load the skill via `loader.load("orchestrator").await.unwrap()`.
+4. Assert every field of the returned `SkillManifest`:
+   - `name` == `"orchestrator"`
+   - `version` == `"1.0"`
+   - `description` == `"Routes incoming requests to the best-matching specialized agent based on intent analysis"`
+   - `model.provider` == `"anthropic"`
+   - `model.name` == `"claude-sonnet-4-6"`
+   - `model.temperature` ~= `0.1` (use `(value - 0.1).abs() < f64::EPSILON` pattern)
+   - `tools` == `["list_agents", "route_to_agent"]`
+   - `constraints.max_turns` == `3`
+   - `constraints.confidence_threshold` ~= `0.9` (same float comparison pattern)
+   - `constraints.escalate_to` == `None`
+   - `constraints.allowed_actions` == `["route", "discover"]`
+   - `output.format` == `"structured_json"`
+   - `output.schema` has exactly 2 entries
+   - `output.schema["target_agent"]` == `"string"`
+   - `output.schema["reasoning"]` == `"string"`
+   - `preamble` is not empty (`assert!(!manifest.preamble.is_empty())`)
+   - `preamble` contains a routing-related keyword (e.g., `assert!(manifest.preamble.contains("route") || manifest.preamble.contains("router"))`)
+
+## Implementation Details
+- The test follows the exact same structure as `load_cogs_analyst_skill` (the most comprehensive existing test). Copy that pattern and adjust field values.
+- `AllToolsExist` is already imported and used in `make_loader()`, so the stub tool names `list_agents` and `route_to_agent` will pass validation without needing to be registered in the tool registry.
+- Float comparisons must use the `(value - expected).abs() < f64::EPSILON` idiom, consistent with the existing tests.
+- The test file currently has no `load_orchestrator_skill` function, so appending to the end of the file is the cleanest approach.
+- No new imports are needed -- everything required (`SkillLoader`, `AllToolsExist`, `ToolRegistry`, `Arc`) is already imported.
+
+## Dependencies
+- **Blocked by**: "Create `skills/orchestrator.md` routing skill file" -- the `orchestrator.md` file must exist before this test can pass. The test directly loads and parses that file.
+- **No downstream blockers**: This task is non-blocking.
+
+## Risks & Edge Cases
+- **Skill file not yet created**: This test will fail at runtime if `skills/orchestrator.md` does not exist. This is expected since this task is blocked by skill file creation.
+- **Preamble content sensitivity**: The preamble assertion (`contains("route")`) should use a word likely to appear in any reasonable routing preamble. The task description for the skill file specifies routing-only instructions, so "route" is a safe keyword.
+- **Field value mismatch**: If the skill file is created with different values than specified in the task breakdown (e.g., different description text), the test will fail. The spec values here are taken directly from the task breakdown in `.claude/tasks/issue-18.md` and must stay in sync.
+
+## Verification
+1. `cargo check -p skill-loader --tests` -- confirms the test compiles.
+2. `cargo test -p skill-loader --test example_skills_test load_orchestrator_skill` -- confirms the test passes (requires `skills/orchestrator.md` to exist).
+3. `cargo test -p skill-loader --test example_skills_test` -- confirms all existing tests still pass alongside the new one.
+4. `cargo clippy -p skill-loader --tests` -- confirms no lint warnings in the test file.

--- a/.claude/specs/issue-18/create-skills-orchestrator-md-routing-skill-file.md
+++ b/.claude/specs/issue-18/create-skills-orchestrator-md-routing-skill-file.md
@@ -1,0 +1,125 @@
+# Spec: Create `skills/orchestrator.md` routing skill file
+> From: .claude/tasks/issue-18.md
+
+## Objective
+
+Create a new skill file at `skills/orchestrator.md` that defines the orchestrator agent's routing behavior. The file uses the established markdown-with-frontmatter format (consistent with `echo.md`, `cogs-analyst.md`, `skill-writer.md`) and its YAML frontmatter must deserialize cleanly into `SkillFrontmatter` (which maps to `SkillManifest`). The orchestrator's sole purpose is to analyze incoming requests and route them to the best-matching specialized agent.
+
+## Current State
+
+Three skill files exist under `skills/`:
+- `echo.md` -- minimal test skill, no tools, `format: text`
+- `cogs-analyst.md` -- domain skill with tools and `escalate_to`
+- `skill-writer.md` -- seed factory skill, `format: structured_json`
+
+No `orchestrator.md` file exists yet. The orchestrator crate (`crates/orchestrator/`) currently uses a hardcoded manifest rather than loading from a skill file.
+
+## Requirements
+
+### Frontmatter fields (YAML between `---` delimiters)
+
+| Field | Value |
+|---|---|
+| `name` | `orchestrator` |
+| `version` | `"1.0"` (must be a quoted string) |
+| `description` | `Routes incoming requests to the best-matching specialized agent based on intent analysis` |
+| `model.provider` | `anthropic` |
+| `model.name` | `claude-sonnet-4-6` |
+| `model.temperature` | `0.1` |
+| `tools` | `[list_agents, route_to_agent]` |
+| `constraints.max_turns` | `3` |
+| `constraints.confidence_threshold` | `0.9` |
+| `constraints.escalate_to` | omitted (defaults to `None` via `#[serde(default)]`) |
+| `constraints.allowed_actions` | `[route, discover]` |
+| `output.format` | `structured_json` |
+| `output.schema` | `target_agent: string`, `reasoning: string` |
+
+### Markdown body (preamble)
+
+- Must not be empty (validation rule in `check_preamble`)
+- Must be under 20 lines
+- Must contain concise routing-only instructions (no domain logic, no tool usage guidance beyond routing)
+
+### Validation constraints the file must satisfy
+
+These are enforced by `crates/skill-loader/src/validation.rs`:
+
+1. `name`, `version`, `model.provider`, `model.name` must be non-empty strings
+2. `preamble` must not be empty (body after closing `---`)
+3. `confidence_threshold` must be in `[0.0, 1.0]` -- value `0.9` satisfies this
+4. `max_turns` must be `> 0` -- value `3` satisfies this
+5. `output.format` must be one of `["json", "structured_json", "text"]` -- value `structured_json` satisfies this
+6. `escalate_to` must not be an empty string when provided -- omitted entirely, so `None`, which passes
+
+## Implementation Details
+
+Create a single file `skills/orchestrator.md` with the following structure:
+
+```
+---
+<YAML frontmatter with all fields from the Requirements table>
+---
+<Markdown preamble: concise routing instructions, under 20 lines>
+```
+
+The preamble should instruct the orchestrator agent to:
+- Analyze the user's request to determine intent
+- Use `list_agents` to discover available agents and their capabilities
+- Select the best-matching agent based on intent analysis
+- Use `route_to_agent` to forward the request
+- Return structured JSON with `target_agent` (the selected agent name) and `reasoning` (brief explanation of why that agent was chosen)
+- If no agent matches with sufficient confidence, indicate this in the response rather than guessing
+
+The preamble must be focused exclusively on routing logic. It must not contain domain-specific instructions for any downstream agent.
+
+### Format conventions (match existing files)
+
+- Two-space indentation for nested YAML
+- List items use `- item` format for tools
+- Schema fields use `key: type` format (e.g., `target_agent: string`)
+- No trailing blank lines after the preamble
+- File ends with a newline character
+
+## Dependencies
+
+- `crates/agent-sdk/src/skill_manifest.rs` -- `SkillManifest` struct
+- `crates/agent-sdk/src/constraints.rs` -- `Constraints` struct (defines `escalate_to` as `Option<String>` with `#[serde(default)]`)
+- `crates/agent-sdk/src/model_config.rs` -- `ModelConfig` struct
+- `crates/agent-sdk/src/output_schema.rs` -- `OutputSchema` struct, `ALLOWED_OUTPUT_FORMATS`
+- `crates/skill-loader/src/frontmatter.rs` -- `SkillFrontmatter` deserialization, `extract_frontmatter` parser
+- `crates/skill-loader/src/validation.rs` -- `validate()` function with all check functions
+
+## Risks & Edge Cases
+
+1. **YAML version quoting**: `version: 1.0` without quotes would be parsed as a float by YAML, not a string. Must be `version: "1.0"` to satisfy `SkillFrontmatter.version: String` deserialization.
+2. **Empty preamble**: If the body after the closing `---` is blank or whitespace-only, `check_preamble` will reject it. The preamble must contain substantive routing instructions.
+3. **Tool name validity**: `list_agents` and `route_to_agent` must be recognized by the tool registry at runtime. During file-level validation with `AllToolsExist` stub this passes, but integration tests that use a real registry will need these tools registered.
+4. **Temperature value**: `0.1` is valid as `f64`. Low temperature is appropriate for deterministic routing decisions.
+5. **Schema field types**: The `output.schema` is `HashMap<String, String>`, so values like `string` are just descriptive type labels (not enforced types). This matches the convention in `cogs-analyst.md` and `skill-writer.md`.
+
+## Verification
+
+1. **Parse test**: Run the skill loader against `skills/orchestrator.md` and confirm `extract_frontmatter` returns valid YAML and a non-empty body.
+2. **Deserialization test**: Confirm the YAML deserializes into `SkillFrontmatter` without errors.
+3. **Validation test**: Confirm `validate()` passes with all checks (required strings, preamble, confidence threshold, max turns, output format, escalate_to).
+4. **Field value assertions**: Verify each field matches the specified values:
+   - `name == "orchestrator"`
+   - `version == "1.0"`
+   - `model.provider == "anthropic"`
+   - `model.name == "claude-sonnet-4-6"`
+   - `model.temperature == 0.1`
+   - `tools == ["list_agents", "route_to_agent"]`
+   - `constraints.max_turns == 3`
+   - `constraints.confidence_threshold == 0.9`
+   - `constraints.escalate_to == None`
+   - `constraints.allowed_actions == ["route", "discover"]`
+   - `output.format == "structured_json"`
+   - `output.schema` contains keys `target_agent` and `reasoning` with value `"string"`
+5. **Preamble line count**: Confirm body is under 20 lines and non-empty.
+6. **Cargo test**: Run `cargo test` to ensure no regressions.
+
+### Blocking
+
+This spec blocks:
+- "Add integration test for orchestrator skill"
+- "Update orchestrator to load skill file instead of hardcoded manifest"

--- a/.claude/specs/issue-18/run-verification-suite.md
+++ b/.claude/specs/issue-18/run-verification-suite.md
@@ -1,0 +1,32 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-18.md
+
+## Objective
+Run the full verification suite to confirm all changes compile, pass linting, and all tests (new and existing) pass without regressions.
+
+## Current State
+The workspace contains multiple crates: agent-sdk, agent-runtime, orchestrator, skill-loader, tool-registry. All currently pass cargo check, cargo clippy, and cargo test.
+
+## Requirements
+1. `cargo check` must succeed with no errors across the full workspace
+2. `cargo clippy` must produce no new warnings
+3. `cargo test` must pass all tests including the new orchestrator skill integration test
+4. No regressions in existing crates
+
+## Implementation Details
+This is a verification-only task. No code changes. Run:
+- `cargo check`
+- `cargo clippy`
+- `cargo test`
+
+## Dependencies
+- Blocked by: All other tasks in issue-18
+- Blocking: Nothing
+
+## Risks & Edge Cases
+- New skill file could fail validation if frontmatter format is incorrect
+- Orchestrator wiring changes could break existing tests if build_default_manifest removal is not handled carefully
+
+## Verification
+All three commands pass with zero errors and zero warnings.

--- a/.claude/specs/issue-18/update-orchestrator-to-load-skill-file-instead-of-hardcoded-manifest.md
+++ b/.claude/specs/issue-18/update-orchestrator-to-load-skill-file-instead-of-hardcoded-manifest.md
@@ -1,0 +1,135 @@
+# Spec: Update orchestrator to load skill file instead of hardcoded manifest
+> From: .claude/tasks/issue-18.md
+
+## Objective
+
+Replace the hardcoded `build_default_manifest()` function in `crates/orchestrator/src/orchestrator.rs` so that the orchestrator loads its `SkillManifest` from the `skills/orchestrator.md` skill file via `SkillLoader`, proving the system's homogeneity principle: the orchestrator is just runtime + skill file, identical to every other agent.
+
+## Current State
+
+- `build_default_manifest()` (line 350 in `orchestrator.rs`) returns a placeholder `SkillManifest` with `provider: "none"`, `name: "none"`, empty preamble, empty tools list, and zero-value constraints.
+- `from_config()` (line 65) and `from_config_with_model()` (line 138) both call `build_default_manifest()` internally to construct the manifest, giving the caller no way to supply a real one.
+- `Orchestrator::new()` already accepts a `SkillManifest` parameter -- the issue is only in the `from_config` / `from_config_with_model` convenience constructors.
+- Tests in `orchestrator_test.rs` use a separate `build_test_manifest()` helper (line 76) that constructs a similar placeholder manifest. These tests call `Orchestrator::new()` directly and are not affected by changes to `from_config`.
+- `SkillLoader` (in `crates/skill-loader/src/lib.rs`) provides `async fn load(&self, skill_name: &str) -> Result<SkillManifest, SkillError>`, which reads `{skill_dir}/{skill_name}.md`, parses frontmatter, validates tools, and returns a `SkillManifest`.
+- `SkillLoader::new()` requires a `PathBuf` skill directory, an `Arc<ToolRegistry>`, and a `Box<dyn ToolExists + Send + Sync>`.
+
+## Requirements
+
+1. **`from_config` and `from_config_with_model` must accept a `SkillManifest` parameter** instead of calling `build_default_manifest()`. This is the simplest change that decouples manifest construction from orchestrator construction, letting the caller load the manifest however they choose (via `SkillLoader`, from a test fixture, etc.).
+
+2. **Remove `build_default_manifest()`**. Once the callers pass the manifest in, the hardcoded fallback serves no purpose and should be deleted to avoid confusion.
+
+3. **Update `OrchestratorConfig`** (optional). If it makes sense for config-driven construction, add an optional `skill_file` or `skill_dir` field to `OrchestratorConfig`. However, since `SkillLoader` requires async I/O and a `ToolRegistry`, and `OrchestratorConfig` is a plain deserialization struct, the simpler approach is to keep manifest loading external and pass the result in. Do NOT add `SkillManifest` as a field on `OrchestratorConfig` because `SkillManifest` is not `Deserialize`.
+
+4. **Preserve test patterns**. The existing `build_test_manifest()` in `orchestrator_test.rs` is fine as-is. Tests that call `Orchestrator::new()` directly are unaffected. If any tests call `from_config` or `from_config_with_model`, update them to pass a manifest. Currently no tests use these methods (they all use `Orchestrator::new()`), so test changes are expected to be minimal.
+
+5. **Add an `OrchestratorError` variant for skill loading failures**, or convert `SkillError` into the existing `Config` variant, so that errors from `SkillLoader` propagate cleanly through the orchestrator's error type.
+
+## Implementation Details
+
+### Step 1: Update `from_config` signature
+
+Change:
+```rust
+pub fn from_config(config: OrchestratorConfig) -> Result<Self, OrchestratorError>
+```
+To:
+```rust
+pub fn from_config(config: OrchestratorConfig, manifest: SkillManifest) -> Result<Self, OrchestratorError>
+```
+
+Remove the `let manifest = build_default_manifest();` line and use the passed-in `manifest` parameter instead.
+
+### Step 2: Update `from_config_with_model` signature
+
+Change:
+```rust
+pub async fn from_config_with_model<M: EmbeddingModel>(
+    config: OrchestratorConfig,
+    model: &M,
+    similarity_threshold: f64,
+) -> Result<Self, OrchestratorError>
+```
+To:
+```rust
+pub async fn from_config_with_model<M: EmbeddingModel>(
+    config: OrchestratorConfig,
+    manifest: SkillManifest,
+    model: &M,
+    similarity_threshold: f64,
+) -> Result<Self, OrchestratorError>
+```
+
+Remove the `let manifest = build_default_manifest();` line and use the passed-in `manifest` parameter instead.
+
+### Step 3: Remove `build_default_manifest()`
+
+Delete the entire `build_default_manifest()` function (lines 350-373). It is no longer called.
+
+### Step 4: Update call sites
+
+Search the workspace for any callers of `from_config` or `from_config_with_model` (e.g., in `main.rs` or binary entrypoints) and update them to load the manifest via `SkillLoader` before calling the constructor. The typical call site pattern becomes:
+
+```rust
+let loader = SkillLoader::new(skill_dir, tool_registry, tool_checker);
+let manifest = loader.load("orchestrator").await?;
+let orchestrator = Orchestrator::from_config(config, manifest)?;
+```
+
+If no binary entrypoints exist yet (the orchestrator crate is a library), this step is a no-op.
+
+### Step 5: Error bridging
+
+Add a `From<skill_loader::SkillError>` impl for `OrchestratorError`, mapping it to the existing `Config` variant:
+
+```rust
+impl From<SkillError> for OrchestratorError {
+    fn from(err: SkillError) -> Self {
+        OrchestratorError::Config {
+            reason: err.to_string(),
+        }
+    }
+}
+```
+
+This requires adding `skill-loader` as a dependency in `crates/orchestrator/Cargo.toml`. Evaluate whether this coupling is acceptable -- if the orchestrator will always load its own skill file, the dependency is justified. If not, the error conversion can live at the call site instead, and no new dependency is needed.
+
+### Step 6: Update tests (if needed)
+
+- Verify no tests in `crates/orchestrator/tests/` call `from_config` or `from_config_with_model`. Currently none do -- they all use `Orchestrator::new(build_test_manifest(), ...)`.
+- If any are found, update them to pass a test manifest as the new parameter.
+- The `build_test_manifest()` helper in `orchestrator_test.rs` remains unchanged.
+
+### Files modified
+
+- `crates/orchestrator/src/orchestrator.rs` -- change `from_config` and `from_config_with_model` signatures, remove `build_default_manifest()`
+- `crates/orchestrator/src/config.rs` -- no changes expected unless adding a `skill_dir` field
+- `crates/orchestrator/Cargo.toml` -- add `skill-loader` dependency only if error bridging is added in the orchestrator crate
+- Any binary entrypoints that call `from_config` or `from_config_with_model`
+
+## Dependencies
+
+- **Blocked by**: "Create `skills/orchestrator.md` routing skill file" -- the skill file must exist before callers can load it via `SkillLoader`. However, the code changes in this task (accepting a `SkillManifest` parameter) can be implemented and compiled without the skill file existing.
+- **Uses**: `SkillLoader` from `crates/skill-loader/src/lib.rs` at the call site level. The orchestrator crate itself only needs to accept a `SkillManifest` (defined in `agent-sdk`), which it already depends on.
+
+## Risks & Edge Cases
+
+1. **Breaking change to public API**: `from_config` and `from_config_with_model` are public methods. Any external callers will need to update. Since this is an internal project, the risk is low, but grep the workspace for all call sites before merging.
+
+2. **Skill file not found at runtime**: If the caller uses `SkillLoader` and the `skills/orchestrator.md` file is missing or malformed, the orchestrator will fail to start. This is intentional -- a misconfigured orchestrator should fail fast rather than silently running with a dummy manifest.
+
+3. **Circular dependency risk**: If `orchestrator` depends on `skill-loader`, verify there is no reverse dependency. Currently `skill-loader` does not depend on `orchestrator`, so adding the forward dependency is safe. However, this dependency is only needed if error bridging is done inside the orchestrator crate; the simpler approach avoids it entirely.
+
+4. **Async requirement**: `SkillLoader::load()` is async, which matches `from_config_with_model` (already async) but not `from_config` (currently sync). Since the manifest is now passed in pre-loaded, `from_config` remains sync. The async loading happens at the call site.
+
+5. **Test isolation**: Tests use `build_test_manifest()` which constructs manifests in-memory. This is correct and should not be changed to load from disk, as that would couple unit tests to the file system.
+
+## Verification
+
+1. `cargo check` -- confirms the changed signatures compile across the workspace
+2. `cargo clippy` -- no new warnings
+3. `cargo test` -- all existing tests pass (tests use `Orchestrator::new()` directly, not `from_config`)
+4. Grep for `build_default_manifest` -- zero occurrences remain
+5. Grep for `from_config` -- all call sites pass a `SkillManifest` argument
+6. If a binary entrypoint exists, verify it loads `skills/orchestrator.md` via `SkillLoader` and passes the result to `from_config`

--- a/.claude/specs/issue-19/expand-skill-writer-preamble-with-complete-skillmanifest-schema-documentation.md
+++ b/.claude/specs/issue-19/expand-skill-writer-preamble-with-complete-skillmanifest-schema-documentation.md
@@ -1,0 +1,209 @@
+# Spec: Expand skill-writer preamble with complete SkillManifest schema documentation
+> From: .claude/tasks/issue-19.md
+
+## Objective
+
+Rewrite the markdown body (preamble) of `skills/skill-writer.md` to transform it from a shallow 18-line stub into a comprehensive skill file format specification. The preamble is the skill-writer agent's sole reference material for generating valid skill files -- it must encode the complete `SkillManifest` schema, all field types and constraints, validation rules, and a detailed generation process. The YAML frontmatter must not be modified.
+
+## Current State
+
+The file `skills/skill-writer.md` has correct YAML frontmatter (lines 1-23) that passes all integration tests. The markdown body (lines 24-41) contains:
+
+- A single introductory sentence (line 24)
+- A `## Process` section with 7 numbered steps (lines 26-34) that are high-level and do not reference specific schema fields or validation rules
+- A `## Output` section (lines 36-41) describing `skill_yaml` and `validation_result` JSON fields
+
+The preamble is too shallow to serve its purpose. The skill-writer agent is the first seed agent in Spore's self-bootstrapping factory. Its effectiveness depends entirely on how thoroughly it encodes the skill file schema in its preamble, because the LLM will use this text as its only reference for generating valid skill files.
+
+Other skill files in the project (`cogs-analyst.md`, `orchestrator.md`) have domain-appropriate preambles of 15-20 lines. The skill-writer is unique because its domain _is_ the skill file format itself, so its preamble must be substantially longer to document the full schema.
+
+## Requirements
+
+### 1. Expanded introductory paragraph
+
+Replace the current single-sentence introduction with a paragraph that:
+- Establishes the skill-writer as the first seed agent in Spore's self-bootstrapping factory
+- Mentions its partnership with the tool-coder agent (issue #20)
+- Explains that given a plain-language description, it produces a validated skill file in markdown-with-frontmatter format
+- Sets the expectation that the agent must follow the format specification defined below
+
+### 2. `## Skill File Format Specification` section
+
+Document the complete file structure and every `SkillManifest` field. This section must cover:
+
+**File structure overview:**
+- Skill files are markdown files with YAML frontmatter delimited by `---` lines
+- The YAML frontmatter contains all fields except `preamble`
+- The markdown body after the closing `---` becomes the `preamble` field
+- Together they map to the `SkillManifest` struct (8 fields total)
+
+**Top-level fields** (from `SkillManifest` in `crates/agent-sdk/src/skill_manifest.rs`):
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `String` | Unique skill identifier, used as the filename stem |
+| `version` | `String` | Semantic version; must be quoted in YAML to prevent float coercion |
+| `description` | `String` | One-line summary of the skill's purpose |
+| `model` | `ModelConfig` | LLM configuration (see sub-fields below) |
+| `tools` | `Vec<String>` | List of tool names the skill requires |
+| `constraints` | `Constraints` | Execution guardrails (see sub-fields below) |
+| `output` | `OutputSchema` | Response format specification (see sub-fields below) |
+| `preamble` | `String` | Behavioral instructions (from markdown body, not YAML) |
+
+**`ModelConfig` sub-fields** (from `crates/agent-sdk/src/model_config.rs`):
+
+| Field | Type | Notes |
+|---|---|---|
+| `model.provider` | `String` | e.g., `anthropic` |
+| `model.name` | `String` | e.g., `claude-sonnet-4-6` |
+| `model.temperature` | `f64` | Controls randomness; lower values for deterministic tasks |
+
+**`Constraints` sub-fields** (from `crates/agent-sdk/src/constraints.rs`):
+
+| Field | Type | Notes |
+|---|---|---|
+| `constraints.max_turns` | `u32` | Maximum agent interaction turns; must be > 0 |
+| `constraints.confidence_threshold` | `f64` | Minimum confidence to proceed; must be in [0.0, 1.0] |
+| `constraints.escalate_to` | `Option<String>` | Agent to escalate to when confidence is insufficient; omit entirely when not needed (uses `#[serde(default)]`); must not be an empty string if provided |
+| `constraints.allowed_actions` | `Vec<String>` | Permitted action types (e.g., `read`, `write`, `query`, `route`, `discover`) |
+
+**`OutputSchema` sub-fields** (from `crates/agent-sdk/src/output_schema.rs`):
+
+| Field | Type | Notes |
+|---|---|---|
+| `output.format` | `String` | Must be one of: `json`, `structured_json`, `text` (defined in `ALLOWED_OUTPUT_FORMATS`) |
+| `output.schema` | `HashMap<String, String>` | Key-value pairs where keys are field names and values are descriptive type labels (e.g., `string`, `float`) |
+
+### 3. `## Validation Rules` section
+
+Document all rules enforced by `crates/skill-loader/src/validation.rs`:
+
+1. **Required non-empty strings**: `name`, `version`, `model.provider`, and `model.name` must not be empty or whitespace-only
+2. **Non-empty preamble**: The markdown body after the closing `---` must not be empty or whitespace-only
+3. **Confidence threshold range**: `confidence_threshold` must be in `[0.0, 1.0]` inclusive
+4. **Max turns positive**: `max_turns` must be greater than 0
+5. **Tool existence**: Every tool name in the `tools` list must exist in the tool registry
+6. **Output format validity**: `output.format` must be one of `"json"`, `"structured_json"`, or `"text"`
+7. **Escalate-to non-empty when present**: If `escalate_to` is provided, it must not be an empty or whitespace-only string; omit the field entirely to default to `None`
+8. **Version quoting**: `version` must be quoted in YAML (e.g., `"1.0"`) to prevent YAML interpreting it as a float
+9. **No standalone `---` in preamble body**: The frontmatter parser uses `---` as a delimiter; a standalone `---` line in the markdown body could be misinterpreted as a frontmatter boundary
+
+### 4. Expanded `## Process` section
+
+Replace the current 7 high-level steps with more detailed steps that reference the format specification and validation rules. The steps should cover:
+
+1. Analyze the input description to identify core capability, required tools, and domain constraints
+2. Determine model configuration based on task complexity (provider, model name, temperature)
+3. Identify required tools and verify they exist in the tool registry
+4. Select appropriate constraints (max_turns, confidence_threshold, escalate_to, allowed_actions)
+5. Choose the output format and define the output schema fields
+6. Generate the complete YAML frontmatter conforming to the Skill File Format Specification above
+7. Write the markdown preamble body with clear behavioral guidelines, ensuring it is non-empty and does not contain standalone `---` lines
+8. Validate the complete skill file against all Validation Rules listed above
+9. Return the generated skill file and validation results
+
+### 5. Keep existing `## Output` section
+
+Preserve the existing output section content describing `skill_yaml` and `validation_result` structured JSON fields. Minor wording improvements are acceptable but the semantic content must not change.
+
+### Do NOT modify YAML frontmatter
+
+Lines 1-23 (the `---`-delimited YAML block) must remain exactly as they are. The frontmatter is already correct and passes all integration tests.
+
+## Implementation Details
+
+### Section ordering in the final file
+
+The markdown body should be structured as:
+
+1. Introductory paragraph(s) -- no heading
+2. `## Skill File Format Specification`
+3. `## Validation Rules`
+4. `## Process`
+5. `## Output`
+
+### Formatting conventions
+
+- Use markdown tables for field documentation where appropriate (matching patterns in the codebase)
+- Use numbered lists for sequential steps and ordered rules
+- Use backtick formatting for field names, types, and values (e.g., `confidence_threshold`, `f64`, `"structured_json"`)
+- Use `----` (four dashes) instead of `---` (three dashes) if horizontal rules are needed in the preamble, to avoid conflicting with the frontmatter delimiter parser
+- Do not use HTML or complex markdown constructs; keep it readable as plain text since this becomes an LLM prompt
+
+### Content accuracy
+
+All field names, types, default behaviors, and validation rules must exactly match the Rust source code:
+
+- `SkillManifest`: `crates/agent-sdk/src/skill_manifest.rs`
+- `ModelConfig`: `crates/agent-sdk/src/model_config.rs`
+- `Constraints`: `crates/agent-sdk/src/constraints.rs` (note `#[serde(default, skip_serializing_if = "Option::is_none")]` on `escalate_to`)
+- `OutputSchema`: `crates/agent-sdk/src/output_schema.rs` (note `ALLOWED_OUTPUT_FORMATS` constant)
+- Validation logic: `crates/skill-loader/src/validation.rs` (7 check functions)
+
+### Key phrases the preamble must contain
+
+The downstream integration test (Group 2 task) will assert keyword presence. The preamble should naturally contain these terms:
+
+- "SkillManifest" or "skill file format"
+- "confidence_threshold"
+- "ModelConfig" or "model"
+- "OutputSchema" or "output format"
+- "validation"
+
+These should appear organically within the specification text, not as forced insertions.
+
+## Dependencies
+
+- `crates/agent-sdk/src/skill_manifest.rs` -- `SkillManifest` struct definition (8 fields)
+- `crates/agent-sdk/src/model_config.rs` -- `ModelConfig` struct definition (3 fields)
+- `crates/agent-sdk/src/constraints.rs` -- `Constraints` struct definition (4 fields, `escalate_to` is `Option<String>` with serde defaults)
+- `crates/agent-sdk/src/output_schema.rs` -- `OutputSchema` struct definition (2 fields) and `ALLOWED_OUTPUT_FORMATS` constant
+- `crates/skill-loader/src/validation.rs` -- `validate()` function and 7 individual check functions
+- `crates/skill-loader/src/frontmatter.rs` -- `SkillFrontmatter` struct, `extract_frontmatter` parser (uses `---` as delimiter)
+- `skills/cogs-analyst.md`, `skills/orchestrator.md` -- preamble style reference (though skill-writer preamble will be longer due to its schema-documentation purpose)
+
+## Risks & Edge Cases
+
+1. **Standalone `---` in preamble**: The frontmatter parser in `frontmatter.rs` scans for `---` to find the closing delimiter. If the preamble body contains a line that is exactly `---` (trimmed), it could cause parse failures or incorrect splitting. Avoid `---` on its own line; use `----` (four dashes) for horizontal rules if needed.
+
+2. **Preamble length vs. LLM context**: The expanded preamble will be substantially longer than other skill preambles (likely 80-120 lines vs. 15-20 lines for other skills). This is intentional and necessary -- the skill-writer's domain is the format itself. However, the preamble should remain concise and avoid unnecessary repetition to minimize token usage.
+
+3. **YAML frontmatter regression**: Any accidental modification to the YAML frontmatter (lines 1-23) could break the 4 existing integration tests. The implementation must leave the frontmatter byte-identical.
+
+4. **Version quoting documentation**: The spec documents that `version` must be quoted in YAML. This is a critical rule because YAML parses `1.0` as a float, which would fail `String` deserialization. The preamble must call this out clearly.
+
+5. **Tool stub names**: The frontmatter declares `write_file` and `validate_skill` as tools. These do not exist in the tool registry yet (they will be created by issue #20 tool-coder or issue #8). The preamble should not reference these specific tool names as examples of valid tools, since they are specific to this skill. The format spec should document the `tools` field generically.
+
+6. **`escalate_to` omission semantics**: The `Constraints` struct uses `#[serde(default, skip_serializing_if = "Option::is_none")]`, meaning the field can be entirely omitted from YAML to get `None`. This is different from providing `escalate_to: ""` (which would fail validation). The preamble must document this distinction clearly.
+
+7. **`output.schema` is descriptive only**: The `HashMap<String, String>` values like `"string"` and `"float"` are descriptive labels, not enforced types. The preamble should document this to prevent confusion.
+
+## Verification
+
+1. **Frontmatter unchanged**: Diff the YAML frontmatter (lines 1-23) before and after the change to confirm it is byte-identical.
+
+2. **Preamble non-empty**: Confirm the markdown body after the closing `---` is non-empty and contains substantive content.
+
+3. **No standalone `---` lines**: Verify the preamble body does not contain any line that is exactly `---` (trimmed), which would conflict with the frontmatter parser.
+
+4. **Key phrase presence**: Verify the preamble contains the following terms (case-insensitive or natural occurrences):
+   - "SkillManifest" or "skill file format"
+   - "confidence_threshold"
+   - "ModelConfig" or "model"
+   - "OutputSchema" or "output format"
+   - "validation"
+
+5. **Schema completeness**: Verify all 8 `SkillManifest` fields are documented, all 3 `ModelConfig` fields, all 4 `Constraints` fields, and all 2 `OutputSchema` fields.
+
+6. **Validation rules completeness**: Verify all 7 check functions from `validation.rs` are documented as rules, plus the YAML quoting and `---` delimiter rules.
+
+7. **Section structure**: Verify the preamble contains sections titled `## Skill File Format Specification`, `## Validation Rules`, `## Process`, and `## Output`.
+
+8. **Cargo test**: Run `cargo test` to confirm all existing integration tests still pass (frontmatter parsing, deserialization, validation, field value assertions).
+
+9. **Cargo clippy / cargo check**: Run to confirm no build or lint regressions.
+
+### Blocking
+
+This spec blocks:
+- "Strengthen integration test for skill-writer preamble content" (Group 2 task)

--- a/.claude/specs/issue-19/run-verification-suite.md
+++ b/.claude/specs/issue-19/run-verification-suite.md
@@ -1,0 +1,32 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-19.md
+
+## Objective
+Run the full verification suite to confirm all changes compile, pass linting, and all tests (new and existing) pass without regressions.
+
+## Current State
+The workspace contains multiple crates: agent-sdk, agent-runtime, orchestrator, skill-loader, tool-registry. All currently pass cargo check, cargo clippy, and cargo test.
+
+## Requirements
+1. `cargo check` must succeed with no errors across the full workspace
+2. `cargo clippy` must produce no new warnings
+3. `cargo test` must pass all tests including the strengthened skill-writer integration test
+4. No regressions in existing crates
+
+## Implementation Details
+This is a verification-only task. No code changes. Run:
+- `cargo check`
+- `cargo clippy`
+- `cargo test`
+
+## Dependencies
+- Blocked by: All other tasks in issue-19
+- Blocking: Nothing
+
+## Risks & Edge Cases
+- Preamble changes could break existing integration test if frontmatter is accidentally modified
+- New test assertions could be too strict and fail on minor preamble wording changes
+
+## Verification
+All three commands pass with zero errors and zero warnings.

--- a/.claude/specs/issue-19/strengthen-integration-test-for-skill-writer-preamble-content.md
+++ b/.claude/specs/issue-19/strengthen-integration-test-for-skill-writer-preamble-content.md
@@ -1,0 +1,83 @@
+# Spec: Strengthen integration test for skill-writer preamble content
+> From: .claude/tasks/issue-19.md
+
+## Objective
+
+Add keyword-presence assertions to the `load_skill_writer_skill` integration test so it verifies that the skill-writer preamble actually encodes the SkillManifest schema specification, rather than merely checking that the preamble is non-empty and contains a newline.
+
+## Current State
+
+The `load_skill_writer_skill` test in `crates/skill-loader/tests/example_skills_test.rs` (lines 88-124) asserts all frontmatter fields correctly but only has two weak preamble assertions:
+
+```rust
+assert!(!manifest.preamble.is_empty());
+assert!(manifest.preamble.contains('\n'));
+```
+
+By contrast, other tests in the same file use content-based preamble checks:
+- `load_cogs_analyst_skill` asserts `manifest.preamble.contains("COGS")`
+- `load_orchestrator_skill` asserts `manifest.preamble.contains("route") || manifest.preamble.contains("router")`
+
+The skill-writer test should follow these same patterns but with assertions that confirm the format specification content is present.
+
+## Requirements
+
+Replace the two existing weak preamble assertions with a stronger set. Each assertion should use `contains()` with keyword presence checks (not exact string matches). Use `||` alternatives where multiple phrasings are acceptable.
+
+The following concepts must be verified as present in the preamble:
+
+1. **Schema/format reference**: The preamble mentions the manifest schema or skill file format.
+   - Check: `manifest.preamble.contains("SkillManifest") || manifest.preamble.contains("skill file format")`
+
+2. **Confidence threshold**: The preamble documents the `confidence_threshold` constraint.
+   - Check: `manifest.preamble.contains("confidence_threshold")`
+
+3. **Model configuration**: The preamble documents model configuration.
+   - Check: `manifest.preamble.contains("ModelConfig") || manifest.preamble.contains("model")`
+
+4. **Output schema**: The preamble documents the output format/schema.
+   - Check: `manifest.preamble.contains("OutputSchema") || manifest.preamble.contains("output format")`
+
+5. **Validation**: The preamble includes validation rules or guidance.
+   - Check: `manifest.preamble.contains("validation") || manifest.preamble.contains("Validation")`
+
+Keep the existing `assert!(!manifest.preamble.is_empty())` assertion. The `contains('\n')` assertion can be kept or removed (it is implied by the richer checks but harmless to retain).
+
+## Implementation Details
+
+Edit the `load_skill_writer_skill` test function in `crates/skill-loader/tests/example_skills_test.rs`. Replace lines 122-123 with the expanded assertions. The changes are confined to this single function; no other tests or files are modified.
+
+The assertions should follow the existing style in the file:
+- Use `assert!()` with `manifest.preamble.contains(...)`
+- Use `||` for alternative acceptable phrasings within a single `assert!()`
+- Add a descriptive failure message string as the second argument to `assert!()` so failures are diagnosable, e.g.:
+  ```rust
+  assert!(
+      manifest.preamble.contains("SkillManifest") || manifest.preamble.contains("skill file format"),
+      "preamble should reference the skill manifest schema or file format"
+  );
+  ```
+
+No new imports, helper functions, or test utilities are needed. No new test functions are created -- this only modifies the existing `load_skill_writer_skill` function.
+
+## Dependencies
+
+**Blocked by**: "Expand skill-writer preamble with complete SkillManifest schema documentation" (Group 1 task). That task rewrites the preamble body of `skills/skill-writer.md` to include the full format specification. Until that preamble contains the expected keywords, these new assertions will fail.
+
+**Blocking**: Nothing. This is a non-blocking leaf task (Group 2).
+
+## Risks & Edge Cases
+
+1. **Keyword drift**: If the preamble task uses different terminology (e.g., "manifest schema" instead of "SkillManifest"), assertions could fail. Mitigated by using `||` alternatives and checking for both Rust type names and plain-English equivalents.
+
+2. **Case sensitivity**: `contains()` is case-sensitive. The check for "validation" uses `|| manifest.preamble.contains("Validation")` to handle both heading case and inline usage. If the preamble uses all-caps "VALIDATION", add that variant too.
+
+3. **Over-constraining**: The assertions intentionally use broad keyword checks rather than exact substrings. Do not assert on specific sentence structures, field ordering, or formatting details. The goal is to confirm the presence of key concepts, not to pin down exact wording.
+
+4. **Frontmatter assertions unchanged**: Do not modify any of the existing frontmatter assertions (lines 93-120). Those are correct and tested. This task only touches preamble assertions.
+
+## Verification
+
+1. After Group 1 completes (preamble expansion), run `cargo test --test example_skills_test load_skill_writer_skill` and confirm all new assertions pass.
+2. Run the full test suite with `cargo test` to confirm no regressions in other tests.
+3. Run `cargo clippy` to confirm no new warnings from the added assertions.

--- a/.claude/specs/issue-44/add-tools-read-file-to-workspace-cargo-toml.md
+++ b/.claude/specs/issue-44/add-tools-read-file-to-workspace-cargo-toml.md
@@ -1,0 +1,72 @@
+# Spec: Add `"tools/read-file"` to workspace `Cargo.toml`
+
+> From: .claude/tasks/issue-44.md
+
+## Objective
+
+Add `"tools/read-file"` to the `members` list in the root `Cargo.toml` workspace definition. This registers the `read-file` crate with the Cargo workspace so that `cargo build -p read-file` and `cargo test -p read-file` work correctly, matching the pattern already established by `"tools/echo-tool"`.
+
+## Current State
+
+The root `Cargo.toml` at `/Users/sbeardsley/Developer/squirrelsoft-dev/spore/Cargo.toml` defines a Cargo workspace with the following members:
+
+```toml
+[workspace]
+resolver = "2"
+members = [
+    "crates/agent-sdk",
+    "crates/skill-loader",
+    "crates/tool-registry",
+    "crates/agent-runtime",
+    "crates/orchestrator",
+    "tools/echo-tool",
+]
+```
+
+The `tools/echo-tool` entry is the established pattern for tool crates living under the `tools/` directory. There is currently no `tools/read-file` directory in the repository — that crate must be created by a separate task before this workspace entry becomes meaningful, but adding the entry here unblocks that work and is safe to do independently.
+
+## Requirements
+
+- The string `"tools/read-file"` must appear in the `members` list of the `[workspace]` section in the root `Cargo.toml`.
+- The entry must follow immediately after `"tools/echo-tool"` to maintain consistent ordering (tools grouped together after crates).
+- No other changes to `Cargo.toml` are permitted — no new dependencies, no profile changes, no feature changes.
+- After the change, `cargo check` must succeed at the workspace level (assuming `tools/read-file` exists with a valid `Cargo.toml`).
+
+## Implementation Details
+
+- **File to modify:** `/Users/sbeardsley/Developer/squirrelsoft-dev/spore/Cargo.toml`
+- **Change:** Insert `"tools/read-file",` on a new line directly after the `"tools/echo-tool",` line within the `members` array.
+- **No new files** are created by this task — only `Cargo.toml` is touched.
+- The resulting `members` block should look like:
+
+```toml
+members = [
+    "crates/agent-sdk",
+    "crates/skill-loader",
+    "crates/tool-registry",
+    "crates/agent-runtime",
+    "crates/orchestrator",
+    "tools/echo-tool",
+    "tools/read-file",
+]
+```
+
+## Dependencies
+
+- Blocked by: None — this change is safe to make before the `tools/read-file` crate itself exists (Cargo will report a missing-manifest error only when the directory is absent, not on edit alone).
+- Blocking: "Run verification suite" — the verification suite depends on `cargo build -p read-file` and `cargo test -p read-file` being resolvable, which requires this workspace registration.
+
+## Risks & Edge Cases
+
+- **Missing crate directory:** If `tools/read-file/` does not yet exist when `cargo build` or `cargo check` is run at the workspace level, Cargo will emit an error about a missing `Cargo.toml`. This is expected and harmless until the crate scaffold task is complete.
+- **Ordering drift:** Future workspace members added between `echo-tool` and `read-file` would disturb alphabetical ordering. The list is not currently alphabetical, so follow insertion order (tools grouped after crates) rather than enforcing alphabetical ordering.
+- **Resolver compatibility:** The workspace already uses `resolver = "2"`, which is compatible with the edition 2024 used by `echo-tool`. The new member must also declare `edition = "2024"` in its own `Cargo.toml` (out of scope for this task).
+
+## Verification
+
+1. Open `Cargo.toml` and confirm `"tools/read-file"` appears in the `members` list after `"tools/echo-tool"`.
+2. Once `tools/read-file/` exists with a valid `Cargo.toml` (separate task), run:
+   - `cargo check -p read-file` — must exit 0.
+   - `cargo build -p read-file` — must exit 0.
+   - `cargo test -p read-file` — must exit 0.
+3. Run `cargo check` at the workspace root to confirm no other member is broken by the addition.

--- a/.claude/specs/issue-44/create-tools-read-file-cargo-toml.md
+++ b/.claude/specs/issue-44/create-tools-read-file-cargo-toml.md
@@ -1,0 +1,62 @@
+# Spec: Create `tools/read-file/Cargo.toml`
+
+> From: .claude/tasks/issue-44.md
+
+## Objective
+
+Create the `Cargo.toml` manifest for the `read-file` MCP tool crate. This file defines the package name, edition, runtime dependencies, and dev-dependencies required to build the tool binary and run its integration tests. It is the first prerequisite for all other `read-file` implementation tasks.
+
+## Current State
+
+`tools/echo-tool/Cargo.toml` is the reference implementation. It uses:
+
+- `[package]` with `name = "echo-tool"`, `version = "0.1.0"`, `edition = "2024"`
+- `[dependencies]`: `rmcp` (features: `transport-io`, `server`, `macros`), `tokio` (features: `macros`, `rt`, `io-std`), `serde` (feature: `derive`), `serde_json`, `tracing`, `tracing-subscriber` (feature: `env-filter`)
+- `[dev-dependencies]`: `tokio` (features: `macros`, `rt`, `rt-multi-thread`), `rmcp` (features: `client`, `transport-child-process`), `serde_json`
+
+The root `Cargo.toml` workspace at `/Users/sbeardsley/Developer/squirrelsoft-dev/spore/Cargo.toml` currently lists `tools/echo-tool` in `members` but does not yet include `tools/read-file`. Adding `tools/read-file` to the workspace `members` is a separate task ("Add `tools/read-file` to workspace `Cargo.toml`") that runs in parallel with this one.
+
+All dependencies used by `echo-tool` are already present in the workspace; no new third-party crates are needed.
+
+## Requirements
+
+- The file must be created at `tools/read-file/Cargo.toml`.
+- `[package] name` must be `"read-file"` (the binary produced will be `read-file`; the env macro in integration tests will be `CARGO_BIN_EXE_read-file`).
+- `[package] version` must be `"0.1.0"` and `edition` must be `"2024"`, matching the workspace convention.
+- `[dependencies]` must include exactly:
+  - `rmcp = { version = "1", features = ["transport-io", "server", "macros"] }`
+  - `tokio = { version = "1", features = ["macros", "rt", "io-std"] }`
+  - `serde = { version = "1", features = ["derive"] }`
+  - `serde_json = "1"`
+  - `tracing = "0.1"`
+  - `tracing-subscriber = { version = "0.3", features = ["env-filter"] }`
+- `[dev-dependencies]` must include exactly:
+  - `tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }`
+  - `rmcp = { version = "1", features = ["client", "transport-child-process"] }`
+  - `serde_json = "1"`
+- No additional dependencies may be added beyond those listed above.
+
+## Implementation Details
+
+- File to create: `tools/read-file/Cargo.toml`
+- The file is a direct copy of `tools/echo-tool/Cargo.toml` with only `name = "echo-tool"` changed to `name = "read-file"`. No other lines change.
+- The `rt-multi-thread` feature in `[dev-dependencies]` for `tokio` is required because the integration tests use `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`.
+- The `client` and `transport-child-process` features in `[dev-dependencies]` for `rmcp` are required because the integration tests spawn the `read-file` binary as a child process and communicate with it over stdio via an MCP client.
+- No `[[bin]]` section is needed; Cargo infers the binary from `src/main.rs` and uses the package name as the binary name.
+
+## Dependencies
+
+- Blocked by: None
+- Blocking: "Implement `ReadFileTool` struct and handler in `src/read_file.rs`", "Write `src/main.rs`", "Write integration test in `tests/read_file_server_test.rs`"
+
+## Risks & Edge Cases
+
+- If `tools/read-file` is not added to the workspace `members` in the root `Cargo.toml` (a parallel task), `cargo build -p read-file` and `cargo test -p read-file` will fail with an unknown package error. This task and the workspace membership task must both complete before any build or test commands are run.
+- Version constraints (`rmcp = "1"`, `tokio = "1"`, etc.) must stay in sync with what `echo-tool` uses. Drifting versions could cause duplicate dependency resolution in the workspace.
+- The `edition = "2024"` field requires a Rust toolchain that supports the 2024 edition. This is already established by `echo-tool` using the same edition, so no toolchain change is needed.
+
+## Verification
+
+- `tools/read-file/Cargo.toml` exists and its content matches `tools/echo-tool/Cargo.toml` with only the `name` field changed to `"read-file"`.
+- After `tools/read-file` is added to the workspace `members`, running `cargo check -p read-file` succeeds (once `src/main.rs` exists).
+- Running `cargo metadata --manifest-path tools/read-file/Cargo.toml` resolves without errors and lists the expected dependencies.

--- a/.claude/specs/issue-44/implement-readfiletool-struct-and-handler.md
+++ b/.claude/specs/issue-44/implement-readfiletool-struct-and-handler.md
@@ -1,0 +1,88 @@
+# Spec: Implement `ReadFileTool` struct and handler in `src/read_file.rs`
+
+> From: .claude/tasks/issue-44.md
+
+## Objective
+
+Create `tools/read-file/src/read_file.rs`, which defines the core MCP tool logic for reading file contents from disk. This module is the heart of the `read-file` crate: it exposes a single `read_file` tool over the MCP `tools/call` protocol, returning file contents as a string or a descriptive error string on failure. It mirrors `tools/echo-tool/src/echo.rs` exactly in structure and macro usage.
+
+## Current State
+
+The `tools/echo-tool` crate is the canonical reference implementation. Its `src/echo.rs` shows the full pattern this module must follow:
+
+- `EchoRequest` — a `#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]` struct with a single doc-commented field.
+- `EchoTool { tool_router: ToolRouter<Self> }` — constructed via `Self::tool_router()` in `new()`.
+- `#[tool_router] impl EchoTool` — contains the annotated tool method returning `String`.
+- `#[tool_handler] impl ServerHandler for EchoTool` — implements `get_info()` to advertise tool capability.
+- A `#[cfg(test)] mod tests` block with synchronous-style unit tests that call the method directly.
+
+The `read-file` crate directory (`tools/read-file/`) does not yet exist. This task depends on `tools/read-file/Cargo.toml` being created first (Group 1 of the task breakdown).
+
+## Requirements
+
+1. The file is `tools/read-file/src/read_file.rs`.
+2. `ReadFileRequest` must be defined with `#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]` and a single `pub path: String` field with doc comment `/// The path to the file to read (absolute or relative)`.
+3. `ReadFileTool` must hold `tool_router: ToolRouter<Self>` and provide a `pub fn new() -> Self` that initialises it via `Self::tool_router()`.
+4. The `impl ReadFileTool` block must be annotated with `#[tool_router]`.
+5. The `read_file` method inside that block must carry `#[tool(description = "Read the contents of a file from disk and return them as a string")]`.
+6. The method signature must be `fn read_file(&self, Parameters(request): Parameters<ReadFileRequest>) -> String`.
+7. The implementation must call `std::fs::read_to_string(&request.path)`, return the content on `Ok`, and on `Err` return a string of the form `format!("Error reading '{}': {}", request.path, e)`.
+8. The `read_file` method body must be 15 lines or fewer; error formatting must be inline (no helper function).
+9. `impl ServerHandler for ReadFileTool` must be annotated with `#[tool_handler]` and implement `get_info()` returning `ServerInfo::new(ServerCapabilities::builder().enable_tools().build())`.
+10. A `#[cfg(test)] mod tests` block must contain exactly three unit tests:
+    - `read_file_returns_content` — creates a temp file via `std::fs::write`, calls the tool, asserts content matches.
+    - `read_file_returns_error_for_missing_file` — calls the tool with a nonexistent path, asserts the result contains `"Error"`.
+    - `read_file_returns_error_for_directory` — calls the tool with a directory path (use `std::env::temp_dir()`), asserts the result contains `"Error"`.
+11. Temp file paths in tests must be derived from `std::env::temp_dir()` for portability (no hardcoded `/tmp`).
+12. No new crate dependencies may be introduced; all required items (`rmcp`, `serde`, `schemars`) are already declared in `Cargo.toml`.
+13. No commented-out code or debug statements in the final file.
+
+## Implementation Details
+
+**File to create:** `tools/read-file/src/read_file.rs`
+
+**Imports** (mirror `echo.rs` exactly):
+```
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+```
+
+**`ReadFileRequest`** — follows the same single-field struct pattern as `EchoRequest`, with `path: String` and its doc comment placed above the field.
+
+**`ReadFileTool::new()`** — identical boilerplate to `EchoTool::new()`, substituting the type name.
+
+**`#[tool_router] impl ReadFileTool`** — the `read_file` method uses a `match` or `unwrap_or_else` on `std::fs::read_to_string` to produce the `String` return. Either style is acceptable as long as the body is at most 15 lines.
+
+**`#[tool_handler] impl ServerHandler for ReadFileTool`** — copy `get_info()` verbatim from `echo.rs`; the content is identical.
+
+**Test helper pattern** — tests call the tool method directly (no spawning), consistent with `echo.rs`. Each test constructs `ReadFileTool::new()` and invokes `tool.read_file(Parameters(ReadFileRequest { path: ... }))`.
+
+**Temp file naming** — use a unique filename per test (e.g., `temp_dir().join("read_file_test_content.txt")`) to avoid cross-test collisions; clean-up after assertions is optional since temp files are ephemeral.
+
+## Dependencies
+
+- **Blocked by:** "Create `tools/read-file/Cargo.toml`" — the crate manifest must exist for this module to compile. `ToolRouter`, `Parameters`, `ServerCapabilities`, `ServerInfo`, and the `rmcp` macros are all pulled from the `rmcp` dependency declared there.
+- **Blocking:** "Write `src/main.rs`" — `main.rs` imports `mod read_file` and uses `ReadFileTool`; it cannot be written until this module exists.
+- **Blocking:** "Write integration test in `tests/read_file_server_test.rs`" — integration tests spawn the compiled binary, which in turn requires this module to compile and link correctly.
+
+## Risks & Edge Cases
+
+- **Directory reads are errors on all target platforms**: `std::fs::read_to_string` on a directory returns an `Err` on Linux and macOS. The test `read_file_returns_error_for_directory` relies on this; it is safe to assert the error-string branch is hit.
+- **Binary file reads**: `read_to_string` returns `Err` for files containing invalid UTF-8. This is acceptable behaviour and does not need special handling in this task; no size or encoding guard is required.
+- **Temp directory path in tests**: `std::env::temp_dir()` returns an `OsString`-based `PathBuf`. Convert to `String` via `.to_string_lossy().to_string()` or `.display().to_string()` when constructing the `ReadFileRequest { path }` field, since the field type is `String`.
+- **Test isolation**: If multiple tests write to the same temp filename concurrently, they could interfere. Use distinct filenames per test case.
+- **`#[tool_router]` macro requirement**: The method `read_file` must be inside the `#[tool_router]`-annotated `impl` block. Placing it in a separate `impl` block will cause a compile error.
+- **Return type constraint**: The `#[tool_router]` macro requires the method to return `String`, not `Result<String, _>`. All error paths must produce a `String` directly.
+
+## Verification
+
+1. `cargo check -p read-file` — confirms the module compiles and all types resolve correctly. (Requires `Cargo.toml` to exist.)
+2. `cargo test -p read-file` — runs the three unit tests; all must pass.
+3. `cargo clippy -p read-file` — must produce no warnings in `read_file.rs`.
+4. Inspect test output to confirm:
+   - `read_file_returns_content` produces the exact bytes written to the temp file.
+   - `read_file_returns_error_for_missing_file` result string starts with or contains `"Error"`.
+   - `read_file_returns_error_for_directory` result string starts with or contains `"Error"`.

--- a/.claude/specs/issue-44/run-verification-suite.md
+++ b/.claude/specs/issue-44/run-verification-suite.md
@@ -1,0 +1,88 @@
+# Spec: Run Verification Suite
+
+> From: .claude/tasks/issue-44.md
+
+## Objective
+
+Run the four cargo commands that confirm the `read-file` MCP tool crate is correct, complete, and causes no regressions in the wider workspace. This is the final gate for the `read_file` implementation: it validates the build, unit tests, lints, and the workspace-wide type-check all succeed before the issue is closed.
+
+## Current State
+
+The workspace root `Cargo.toml` at `/Users/sbeardsley/Developer/squirrelsoft-dev/spore/Cargo.toml` currently contains these members:
+
+```
+crates/agent-sdk
+crates/skill-loader
+crates/tool-registry
+crates/agent-runtime
+crates/orchestrator
+tools/echo-tool
+```
+
+The `tools/read-file` crate will be added by the "Add `tools/read-file` to workspace `Cargo.toml`" task. All prior tasks (Groups 1–4) must be complete before this verification step runs:
+
+- `tools/read-file/Cargo.toml` — package manifest
+- Root `Cargo.toml` updated with `"tools/read-file"` in `members`
+- `tools/read-file/src/read_file.rs` — `ReadFileTool` implementation and unit tests
+- `tools/read-file/src/main.rs` — binary entry point
+- `tools/read-file/tests/read_file_server_test.rs` — integration tests
+- `tools/read-file/README.md` — documentation
+
+The reference crate `tools/echo-tool` uses the same dependency set (`rmcp`, `tokio`, `serde`, `serde_json`, `tracing`, `tracing-subscriber`) and integration test pattern (`TokioChildProcess` + `CARGO_BIN_EXE_<name>`), so its passing state is the baseline.
+
+There are no CI workflow files (no `.github/workflows/`) in the repository. Verification is manual via the four commands described below.
+
+## Requirements
+
+- `cargo build -p read-file` must exit with status 0, producing the `read-file` binary.
+- `cargo test -p read-file` must exit with status 0, with all unit tests in `src/read_file.rs` and all integration tests in `tests/read_file_server_test.rs` passing:
+  - Unit: `read_file_returns_content`, `read_file_returns_error_for_missing_file`, `read_file_returns_error_for_directory`
+  - Integration: `tools_list_returns_read_file_tool`, `tools_list_read_file_has_correct_description`, `tools_list_read_file_has_path_parameter`, `tools_call_read_file_returns_content`, `tools_call_read_file_returns_error_for_missing_file`
+- `tools/list` over stdio must return exactly one tool with `name == "read_file"` (verified by `tools_list_returns_read_file_tool`).
+- `tools/call` over stdio must return file contents on success and an error string on failure (verified by `tools_call_read_file_returns_content` and `tools_call_read_file_returns_error_for_missing_file`).
+- `cargo clippy -p read-file` must exit with status 0 with no warnings or errors emitted.
+- `cargo check` (workspace-wide, no `-p` flag) must exit with status 0, confirming no regressions in any workspace member.
+
+## Implementation Details
+
+This task involves no file creation or modification. It is exclusively command execution and output inspection.
+
+Commands to run in order:
+
+1. `cargo build -p read-file`
+   - Confirm exit code 0 and that the binary is produced at `target/debug/read-file`.
+
+2. `cargo test -p read-file`
+   - Confirm exit code 0.
+   - Confirm all 8 tests (3 unit + 5 integration) are listed as `ok` in the output.
+   - The integration tests spawn the `read-file` binary as a child process via `CARGO_BIN_EXE_read-file`; `cargo test` builds the binary before running tests, so a separate `cargo build` is not required for this step, but running build first provides an earlier failure signal.
+
+3. `cargo clippy -p read-file`
+   - Confirm exit code 0 and no `warning:` or `error:` lines in the output.
+   - If warnings appear, they must be resolved in the source files before this task is considered complete.
+
+4. `cargo check`
+   - Confirm exit code 0 across all workspace members.
+   - This verifies that adding `tools/read-file` to the workspace did not introduce any type errors or dependency conflicts in sibling crates.
+
+## Dependencies
+
+- Blocked by: "Create `tools/read-file/Cargo.toml`", "Add `tools/read-file` to workspace `Cargo.toml`", "Implement `ReadFileTool` struct and handler in `src/read_file.rs`", "Write `src/main.rs`", "Write integration test in `tests/read_file_server_test.rs`", "Write `README.md`"
+- Blocking: None
+
+## Risks & Edge Cases
+
+- **Missing workspace member**: If `tools/read-file` was not added to the root `Cargo.toml` `members` list, `cargo build -p read-file` will fail with `error: package ID specification 'read-file' did not match any packages`. Confirm the workspace task completed before running these commands.
+- **Integration test binary not built**: The integration tests rely on `CARGO_BIN_EXE_read-file`. If the binary failed to compile, `cargo test` will fail at the integration test stage even if unit tests pass. The `cargo build -p read-file` step surfaces this earlier.
+- **Clippy edition lint**: The `edition = "2024"` setting enables stricter lints. Any `read_file.rs` or `main.rs` code that passes `cargo check` might still emit clippy warnings (e.g., unnecessary `mut`, unused imports). These must be fixed, not suppressed with `#[allow(...)]` attributes, unless the attribute was already present in the reference `echo-tool`.
+- **Temp file collisions in tests**: Unit tests and integration tests both write to `std::env::temp_dir()`. If tests run in parallel they could collide. Each test should use a unique filename (e.g., incorporating the test name or a UUID). If tests are currently non-unique, this is a bug to report rather than silently ignore.
+- **Workspace-wide check regressions**: `cargo check` without `-p` re-checks all crates. A version conflict between `tools/read-file` and an existing workspace crate (unlikely given the shared dependency set) would surface here. If this step fails while the `-p read-file` commands pass, the root cause is in the workspace dependency graph, not in `read-file` itself.
+
+## Verification
+
+- All four commands exit with status 0 in sequence.
+- `cargo test -p read-file` output shows exactly 8 tests passing with no failures or ignored tests.
+- The integration test output includes a line matching `tools_list_returns_read_file_tool ... ok`, confirming `tools/list` returns a tool named `read_file` over stdio.
+- The integration test output includes a line matching `tools_call_read_file_returns_content ... ok`, confirming `tools/call` works over stdio.
+- `cargo clippy -p read-file` output contains no `warning:` or `error:` lines (only the `Finished` line).
+- `cargo check` output contains no `error:` lines for any workspace member.

--- a/.claude/specs/issue-44/write-integration-test-in-tests-read-file-server-test-rs.md
+++ b/.claude/specs/issue-44/write-integration-test-in-tests-read-file-server-test-rs.md
@@ -1,0 +1,71 @@
+# Spec: Write integration test in `tests/read_file_server_test.rs`
+
+> From: .claude/tasks/issue-44.md
+
+## Objective
+
+Create `tools/read-file/tests/read_file_server_test.rs` to validate the `read-file` MCP server binary end-to-end over stdio transport. These tests spawn the compiled binary as a child process, connect an MCP client via `TokioChildProcess`, and exercise both `tools/list` and `tools/call` protocol paths. This is the final implementation step before documentation.
+
+## Current State
+
+The reference test file is `tools/echo-tool/tests/echo_server_test.rs`. Its structure is:
+
+- A private async helper `spawn_echo_client()` that calls `TokioChildProcess::new(Command::new(env!("CARGO_BIN_EXE_echo-tool")))`, then `().serve(transport).await` to obtain a `RunningService<RoleClient, ()>`.
+- Five `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]` async tests, each calling `spawn_echo_client()`, invoking `client.peer().list_tools(None)` or `client.peer().call_tool(params)`, asserting on the result, and finishing with `client.cancel().await`.
+- Imports from `rmcp`: `CallToolRequestParams`, `RunningService`, `TokioChildProcess`, `RoleClient`, `ServiceExt`.
+- Import from `tokio::process::Command`.
+
+The `read-file` binary will expose a single MCP tool named `read_file` (snake_case method name derived from the Rust method) with:
+- Description: `"Read the contents of a file from disk and return them as a string"` (defined in `src/read_file.rs` via `#[tool(description = "...")]`).
+- Input schema with a single required property `"path"` (derived from `ReadFileRequest { path: String }`).
+- Tool call return: the file contents as a plain string on success, or a string beginning with `"Error"` on failure.
+
+The `[dev-dependencies]` in `tools/read-file/Cargo.toml` include `tokio` with `rt-multi-thread`, `rmcp` with `client` and `transport-child-process`, and `serde_json` — everything required by this test file.
+
+## Requirements
+
+- The file must be created at `tools/read-file/tests/read_file_server_test.rs`.
+- A private async helper `spawn_read_file_client()` must spawn the binary using `env!("CARGO_BIN_EXE_read-file")` and return `RunningService<RoleClient, ()>`.
+- All five tests must be annotated `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`.
+- Each test must call `client.cancel().await.expect(...)` as the final statement.
+- Test `tools_list_returns_read_file_tool`: assert `tools_result.tools.len() == 1` and `tools_result.tools[0].name == "read_file"`.
+- Test `tools_list_read_file_has_correct_description`: assert the tool's description contains `"Read the contents of a file"`.
+- Test `tools_list_read_file_has_path_parameter`: assert `input_schema` properties contain the key `"path"`.
+- Test `tools_call_read_file_returns_content`: write a temp file with `std::fs::write`, call the tool with the file path as the `"path"` argument, assert the response text matches the written content exactly.
+- Test `tools_call_read_file_returns_error_for_missing_file`: call the tool with a path guaranteed not to exist, assert the response text contains `"Error"`.
+- No `use` imports beyond those required for the above (no unused imports).
+
+## Implementation Details
+
+- File to create: `tools/read-file/tests/read_file_server_test.rs`
+- Imports required:
+  - `rmcp::{model::CallToolRequestParams, service::RunningService, transport::TokioChildProcess, RoleClient, ServiceExt}`
+  - `tokio::process::Command`
+- The `spawn_read_file_client` helper mirrors `spawn_echo_client` from the echo test exactly, substituting `CARGO_BIN_EXE_read-file` and an appropriate error message string.
+- For `tools_call_read_file_returns_content`: use `std::env::temp_dir()` to construct a portable temp file path (e.g., append a fixed filename like `"read_file_test_content.txt"`). Write a known string with `std::fs::write`. Pass the path as a `String` in the `serde_json::json!({ "path": path_str })` argument map. Assert `text.text == written_content`.
+- For `tools_call_read_file_returns_error_for_missing_file`: use a path that is guaranteed absent, such as `"/nonexistent_path_for_testing_12345/file.txt"`. Assert `text.text.contains("Error")`.
+- `CallToolRequestParams::new("read_file").with_arguments(...)` is the call pattern, matching how the echo test calls `"echo"`.
+- The `input_schema` properties check uses `tool.input_schema.get("properties").expect(...).get("path").is_some()`.
+- All assertions must include a descriptive failure message as the third argument to `assert!` / `assert_eq!`.
+
+## Dependencies
+
+- Blocked by: "Write `src/main.rs`" (the binary must exist for `env!("CARGO_BIN_EXE_read-file")` to resolve and for the child process to be spawnable)
+- Blocking: "Write `README.md`"
+
+## Risks & Edge Cases
+
+- The temp file path used in `tools_call_read_file_returns_content` must be writable in the test environment. Using `std::env::temp_dir()` avoids hardcoding `/tmp`, which may not be writable on all platforms.
+- If two test runs execute concurrently and both write the same temp filename, they could interfere. Mitigate by using a unique filename (e.g., incorporating the test name) or by accepting the race condition given the content written is identical.
+- The `env!("CARGO_BIN_EXE_read-file")` macro resolves at compile time only when the binary target exists in the same crate. If `Cargo.toml` is missing the package or the binary is not built before the test binary, `cargo test` will fail to compile. This is resolved once the Cargo.toml and `src/main.rs` tasks complete.
+- The `tools_call_read_file_returns_error_for_missing_file` test depends on the `read-file` implementation returning a string that contains the literal text `"Error"`. The implementation spec specifies `format!("Error reading '{}': {}", request.path, e)`, which satisfies this assertion.
+- Calling `client.cancel().await` after a failed tool call (where the server returned an error string but did not crash) must succeed; the server should remain running after returning an error-string response.
+
+## Verification
+
+- `cargo test -p read-file` runs all five integration tests and all pass.
+- `cargo clippy -p read-file` reports no warnings in the test file.
+- Running `cargo test -p read-file -- --test-output immediate` shows each of the five test names in the output.
+- The test `tools_list_returns_read_file_tool` confirms the binary exposes exactly one tool named `read_file` over the MCP protocol.
+- The test `tools_call_read_file_returns_content` confirms real file I/O works end-to-end through the MCP stdio transport.
+- The test `tools_call_read_file_returns_error_for_missing_file` confirms error strings propagate correctly through the protocol without panicking the server.

--- a/.claude/specs/issue-44/write-readme-md.md
+++ b/.claude/specs/issue-44/write-readme-md.md
@@ -1,0 +1,52 @@
+# Spec: Write `README.md`
+
+> From: .claude/tasks/issue-44.md
+
+## Objective
+
+Create `tools/read-file/README.md` so that developers can quickly understand how to build, run, and test the `read-file` MCP tool server. It mirrors the structure of `tools/echo-tool/README.md` and stays under 40 lines.
+
+## Current State
+
+`tools/echo-tool/README.md` exists and serves as the reference template. It contains sections for Build, Run, Test with MCP Inspector, Creating a New Tool, and Tool Registry. The `read-file` crate will follow the same stdio transport pattern as `echo-tool`.
+
+The `tools/read-file/` directory is being scaffolded by earlier tasks in this issue. By the time this task runs, the integration test in `tools/read-file/tests/read_file_server_test.rs` must already pass, confirming the server works correctly over stdio.
+
+## Requirements
+
+- File path is exactly `tools/read-file/README.md`.
+- File is under 40 lines total.
+- Contains a Build section with command `cargo build -p read-file`.
+- Contains a Run section with command `cargo run -p read-file`.
+- Describes the stdio transport: reads MCP messages from stdin, writes responses to stdout, logs to stderr.
+- Contains a "Test with MCP Inspector" section with command `npx @modelcontextprotocol/inspector cargo run -p read-file`.
+- Describes the tool's input (`path` parameter) and output (file contents string on success, descriptive error string on failure).
+- Does not include the "Creating a New Tool" or "Tool Registry" sections from `echo-tool/README.md`; those are specific to the reference template.
+
+## Implementation Details
+
+- File to create: `tools/read-file/README.md`
+- Structure (sections in order):
+  1. Title and one-sentence description of what the tool does.
+  2. **Build** — `cargo build -p read-file` code block.
+  3. **Run** — `cargo run -p read-file` code block, followed by the stdio transport explanation.
+  4. **Test with MCP Inspector** — `npx @modelcontextprotocol/inspector cargo run -p read-file` code block, brief explanation of what the inspector does.
+  5. **Tool** — documents the single exposed MCP tool: its name (`read_file`), the `path` input parameter (string, absolute or relative path), and the output (file contents as a string, or an error string beginning with `"Error"` if the file cannot be read).
+
+## Dependencies
+
+- Blocked by: "Write integration test in `tests/read_file_server_test.rs`" — the server must be fully implemented and tested before documenting it.
+- Blocking: "Run verification suite" — the verification task expects all files, including the README, to be in place.
+
+## Risks & Edge Cases
+
+- Keeping the file under 40 lines requires omitting the boilerplate "Creating a New Tool" walkthrough present in `echo-tool/README.md`; that content belongs only in the reference template.
+- The `path` parameter accepts both absolute and relative paths; the README should note this without implying symlink or size-limit behavior that is not yet implemented.
+
+## Verification
+
+- `wc -l tools/read-file/README.md` reports fewer than 40 lines.
+- The file contains the strings `cargo build -p read-file`, `cargo run -p read-file`, and `npx @modelcontextprotocol/inspector cargo run -p read-file`.
+- The file mentions `path` as the input parameter.
+- The file mentions both success output (file contents) and error output.
+- Visual inspection confirms the structure matches the style of `tools/echo-tool/README.md`.

--- a/.claude/specs/issue-44/write-src-main-rs.md
+++ b/.claude/specs/issue-44/write-src-main-rs.md
@@ -1,0 +1,60 @@
+# Spec: Write `src/main.rs`
+
+> From: .claude/tasks/issue-44.md
+
+## Objective
+
+Create `tools/read-file/src/main.rs` as the binary entry point for the `read-file` MCP server. This file wires the `ReadFileTool` struct into the `rmcp` stdio transport runtime and is the counterpart to `tools/echo-tool/src/main.rs`, following the same structural pattern exactly.
+
+## Current State
+
+`tools/echo-tool/src/main.rs` (24 lines) serves as the reference implementation. It:
+
+- Imports `rmcp::ServiceExt` and `tracing_subscriber` with `EnvFilter`
+- Declares `mod echo` and imports `EchoTool` from it
+- Defines `#[tokio::main(flavor = "current_thread")]` async `main`
+- Initialises a `tracing_subscriber` writing to stderr with no ANSI codes
+- Logs an info message identifying the server
+- Constructs the tool via `EchoTool::new()`, calls `.serve(rmcp::transport::stdio())`, and awaits `.waiting()`
+
+`tools/read-file/src/read_file.rs` must exist and export `ReadFileTool` before this file can compile (see Dependencies).
+
+## Requirements
+
+- The file must be `tools/read-file/src/main.rs`
+- The module declaration must be `mod read_file` (not `mod echo`)
+- The struct import must be `use read_file::ReadFileTool`
+- The tracing info log line must read exactly `"Starting read-file MCP server"`
+- The file must be 25 lines or fewer
+- All other structure (imports, tokio runtime flavour, tracing setup, serve/waiting pattern) must mirror `tools/echo-tool/src/main.rs` without deviation
+- No new dependencies may be introduced; all required crates (`rmcp`, `tokio`, `tracing`, `tracing-subscriber`) are already declared in `tools/read-file/Cargo.toml`
+
+## Implementation Details
+
+- **File to create:** `tools/read-file/src/main.rs`
+- Copy `tools/echo-tool/src/main.rs` verbatim, then apply exactly three substitutions:
+  1. `mod echo` → `mod read_file`
+  2. `use echo::EchoTool` → `use read_file::ReadFileTool`
+  3. `"Starting echo-tool MCP server"` → `"Starting read-file MCP server"`
+  4. `EchoTool::new()` → `ReadFileTool::new()`
+- The `#[tokio::main(flavor = "current_thread")]` attribute and the full tracing subscriber init chain must remain unchanged
+- The error inspection closure `|e| tracing::error!("serving error: {:?}", e)` must remain unchanged
+
+## Dependencies
+
+- Blocked by: "Implement `ReadFileTool` struct and handler in `src/read_file.rs`" — `ReadFileTool` and its `new()` constructor must be defined and exported from `tools/read-file/src/read_file.rs` before this file compiles
+- Blocking: "Write integration test in `tests/read_file_server_test.rs`" — the integration test spawns the compiled `read-file` binary, which requires this entry point to exist
+
+## Risks & Edge Cases
+
+- **Module name collision:** Rust's module system requires `mod read_file` to match the filename `read_file.rs` exactly. A mismatch (e.g., `mod readfile`) will cause a compile error.
+- **`current_thread` runtime:** The single-threaded tokio runtime is intentional for stdio-based MCP servers. Do not change the flavour to `multi_thread`.
+- **ANSI codes disabled:** `with_ansi(false)` is required because the server communicates over stdio; ANSI escape sequences in log output would corrupt the MCP message stream. This line must not be removed.
+
+## Verification
+
+- `cargo build -p read-file` completes without errors or warnings
+- `cargo clippy -p read-file` reports no issues
+- The compiled binary exists at the path reported by `cargo build` (typically `target/debug/read-file`)
+- Line count: `wc -l tools/read-file/src/main.rs` reports 25 or fewer
+- The integration test suite (`cargo test -p read-file`) passes, confirming the binary starts and responds to MCP protocol messages

--- a/.claude/specs/issue-49/add-tools-docker-push-to-workspace-cargo-toml.md
+++ b/.claude/specs/issue-49/add-tools-docker-push-to-workspace-cargo-toml.md
@@ -1,0 +1,86 @@
+# Spec: Add `"tools/docker-push"` to workspace `Cargo.toml`
+
+> From: .claude/tasks/issue-49.md
+
+## Objective
+
+Add `"tools/docker-push"` to the `members` list in the root `Cargo.toml` workspace definition. This registers the `docker-push` crate with the Cargo workspace so that `cargo build -p docker-push`, `cargo test -p docker-push`, and `cargo clippy -p docker-push` work correctly, following the pattern established by the existing tool crates (`echo-tool`, `cargo-build`, etc.).
+
+## Current State
+
+The root `Cargo.toml` at `/Users/sbeardsley/Developer/squirrelsoft-dev/spore/Cargo.toml` defines a Cargo workspace with the following members:
+
+```toml
+[workspace]
+resolver = "2"
+members = [
+    "crates/agent-sdk",
+    "crates/skill-loader",
+    "crates/tool-registry",
+    "crates/agent-runtime",
+    "crates/mcp-tool-harness",
+    "crates/orchestrator",
+    "crates/mcp-test-utils",
+    "tools/echo-tool",
+    "tools/read-file",
+    "tools/write-file",
+    "tools/validate-skill",
+    "tools/cargo-build",
+]
+```
+
+The `tools/cargo-build` entry is the last member in the list. There is currently no `tools/docker-push` directory in the repository — that crate must be created by a separate task ("Create `tools/docker-push/Cargo.toml`") before this workspace entry becomes meaningful, but adding the entry here is safe to do independently and unblocks the verification suite.
+
+## Requirements
+
+- The string `"tools/docker-push"` must appear in the `members` list of the `[workspace]` section in the root `Cargo.toml`.
+- The entry must be placed immediately after `"tools/cargo-build"` to maintain the existing ordering convention (crates grouped first, then tools in insertion order).
+- No other changes to `Cargo.toml` are permitted — no new dependencies, no profile changes, no feature changes.
+- After the change, `cargo check` must succeed at the workspace level (assuming `tools/docker-push` exists with a valid `Cargo.toml`).
+
+## Implementation Details
+
+- **File to modify:** `/Users/sbeardsley/Developer/squirrelsoft-dev/spore/Cargo.toml`
+- **Change:** Insert `"tools/docker-push",` on a new line directly after the `"tools/cargo-build",` line within the `members` array.
+- **No new files** are created by this task — only `Cargo.toml` is touched.
+- The resulting `members` block should look like:
+
+```toml
+members = [
+    "crates/agent-sdk",
+    "crates/skill-loader",
+    "crates/tool-registry",
+    "crates/agent-runtime",
+    "crates/mcp-tool-harness",
+    "crates/orchestrator",
+    "crates/mcp-test-utils",
+    "tools/echo-tool",
+    "tools/read-file",
+    "tools/write-file",
+    "tools/validate-skill",
+    "tools/cargo-build",
+    "tools/docker-push",
+]
+```
+
+## Dependencies
+
+- Blocked by: None — this change is safe to make before the `tools/docker-push` crate itself exists (Cargo will report a missing-manifest error only when a workspace-level build is attempted while the directory is absent, not on edit alone).
+- Blocking: "Run verification suite" — the verification suite depends on `cargo build -p docker-push` and `cargo test -p docker-push` being resolvable, which requires this workspace registration.
+
+## Risks & Edge Cases
+
+- **Missing crate directory:** If `tools/docker-push/` does not yet exist when `cargo build` or `cargo check` is run at the workspace level, Cargo will emit an error about a missing `Cargo.toml`. This is expected and harmless until the crate scaffold task ("Create `tools/docker-push/Cargo.toml`") is complete.
+- **Ordering drift:** The members list is not alphabetically sorted; it follows insertion order with crates grouped before tools. The new entry should go at the end of the tools group (after `cargo-build`) to stay consistent.
+- **Resolver compatibility:** The workspace already uses `resolver = "2"`, which is compatible with the edition 2024 used by existing tool crates. The new `docker-push` member must also declare `edition = "2024"` in its own `Cargo.toml` (out of scope for this task).
+
+## Verification
+
+1. Open `Cargo.toml` and confirm `"tools/docker-push"` appears in the `members` list immediately after `"tools/cargo-build"`.
+2. Confirm no other lines in `Cargo.toml` were changed (no dependency additions, no profile changes, no feature changes).
+3. Once `tools/docker-push/` exists with a valid `Cargo.toml` (separate task), run:
+   - `cargo check -p docker-push` — must exit 0.
+   - `cargo build -p docker-push` — must exit 0.
+   - `cargo test -p docker-push` — must exit 0.
+   - `cargo clippy -p docker-push` — must exit 0.
+4. Run `cargo check` at the workspace root to confirm no other member is broken by the addition.

--- a/.claude/specs/issue-49/create-tools-docker-push-cargo-toml.md
+++ b/.claude/specs/issue-49/create-tools-docker-push-cargo-toml.md
@@ -1,0 +1,121 @@
+# Spec: Create `tools/docker-push/Cargo.toml`
+
+> From: .claude/tasks/issue-49.md
+
+## Objective
+
+Scaffold the `tools/docker-push/` crate by creating its `Cargo.toml` manifest. This crate will be a standalone Rust MCP server binary that pushes a tagged Docker image to a container registry. The manifest follows the established pattern from `tools/cargo-build/Cargo.toml`, changing only the package name.
+
+## Current State
+
+- The workspace root `Cargo.toml` lists the following members:
+  ```toml
+  [workspace]
+  resolver = "2"
+  members = [
+      "crates/agent-sdk",
+      "crates/skill-loader",
+      "crates/tool-registry",
+      "crates/agent-runtime",
+      "crates/mcp-tool-harness",
+      "crates/orchestrator",
+      "crates/mcp-test-utils",
+      "tools/echo-tool",
+      "tools/read-file",
+      "tools/write-file",
+      "tools/validate-skill",
+      "tools/cargo-build",
+  ]
+  ```
+- The `tools/docker-push/` directory does not yet exist.
+- `tools/cargo-build/Cargo.toml` is the reference pattern. It uses `edition = "2024"`, `version = "0.1.0"`, and depends on `mcp-tool-harness` (a workspace-local crate), `rmcp`, `tokio`, `serde`, and `serde_json`.
+- All existing tool crates use the same dependency pattern: `mcp-tool-harness` via path, `rmcp` with `transport-io`/`server`/`macros` features, `tokio` with `macros`/`rt`/`io-std`, `serde` with `derive`, and `serde_json`.
+- All existing tool crates use the same dev-dependency pattern: `mcp-test-utils` via path, `tokio` with `macros`/`rt`/`rt-multi-thread`, `rmcp` with `client`/`transport-child-process`, and `serde_json`.
+
+## Requirements
+
+- Create the directory `tools/docker-push/src/` so that `cargo check` can locate the crate root once the workspace member is added.
+- Create `tools/docker-push/Cargo.toml` with the exact contents specified below.
+- The `[package]` section must have:
+  - `name = "docker-push"`
+  - `version = "0.1.0"`
+  - `edition = "2024"`
+- The `[dependencies]` section must contain exactly these five entries (no more, no less):
+  - `mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }`
+  - `rmcp = { version = "1", features = ["transport-io", "server", "macros"] }`
+  - `tokio = { version = "1", features = ["macros", "rt", "io-std"] }`
+  - `serde = { version = "1", features = ["derive"] }`
+  - `serde_json = "1"`
+- The `[dev-dependencies]` section must contain exactly these four entries:
+  - `mcp-test-utils = { path = "../../crates/mcp-test-utils" }`
+  - `tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }`
+  - `rmcp = { version = "1", features = ["client", "transport-child-process"] }`
+  - `serde_json = "1"`
+- A placeholder `tools/docker-push/src/main.rs` must be created with a minimal `fn main() {}` so that `cargo check` succeeds once the crate is added to the workspace. The real implementation is a separate task.
+
+## Implementation Details
+
+### Files to create
+
+1. **`tools/docker-push/Cargo.toml`** -- the crate manifest with the following content:
+
+   ```toml
+   [package]
+   name = "docker-push"
+   version = "0.1.0"
+   edition = "2024"
+
+   [dependencies]
+   mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }
+   rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
+   tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+   serde = { version = "1", features = ["derive"] }
+   serde_json = "1"
+
+   [dev-dependencies]
+   mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+   tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+   rmcp = { version = "1", features = ["client", "transport-child-process"] }
+   serde_json = "1"
+   ```
+
+2. **`tools/docker-push/src/main.rs`** -- minimal placeholder so the crate compiles:
+
+   ```rust
+   fn main() {}
+   ```
+
+### Files NOT modified by this task
+
+- `Cargo.toml` (root workspace) -- adding the crate to workspace members is a separate task ("Add `tools/docker-push` to workspace `Cargo.toml`").
+
+### Key design decisions
+
+- **Exact copy of `cargo-build` pattern:** The `Cargo.toml` is intentionally identical to `tools/cargo-build/Cargo.toml` except for the package name. This ensures consistency across all tool crates and reduces cognitive overhead for contributors.
+- **`mcp-tool-harness` path dependency:** Unlike the original `echo-tool` which was standalone, newer tool crates depend on `mcp-tool-harness` for shared MCP server boilerplate (`serve_stdio_tool`). The path `../../crates/mcp-tool-harness` is correct relative to `tools/docker-push/`.
+- **`rmcp` features split:** Production dependencies use `transport-io`, `server`, and `macros` for the stdio MCP server. Dev-dependencies use `client` and `transport-child-process` for spawning the tool binary and communicating with it in integration tests.
+- **`tokio` feature split:** Production code needs `macros`, `rt`, and `io-std` (for stdin/stdout in the MCP stdio transport). Dev-dependencies add `rt-multi-thread` for `#[tokio::test(flavor = "multi_thread")]` in integration tests. Cargo unions features when building tests, so this is the correct idiomatic pattern.
+- **`mcp-test-utils` dev-dependency:** Provides `spawn_mcp_client!` macro and `assert_single_tool` helper used by integration tests.
+- **No `schemars` dependency:** Input validation uses `schemars::JsonSchema` derive, but this is re-exported through `rmcp`'s `macros` feature, so no explicit `schemars` dependency is needed.
+
+## Dependencies
+
+- Blocked by: Nothing (Group 1 task, no predecessors)
+- Blocking: "Implement `DockerPushTool` struct and handler", "Write `main.rs`", "Write integration tests" (all require this crate manifest to exist)
+
+## Risks & Edge Cases
+
+- **Path dependency correctness:** The relative paths `../../crates/mcp-tool-harness` and `../../crates/mcp-test-utils` assume the crate lives at `tools/docker-push/`. If the directory structure changes, these paths will break. This is the same pattern used by all existing tool crates, so the risk is low.
+- **Placeholder `main.rs` warnings:** The placeholder `fn main() {}` does not use any of the declared dependencies, which will produce unused-dependency warnings from `cargo clippy`. This is acceptable since the real implementation replaces it in the next task ("Write `main.rs`").
+- **Workspace root not updated:** This task intentionally does NOT add the crate to the workspace `members` list. A separate task handles that. Until both tasks complete, `cargo build` from the workspace root will not build `docker-push`. This is by design -- the two tasks are in the same group (Group 1) and can be done in parallel.
+- **Dependency version alignment:** All dependency versions (`rmcp = "1"`, `tokio = "1"`, `serde = "1"`, `serde_json = "1"`) match those used by `tools/cargo-build/Cargo.toml` exactly. Since these already resolve successfully in the workspace, no version conflicts are expected.
+
+## Verification
+
+- `tools/docker-push/Cargo.toml` exists and contains the exact `[package]`, `[dependencies]`, and `[dev-dependencies]` sections specified above.
+- `tools/docker-push/src/main.rs` exists and contains a valid `fn main() {}`.
+- The directory structure is `tools/docker-push/src/main.rs` and `tools/docker-push/Cargo.toml` (no extra files).
+- After the companion task "Add `tools/docker-push` to workspace `Cargo.toml`" completes, `cargo check -p docker-push` succeeds without errors.
+- The `[dependencies]` section has exactly five entries matching `tools/cargo-build/Cargo.toml`.
+- The `[dev-dependencies]` section has exactly four entries matching `tools/cargo-build/Cargo.toml`.
+- No dependencies are added that are not present in the `cargo-build` reference.

--- a/.claude/specs/issue-49/implement-dockerpushtool-struct-and-handler.md
+++ b/.claude/specs/issue-49/implement-dockerpushtool-struct-and-handler.md
@@ -1,0 +1,177 @@
+# Spec: Implement `DockerPushTool` struct and handler in `src/docker_push.rs`
+
+> From: .claude/tasks/issue-49.md
+
+## Objective
+Create `tools/docker-push/src/docker_push.rs` containing the core MCP tool implementation for pushing Docker images to a container registry. This file defines the request struct, input validation, registry URL resolution, subprocess invocation, digest extraction, and structured JSON response. The implementation follows the `cargo-build` tool pattern exactly, since both tools invoke an external command via `std::process::Command` and return structured JSON.
+
+## Current State
+- `tools/cargo-build/src/cargo_build.rs` exists as the reference pattern. It defines `CargoBuildRequest`, `CargoBuildTool`, validates input, invokes `cargo build` via `std::process::Command`, and returns structured JSON. It uses `#[tool_router]`, `#[tool_handler]`, and `ServerHandler` from `rmcp`.
+- `tools/cargo-build/src/main.rs` is 7 lines: declares `mod cargo_build;`, imports the tool struct, and calls `mcp_tool_harness::serve_stdio_tool`.
+- `crates/mcp-tool-harness/src/lib.rs` provides `serve_stdio_tool<T: ServerHandler>` which initializes tracing to stderr and serves the tool over stdio transport.
+- The `tools/docker-push/` directory and `Cargo.toml` do not yet exist. This task is blocked by the "Create `tools/docker-push/Cargo.toml`" task which will provide identical dependencies to `tools/cargo-build/Cargo.toml` (with `schemars` re-exported by `rmcp`).
+- No `docker_push.rs` file exists anywhere in the workspace.
+
+## Requirements
+
+### Request struct: `DockerPushRequest`
+- Derive `Debug`, `serde::Deserialize`, `schemars::JsonSchema`.
+- Field `image: String` with doc comment `/// Full image reference (e.g., ghcr.io/spore/spore-agent:0.1)`.
+- Field `registry_url: Option<String>` with doc comment `/// Override registry URL; falls back to REGISTRY_URL env var`.
+
+### Tool struct: `DockerPushTool`
+- Fields: `tool_router: ToolRouter<Self>`.
+- Derive `Debug, Clone` (matching the `CargoBuildTool` pattern).
+- Constructor `new()` that calls `Self::tool_router()`.
+
+### Input validation
+- Reject empty `image` strings.
+- Reject `image` strings containing any shell metacharacter: `;`, `|`, `&`, `$`, `` ` ``, `(`, `)`, `{`, `}`, `<`, `>`, `!`, `\n`.
+- Accept only valid Docker image reference characters: alphanumeric, `.`, `-`, `_`, `/`, `:`.
+- Use simple character iteration (no regex dependency).
+- On validation failure, return `{"success": false, "image": "<input>", "digest": "", "push_log": "Invalid image reference: <reason>"}`.
+
+### Registry URL resolution
+- If `registry_url` is `Some(url)`, use that URL.
+- Otherwise, attempt `std::env::var("REGISTRY_URL")`. If `Ok(url)`, use that.
+- If a registry URL is available and the `image` does not already start with it, prepend: `format!("{registry_url}/{image}")`.
+- If no registry URL is available, proceed with the image as-is.
+- Extract this logic into a standalone helper function (`resolve_image_ref` or similar) so it can be unit-tested without invoking Docker.
+
+### Docker push invocation
+- Use `std::process::Command::new("docker").args(["push", &final_image_ref]).output()`.
+- On `Command` spawn failure (`.output()` returns `Err`), return `{"success": false, "image": "<final_ref>", "digest": "", "push_log": "Failed to execute docker: <error>"}`.
+
+### Digest extraction
+- Combine stdout and stderr into a single string (stdout first, then stderr).
+- Search line by line for a substring containing `digest: sha256:`.
+- Extract the full `sha256:<hex>` token (the word immediately following `digest: `).
+- If no match, return empty string.
+- Extract this logic into a standalone helper function (`extract_digest` or similar) so it can be unit-tested without invoking Docker.
+
+### Return format
+- On successful `Command` execution (regardless of exit code): `serde_json::json!({"success": output.status.success(), "image": final_image_ref, "digest": extracted_digest, "push_log": combined_output})`.
+- Return value is `.to_string()` (the tool method returns `String`, matching cargo-build).
+
+### ServerHandler implementation
+- `#[tool_handler] impl ServerHandler for DockerPushTool` with `get_info()` returning `ServerInfo::new(ServerCapabilities::builder().enable_tools().build())`.
+
+### Unit tests (`#[cfg(test)] mod tests`)
+Six tests, none of which require Docker to be installed:
+
+1. **`rejects_empty_image`** -- Call `docker_push` with `image: ""`. Assert `success: false` and `push_log` contains "Invalid image reference".
+
+2. **`rejects_image_with_shell_metachar`** -- Call with `image: "foo;bar"`. Assert `success: false` and `push_log` contains "Invalid image reference".
+
+3. **`rejects_image_with_pipe`** -- Call with `image: "foo|bar"`. Assert `success: false` and `push_log` contains "Invalid image reference".
+
+4. **`accepts_valid_image_reference`** -- Call with `image: "ghcr.io/spore/spore-agent:0.1"`. Assert the result is valid JSON containing all four fields (`success`, `image`, `digest`, `push_log`). Note: this test will attempt to execute `docker push` which may fail if Docker is not installed, but the response still has the expected JSON structure.
+
+5. **`registry_url_is_prepended`** -- Call the `resolve_image_ref` helper directly. Test cases:
+   - `image = "spore-agent:0.1"`, `registry_url = Some("ghcr.io/spore")` produces `"ghcr.io/spore/spore-agent:0.1"`.
+   - `image = "ghcr.io/spore/spore-agent:0.1"`, `registry_url = Some("ghcr.io/spore")` does not double the prefix (returns unchanged).
+
+6. **`digest_extraction_from_output`** -- Call the `extract_digest` helper directly.
+   - Input `"latest: digest: sha256:abc123def456 size: 1234"` returns `"sha256:abc123def456"`.
+   - Input with no digest line returns `""`.
+
+### Test helper pattern
+Follow the `cargo_build.rs` test pattern: define a helper function `call_docker_push(tool, image, registry_url)` that constructs a `DockerPushRequest` and invokes the tool method via `Parameters(...)`. Parse the returned string as `serde_json::Value` for assertions.
+
+## Implementation Details
+
+### Imports
+```rust
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+```
+
+### Validation function: `validate_image_ref`
+A standalone `fn validate_image_ref(image: &str) -> Result<(), String>` that:
+1. Returns `Err("image must not be empty")` if empty.
+2. Iterates over each character. If any character is not alphanumeric and not in the set `.`, `-`, `_`, `/`, `:`, returns `Err` with a description of the invalid character.
+3. Returns `Ok(())` on success.
+
+The shell metacharacter check is implicitly handled: characters like `;`, `|`, `&`, `$`, etc. are not in the allowed set and will be caught by the character allowlist. This is simpler and more secure than maintaining a separate blocklist.
+
+### Registry URL resolution function: `resolve_image_ref`
+A standalone `fn resolve_image_ref(image: &str, registry_url: Option<&str>) -> String` that:
+1. Determines the effective registry URL: `registry_url` parameter first, then `std::env::var("REGISTRY_URL").ok()`.
+2. If a registry URL is available and `image` does not start with it, returns `format!("{}/{}", registry_url, image)`.
+3. Otherwise returns `image.to_string()`.
+
+For testability, consider accepting the env var as a parameter or using a separate internal function that takes all inputs explicitly, so the unit test for `registry_url_is_prepended` does not depend on the environment variable.
+
+### Digest extraction function: `extract_digest`
+A standalone `fn extract_digest(output: &str) -> String` that:
+1. Iterates over lines.
+2. For each line, searches for the substring `"digest: sha256:"`.
+3. If found, extracts the token starting at `sha256:` up to the next whitespace.
+4. Returns the token, or empty string if not found.
+
+### Tool method: `docker_push`
+```rust
+#[tool(description = "Push a tagged Docker image to a container registry")]
+fn docker_push(&self, Parameters(request): Parameters<DockerPushRequest>) -> String
+```
+
+Follows this flow:
+1. Validate `request.image` via `validate_image_ref`. On failure, return error JSON.
+2. Resolve final image ref via `resolve_image_ref`.
+3. Invoke `Command::new("docker").args(["push", &final_ref]).output()`.
+4. On spawn error, return error JSON.
+5. On success, combine stdout + stderr, extract digest, return result JSON.
+
+### Line budget
+- Imports: ~6 lines
+- `DockerPushRequest` struct: ~7 lines
+- `DockerPushTool` struct + derives: ~5 lines
+- `validate_image_ref`: ~15 lines
+- `resolve_image_ref`: ~15 lines
+- `extract_digest`: ~12 lines
+- `#[tool_router] impl` with `new()` + `docker_push()`: ~35 lines
+- `#[tool_handler] impl ServerHandler`: ~8 lines
+- Tests module: ~80 lines
+- Total: ~183 lines
+
+Each function stays well under the 50-line limit from the project rules.
+
+## Dependencies
+- **Blocked by:** "Create `tools/docker-push/Cargo.toml`" -- the crate must exist before this file can be compiled.
+- **Blocking:** "Write `main.rs`" (which declares `mod docker_push;` and uses `DockerPushTool`), "Write integration tests" (which spawn the binary and exercise the tool over MCP).
+- **No new crate dependencies.** All imports (`rmcp`, `serde`, `serde_json`, `schemars` via rmcp re-export) are already specified in the `Cargo.toml` created by the scaffolding task, mirroring `tools/cargo-build/Cargo.toml`.
+
+## Risks & Edge Cases
+
+1. **Docker not installed in test/CI environment.** The `accepts_valid_image_reference` unit test invokes `docker push` via `Command`. If Docker is not installed, `Command::new("docker").output()` returns `Err` and the tool returns the "Failed to execute docker" error JSON. The test must not assert `success: true` -- it should only assert that the response is valid JSON with the four expected fields. The other five unit tests (validation, registry URL, digest extraction) do not require Docker.
+
+2. **Registry URL with trailing slash.** If `registry_url` ends with `/`, the resolved image would have a double slash (e.g., `ghcr.io/spore//image:tag`). Consider trimming trailing slashes from the registry URL. The task description does not specify this, but it is a defensive measure.
+
+3. **Image already contains registry prefix partially.** The `starts_with` check covers exact prefix matching. If the image is `ghcr.io/spore-other/image:tag` and the registry URL is `ghcr.io/spore`, the `starts_with` check would match incorrectly. However, this is an unlikely edge case and the task description specifies using `starts_with`, so follow that behavior.
+
+4. **Environment variable leaking into tests.** The `resolve_image_ref` function reads `REGISTRY_URL` from the environment. If this env var is set in the test runner, it could affect tests unexpectedly. Mitigation: the `registry_url_is_prepended` test should call the helper with an explicit `registry_url` parameter (testing the `Some` path), and should not depend on the env var path for correctness. If the env var path needs testing, use `std::env::set_var`/`remove_var` in a dedicated test (noting that this is not thread-safe).
+
+5. **Large Docker output.** `docker push` can produce verbose output (multiple layers being pushed). The tool captures all of stdout and stderr via `.output()`, which buffers everything in memory. For typical image pushes this is acceptable, but extremely large output could be a concern. This is not addressed in the task and is unlikely in practice.
+
+6. **`schemars` re-export availability.** The `DockerPushRequest` derives `schemars::JsonSchema`. The `rmcp` crate re-exports `schemars`, matching the `cargo-build` pattern which uses `schemars` without a direct dependency. If the re-export is not available, `schemars` would need to be added to `Cargo.toml`. The scaffolding task should match `cargo-build` exactly, so this should not be an issue.
+
+7. **MCP tool name.** The `#[tool_router]` macro derives the tool name from the method name. The method `docker_push` produces tool name `docker_push` (snake_case). This matches the convention described in the task breakdown (binary name `docker-push`, MCP tool name `docker_push`).
+
+## Verification
+
+1. **Compilation:** `cargo check -p docker-push` succeeds with no errors.
+2. **Lint:** `cargo clippy -p docker-push` produces no warnings.
+3. **Unit tests:** `cargo test -p docker-push -- --lib` passes all six unit tests:
+   - `rejects_empty_image`
+   - `rejects_image_with_shell_metachar`
+   - `rejects_image_with_pipe`
+   - `accepts_valid_image_reference`
+   - `registry_url_is_prepended`
+   - `digest_extraction_from_output`
+4. **Line count:** Each function in `docker_push.rs` is under 50 lines. The file overall is under 200 lines.
+5. **No commented-out code or debug statements** in the final file.
+6. **Pattern conformance:** The file structure (imports, request struct, tool struct, `#[tool_router]` impl, `#[tool_handler]` impl, `#[cfg(test)]` mod) mirrors `tools/cargo-build/src/cargo_build.rs` exactly.
+7. **Workspace check:** `cargo check` (full workspace) succeeds with no regressions.

--- a/.claude/specs/issue-49/run-verification-suite.md
+++ b/.claude/specs/issue-49/run-verification-suite.md
@@ -1,0 +1,90 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-49.md
+
+## Objective
+Run the package-scoped verification commands (`cargo build -p docker-push`, `cargo test -p docker-push`, `cargo clippy -p docker-push`) followed by a workspace-wide `cargo check` to confirm that the `docker-push` MCP tool crate compiles cleanly, passes all tests, produces no lint warnings, and introduces no regressions across the workspace. This is the final gate task for issue-49 -- it validates that every preceding task (scaffold, implementation, integration tests, README) integrates correctly.
+
+## Current State
+The workspace is defined in the root `Cargo.toml` with `resolver = "2"`. By the time this task runs, the workspace members will include all existing crates plus the new `tools/docker-push` entry:
+- `crates/agent-sdk`, `crates/skill-loader`, `crates/tool-registry`, `crates/agent-runtime`, `crates/mcp-tool-harness`, `crates/orchestrator`, `crates/mcp-test-utils`
+- `tools/echo-tool`, `tools/read-file`, `tools/write-file`, `tools/validate-skill`, `tools/cargo-build`
+- `tools/docker-push` -- new MCP docker push tool server (added by preceding issue-49 tasks)
+
+By the time this task runs, the preceding issue-49 tasks will have:
+1. Created `tools/docker-push/Cargo.toml` with dependencies on `mcp-tool-harness`, `rmcp` (with `transport-io`, `server`, `macros` features), `tokio`, `serde`, and `serde_json`
+2. Added `"tools/docker-push"` to the workspace `members` array in the root `Cargo.toml`
+3. Implemented the `DockerPushTool` struct with `#[tool_router]` and `ServerHandler` in `tools/docker-push/src/docker_push.rs`, including input validation, registry URL resolution, digest extraction, and six unit tests
+4. Created `tools/docker-push/src/main.rs` mirroring the `cargo-build` pattern
+5. Written integration tests in `tools/docker-push/tests/docker_push_server_test.rs` (four tests: `tools/list` verification, invalid image error, valid image structured JSON, empty image error)
+6. Created `tools/docker-push/README.md`
+
+## Requirements
+- `cargo build -p docker-push` succeeds with zero errors
+- `cargo test -p docker-push` succeeds with all tests passing, including:
+  - Unit tests: `rejects_empty_image`, `rejects_image_with_shell_metachar`, `rejects_image_with_pipe`, `accepts_valid_image_reference`, `registry_url_is_prepended`, `digest_extraction_from_output`
+  - Integration tests: `tools_list_returns_docker_push_tool`, `tools_call_with_invalid_image_returns_error`, `tools_call_with_valid_image_returns_structured_json`, `tools_call_with_empty_image_returns_error`
+- `cargo clippy -p docker-push` succeeds with zero warnings (no `#[allow(...)]` suppressions added solely to silence legitimate warnings)
+- `cargo check` (workspace-wide) succeeds with zero errors, confirming no regressions in any existing crate
+- All acceptance criteria from the issue are satisfied:
+  - Build succeeds
+  - Tests pass
+  - Tool returns structured JSON with `success`, `image`, `digest`, and `push_log` fields
+  - Tool returns structured errors on auth/network/validation failure
+  - Tool is named `docker_push` in MCP `tools/list`
+- No commented-out code or debug statements remain in the `docker-push` source files
+- No unused imports, dead code, or other Clippy lint violations in the `docker-push` crate
+
+## Implementation Details
+This task does not create or modify source files. It is a verification-only task. The steps are:
+
+1. **Run `cargo build -p docker-push`** from the workspace root. This compiles only the `docker-push` crate and its dependencies. If it fails, diagnose the root cause -- likely candidates include:
+   - Missing or incorrect dependency features in `tools/docker-push/Cargo.toml`
+   - Import errors in `docker_push.rs` or `main.rs` (e.g., wrong `rmcp` module paths)
+   - Type mismatches in the `ServerHandler` or `#[tool_router]` implementations
+   - The `tools/docker-push` path not present in the root `Cargo.toml` `members` array
+
+2. **Run `cargo test -p docker-push`** from the workspace root. This compiles and executes all `#[test]` and `#[tokio::test]` functions within the `docker-push` crate. Verify:
+   - All six unit tests pass (input validation, registry URL prepending, digest extraction)
+   - All four integration tests pass (MCP `tools/list` schema, invalid image error, valid image structured JSON, empty image error)
+   - The integration test `tools_list_returns_docker_push_tool` confirms the tool is named `docker_push` (snake_case) in the MCP `tools/list` response
+
+3. **Run `cargo clippy -p docker-push`** from the workspace root. This applies Rust's standard lints plus Clippy's extended checks scoped to the `docker-push` crate. Pay attention to:
+   - Unused imports or variables
+   - Warnings about the `DockerPushTool` struct or its methods
+   - Clippy suggestions for `std::process::Command` usage patterns
+   - Warnings in test modules (both unit and integration tests)
+
+4. **Run `cargo check`** (workspace-wide, no `-p` filter) from the workspace root. This performs type-checking across all workspace members. This confirms that adding `docker-push` to the workspace and its dependency tree does not break any existing crate.
+
+5. If any step fails, **diagnose before fixing** (per project rules). Explain the root cause, then apply the minimal fix to the relevant file(s) introduced by the preceding tasks. Do not modify files outside the `docker-push` crate unless a workspace-level issue is discovered.
+
+### Files potentially touched (fixes only, if needed)
+- `tools/docker-push/Cargo.toml` -- dependency version or feature adjustments
+- `tools/docker-push/src/docker_push.rs` -- import, type, validation logic, or handler fixes
+- `tools/docker-push/src/main.rs` -- module declaration or startup fixes
+- `tools/docker-push/tests/docker_push_server_test.rs` -- test fixture or assertion corrections
+- `Cargo.toml` -- workspace member path fix (unlikely)
+
+## Dependencies
+- Blocked by: All preceding issue-49 tasks ("Create `tools/docker-push/Cargo.toml`", "Add `tools/docker-push` to workspace `Cargo.toml`", "Implement `DockerPushTool` struct and handler", "Write `main.rs`", "Write integration tests", "Write README")
+- Blocking: None (this is the final task for issue-49)
+
+## Risks & Edge Cases
+- **Docker availability in tests**: The `accepts_valid_image_reference` unit test and the `tools_call_with_valid_image_returns_structured_json` integration test invoke the tool with image references that do not exist locally. These tests must not assert `success: true` because Docker may not be installed or the daemon may not be running. They should only verify that the response is well-formed JSON containing the four expected fields.
+- **Binary name vs package name**: The package is `docker-push` (hyphen) but the MCP tool name is `docker_push` (underscore). The integration test binary env macro is `CARGO_BIN_EXE_docker-push`. A mismatch in any of these would cause test failures.
+- **`schemars` dependency**: The `DockerPushRequest` struct uses `#[derive(schemars::JsonSchema)]` to generate the MCP tool input schema. If `schemars` is not available transitively through `mcp-tool-harness` or `rmcp`, `cargo build` will fail. Verify the dependency chain provides `schemars`.
+- **Shell metacharacter validation completeness**: The input validation must reject all specified metacharacters (`;`, `|`, `&`, `$`, backtick, `(`, `)`, `{`, `}`, `<`, `>`, `!`, `\n`). If a character is missed, the unit tests will catch it, but the security gap would exist for any untested characters.
+- **Regressions in other crates**: The workspace-wide `cargo check` may surface pre-existing issues in other crates unrelated to docker-push. If a failure is found, confirm it also exists on the `main` branch before attributing it to docker-push changes.
+- **Integration test child process lifecycle**: Each integration test spawns the `docker-push` binary and must call `client.cancel().await` at the end. If a test panics before reaching the cancel call, orphan processes could accumulate. This is a known pattern across all MCP tool integration tests in this workspace.
+- **Edition 2024 lint behavior**: The workspace uses `edition = "2024"`, which may trigger lints not present in older editions. Address each lint individually rather than blanket-suppressing with `#[allow]`.
+- **Digest extraction edge cases**: The digest extraction helper parses `docker push` output for `digest: sha256:<hex>`. If the Docker CLI output format changes across versions, this parsing could break. The unit test `digest_extraction_from_output` validates the expected format, but real-world output variations are not covered.
+
+## Verification
+- `cargo build -p docker-push` exits with code 0 and produces no error output
+- `cargo test -p docker-push` exits with code 0, all test cases (unit and integration) report `ok`, and the summary line shows 0 failures
+- `cargo clippy -p docker-push -- -D warnings` exits with code 0 and produces no warning output
+- `cargo check` (workspace-wide) exits with code 0 and produces no error output
+- The integration test `tools_list_returns_docker_push_tool` confirms the tool name is `docker_push` in the MCP `tools/list` response
+- The integration test `tools_call_with_invalid_image_returns_error` confirms structured error JSON with `success: false` and `push_log` containing "Invalid image reference"
+- The integration test `tools_call_with_valid_image_returns_structured_json` confirms the response contains all four fields: `success`, `image`, `digest`, `push_log`

--- a/.claude/specs/issue-49/write-integration-tests.md
+++ b/.claude/specs/issue-49/write-integration-tests.md
@@ -1,0 +1,120 @@
+# Spec: Write integration tests in `tests/docker_push_server_test.rs`
+
+> From: .claude/tasks/issue-49.md
+
+## Objective
+
+Create an integration test file that exercises the `docker-push` MCP server binary end-to-end over stdio transport, validating tool listing, input validation error paths, structured JSON responses, and empty-input rejection.
+
+## Current State
+
+- The file `tools/docker-push/tests/docker_push_server_test.rs` does not yet exist (the `tools/docker-push` crate itself does not exist yet).
+- The reference implementation at `tools/cargo-build/tests/cargo_build_server_test.rs` demonstrates the established pattern: spawn the binary via `mcp_test_utils::spawn_mcp_client!`, interact through `client.peer()`, and tear down with `client.cancel().await`.
+- The `mcp-test-utils` crate provides `spawn_mcp_client!` (macro) and `assert_single_tool` (async function) as the two primary test helpers.
+
+## Requirements
+
+### Test 1: `tools_list_returns_docker_push_tool`
+
+- Spawn the binary using `mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_docker-push"))`.
+- Call `mcp_test_utils::assert_single_tool(&client, "docker_push", "Push", &["image", "registry_url"])`.
+- This validates: exactly one tool is exposed, its name is `"docker_push"`, its description contains `"Push"` (case-sensitive), and its input schema has exactly two properties `image` and `registry_url`.
+- End with `client.cancel().await.expect("failed to cancel client")`.
+
+### Test 2: `tools_call_with_invalid_image_returns_error`
+
+- Spawn the binary.
+- Construct `CallToolRequestParams::new("docker_push")` with arguments `{"image": "foo;bar"}`.
+- Call `client.peer().call_tool(params).await`.
+- Extract the first content element as text, parse it as `serde_json::Value`.
+- Assert `json["success"] == false`.
+- Assert `json["push_log"]` (as string) contains `"Invalid image reference"`.
+- End with `client.cancel().await.expect("failed to cancel client")`.
+
+### Test 3: `tools_call_with_valid_image_returns_structured_json`
+
+- Spawn the binary.
+- Construct `CallToolRequestParams::new("docker_push")` with arguments `{"image": "nonexistent-image:latest"}`.
+- Call `client.peer().call_tool(params).await`.
+- Extract text, parse as JSON.
+- Assert that the JSON object contains all four expected fields: `success`, `image`, `digest`, `push_log`. Do NOT assert `success: true` because Docker daemon may not be available in CI, and the image does not exist regardless.
+- End with `client.cancel().await.expect("failed to cancel client")`.
+
+### Test 4: `tools_call_with_empty_image_returns_error`
+
+- Spawn the binary.
+- Construct `CallToolRequestParams::new("docker_push")` with arguments `{"image": ""}`.
+- Call `client.peer().call_tool(params).await`.
+- Extract text, parse as JSON.
+- Assert `json["success"] == false`.
+- End with `client.cancel().await.expect("failed to cancel client")`.
+
+### Cross-cutting
+
+- Every test function uses the attribute `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`.
+- Every test ends with `client.cancel().await.expect("failed to cancel client");`.
+- The file imports `rmcp::model::CallToolRequestParams` (needed by tests 2-4).
+- No other imports are required; `mcp_test_utils` macros and functions are called via their full path.
+
+## Implementation Details
+
+### File location
+
+`tools/docker-push/tests/docker_push_server_test.rs`
+
+### Binary reference
+
+Use `env!("CARGO_BIN_EXE_docker-push")` which Cargo sets automatically for integration tests in the same crate. This requires the `docker-push` binary target to exist in `tools/docker-push/Cargo.toml` and the `mcp-test-utils` dev-dependency to be declared.
+
+### Pattern to mirror
+
+Follow `tools/cargo-build/tests/cargo_build_server_test.rs` exactly in structure:
+1. Single `use` statement for `rmcp::model::CallToolRequestParams`.
+2. Each test is a standalone async function — no shared setup, no test fixtures.
+3. Client is spawned fresh in each test for isolation.
+4. Response text extraction follows the chain: `result.content.first().expect(...).as_text().expect(...)` then `serde_json::from_str(&text.text)`.
+5. JSON field assertions use indexing (`json["field"]`) and compare with `==`.
+6. String-contains assertions use `json["field"].as_str().unwrap_or("").contains(...)`.
+
+### Assertion strategy for Test 3
+
+Since Docker may not be installed or the daemon may not be running, and the image `nonexistent-image:latest` does not exist in any registry, the push will fail. The test only validates that the response is well-formed JSON with all four expected keys. Use `.get("field").is_some()` or equivalent to check key presence without asserting values.
+
+### No new dependencies
+
+The test file uses only `rmcp` (already a dev-dependency) and `mcp-test-utils` (already a dev-dependency). No additional crates needed.
+
+## Dependencies
+
+- **Blocked by**: "Write `main.rs`" — the binary must exist and compile before integration tests can spawn it.
+- **Blocked by**: "Implement `DockerPushTool` struct and handler" — the tool handler must be implemented so the MCP server responds to tool calls.
+- **Blocked by**: "Create `tools/docker-push/Cargo.toml`" — the crate manifest with dev-dependencies must exist.
+- **Blocking**: "Run verification suite" — `cargo test -p docker-push` must pass these integration tests.
+
+## Risks & Edge Cases
+
+1. **Docker daemon availability**: Test 3 intentionally avoids asserting `success: true` because Docker may not be installed or running. Tests 2 and 4 exercise validation paths that reject the input before invoking Docker, so they work regardless of Docker availability.
+
+2. **Binary name mapping**: The Cargo env macro `CARGO_BIN_EXE_docker-push` uses the hyphenated package name. If the package name in `Cargo.toml` changes, this macro breaks at compile time (which is the desired behavior — fail fast).
+
+3. **Tool name vs binary name**: The MCP tool name is `docker_push` (snake_case, from the `#[tool_router]` attribute on the handler method). The binary name is `docker-push` (hyphenated). Tests must use the correct name in each context.
+
+4. **Test isolation**: Each test spawns and tears down its own MCP client process. No shared state, no ordering dependency between tests.
+
+5. **Response format contract**: Tests 2-4 depend on the response JSON having keys `success`, `image`, `digest`, `push_log`. If the handler implementation changes field names, these tests should fail and surface the breakage.
+
+## Verification
+
+After implementing this file, run:
+
+```bash
+cargo test -p docker-push
+```
+
+All four integration tests must pass. Additionally:
+
+```bash
+cargo clippy -p docker-push
+```
+
+must report no warnings in the test file.

--- a/.claude/specs/issue-49/write-readme.md
+++ b/.claude/specs/issue-49/write-readme.md
@@ -1,0 +1,111 @@
+# Spec: Write README
+
+> From: .claude/tasks/issue-49.md
+
+## Objective
+
+Create a README for the `tools/docker-push/` crate that documents the tool's purpose, usage, input parameters, output format, environment variable fallback behavior, and runtime requirements. Model the structure and tone after `tools/echo-tool/README.md`.
+
+## Current State
+
+- The `tools/docker-push/` directory does not yet exist; it will be created by preceding tasks in Groups 1 and 2 (scaffold and core implementation).
+- The `DockerPushTool` struct and handler will be implemented in `tools/docker-push/src/docker_push.rs` as part of the "Implement `DockerPushTool` struct and handler" task, which this task is blocked by.
+- The echo-tool README (`tools/echo-tool/README.md`) serves as the reference template. It uses a flat heading structure with sections for description, build, run, MCP Inspector testing, and additional guidance.
+- The tool accepts two input parameters (`image`, `registry_url`) and returns structured JSON with four fields (`success`, `image`, `digest`, `push_log`).
+
+## Requirements
+
+- The README must contain the following sections:
+  1. **Tool description** -- describe `docker-push` as an MCP tool server that pushes a tagged Docker image to a container registry, returning structured JSON with push status, digest, and logs.
+  2. **Build** -- `cargo build -p docker-push`.
+  3. **Run** -- `cargo run -p docker-push` with a note about stdio transport.
+  4. **Test** -- `cargo test -p docker-push`.
+  5. **Input Parameters** -- document the `image` parameter (required, full image reference such as `ghcr.io/spore/spore-agent:0.1`) and the `registry_url` parameter (optional, overrides the `REGISTRY_URL` environment variable).
+  6. **Output Format** -- describe the JSON response containing `success` (boolean), `image` (the final image reference used), `digest` (sha256 digest extracted from docker push output, or empty string), and `push_log` (combined stdout/stderr from the docker push command).
+  7. **Environment Variables** -- document the `REGISTRY_URL` fallback: if `registry_url` is not provided as a parameter, the tool reads `REGISTRY_URL` from the environment. If available and the image does not already include the registry prefix, it is prepended automatically.
+  8. **Test with MCP Inspector** -- `npx @modelcontextprotocol/inspector cargo run -p docker-push`.
+  9. **Prerequisites** -- note that Docker must be installed and available in the environment for the push to succeed, and that authentication should be configured via `docker login` or credential helpers before invoking the tool.
+- The README must use standard markdown formatting consistent with the echo-tool README (heading hierarchy, fenced code blocks for commands).
+- The README must not contain speculative information about features not implemented in the tool.
+
+## Implementation Details
+
+### File to create
+
+- **`tools/docker-push/README.md`**
+
+### Document structure
+
+```
+# docker-push
+
+<One-paragraph description: MCP tool server that pushes tagged Docker images to a container registry>
+
+## Build
+
+<cargo build command>
+
+## Run
+
+<cargo run command with stdio transport note>
+
+## Test
+
+<cargo test command>
+
+## Input Parameters
+
+<Table or list describing `image` and `registry_url`>
+
+## Output Format
+
+<Description of JSON response with `success`, `image`, `digest`, `push_log` fields>
+
+## Environment Variables
+
+<REGISTRY_URL fallback behavior>
+
+## Test with MCP Inspector
+
+<npx inspector command with brief explanation>
+
+## Prerequisites
+
+<Docker availability requirement and authentication note>
+```
+
+### Key content details
+
+- The "Run" section should note that the tool uses stdio transport (stdin/stdout for MCP messages, stderr for logging), matching the echo-tool pattern.
+- The "Input Parameters" section should clearly indicate that `image` is required and `registry_url` is optional.
+- The "Output Format" section should show an example JSON response structure to make the format concrete.
+- The "Environment Variables" section should explain the resolution order: `registry_url` parameter takes precedence over `REGISTRY_URL` env var. If neither is provided and the image has no registry prefix, Docker's default registry is used.
+- The "Prerequisites" section should note two requirements: (1) Docker must be installed and the `docker` command must be available on PATH, and (2) authentication to the target registry must be pre-configured (the tool does not handle login).
+- No functions, types, or interfaces are added by this task.
+
+## Dependencies
+
+- Blocked by: "Implement `DockerPushTool` struct and handler" -- the README documents the implemented tool's input parameters, output format, and behavior. Writing it before the tool exists risks documenting behavior that changes during implementation.
+- Blocking: None
+
+## Risks & Edge Cases
+
+1. **API drift:** If the `DockerPushTool` implementation changes after the README is written (e.g., field names, parameter names, validation behavior), the README will become inaccurate. Mitigate by reviewing the final implementation before writing the README and keeping descriptions aligned with the actual struct definitions.
+2. **MCP Inspector availability:** The `npx @modelcontextprotocol/inspector` command depends on the inspector package being published to npm. This is an external dependency outside project control.
+3. **Docker-specific behavior:** The digest extraction format (`sha256:<hex>`) and push output format are Docker-specific. If the tool is later extended to support other container runtimes (e.g., Podman), the README will need updates.
+4. **Environment variable naming:** The `REGISTRY_URL` environment variable name is established in the task specification. If it changes during implementation, the README must be updated accordingly.
+
+## Verification
+
+1. The file `tools/docker-push/README.md` exists and is valid markdown.
+2. All required sections are present: description, build, run, test, input parameters, output format, environment variables, MCP Inspector, and prerequisites.
+3. The build command is exactly `cargo build -p docker-push`.
+4. The run command is exactly `cargo run -p docker-push`.
+5. The test command is exactly `cargo test -p docker-push`.
+6. The inspector command is exactly `npx @modelcontextprotocol/inspector cargo run -p docker-push`.
+7. Both input parameters (`image`, `registry_url`) are documented with their types and required/optional status.
+8. All four output JSON fields (`success`, `image`, `digest`, `push_log`) are documented.
+9. The `REGISTRY_URL` environment variable fallback behavior is documented.
+10. A note about Docker being required in the environment is present.
+11. A note about pre-configured authentication is present.
+12. `cargo test` and `cargo clippy` pass (no code changes, but confirm nothing is broken).

--- a/.claude/specs/issue-49/write-src-main-rs.md
+++ b/.claude/specs/issue-49/write-src-main-rs.md
@@ -1,0 +1,73 @@
+# Spec: Write `src/main.rs`
+
+> From: .claude/tasks/issue-49.md
+
+## Objective
+Create the entrypoint file for the `docker-push` MCP tool server. This file mirrors `tools/cargo-build/src/main.rs` exactly in structure, substituting only the module name, struct name, and tool name string for docker-push.
+
+## Current State
+- `tools/cargo-build/src/main.rs` exists and serves as the canonical template. It uses the `mcp_tool_harness::serve_stdio_tool` helper to avoid inlining tracing setup, keeping the file to 7 lines.
+- The `mcp-tool-harness` crate exposes `serve_stdio_tool<T: ServerHandler>(tool: T, tool_name: &str) -> Result<(), Box<dyn std::error::Error>>`, which handles tracing initialization (to stderr, ANSI disabled), startup logging, and MCP stdio transport serving.
+- `tools/docker-push/src/main.rs` does not yet exist.
+- `tools/docker-push/src/docker_push.rs` (the `DockerPushTool` struct and handler) is not yet implemented; this task is blocked by that work.
+
+## Requirements
+- Create `tools/docker-push/src/main.rs` following the exact same pattern as `tools/cargo-build/src/main.rs`.
+- The module declaration must be `mod docker_push;`.
+- The use statement must import `docker_push::DockerPushTool`.
+- The `#[tokio::main]` attribute must use `flavor = "current_thread"` (matching the cargo-build pattern).
+- The `main()` function must call `mcp_tool_harness::serve_stdio_tool(DockerPushTool::new(), "docker-push").await`.
+- The return type must be `Result<(), Box<dyn std::error::Error>>`.
+- No direct `tracing_subscriber` setup in this file -- that is handled by `serve_stdio_tool`.
+- No `clap` dependency. No CLI argument parsing.
+- No `use` of `rmcp` or `tracing_subscriber` -- those are encapsulated by the harness.
+- The file must be under 10 lines.
+
+## Implementation Details
+
+### File: `tools/docker-push/src/main.rs`
+
+```rust
+mod docker_push;
+use docker_push::DockerPushTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(DockerPushTool::new(), "docker-push").await
+}
+```
+
+This is 7 lines, well within the 10-line budget.
+
+### Changes from `tools/cargo-build/src/main.rs`
+
+| Line | cargo-build | docker-push |
+|------|-------------|-------------|
+| 1 | `mod cargo_build;` | `mod docker_push;` |
+| 2 | `use cargo_build::CargoBuildTool;` | `use docker_push::DockerPushTool;` |
+| 6 | `mcp_tool_harness::serve_stdio_tool(CargoBuildTool::new(), "cargo-build").await` | `mcp_tool_harness::serve_stdio_tool(DockerPushTool::new(), "docker-push").await` |
+
+No other lines change.
+
+## Dependencies
+- Blocked by: "Implement `DockerPushTool` struct and handler" -- the `docker_push` module must define `DockerPushTool` with a `new()` constructor and a `ServerHandler` implementation before this file can compile.
+- Blocking: "Write integration tests" -- the integration tests spawn the compiled binary, which requires `main.rs` to exist.
+
+## Risks & Edge Cases
+
+1. **`DockerPushTool` not yet available:** This file imports `docker_push::DockerPushTool`, which must be defined in `tools/docker-push/src/docker_push.rs`. If the blocked task has not landed, compilation will fail. Mitigation: ensure the handler task is complete before attempting to build.
+
+2. **Stdout contamination:** Any accidental `println!` or default tracing subscriber writing to stdout will corrupt the MCP stdio transport. Mitigation: `serve_stdio_tool` explicitly configures tracing with `.with_writer(std::io::stderr)`, and this file contains no direct print statements.
+
+3. **Module naming:** The module file must be named `docker_push.rs` (with underscore), matching the `mod docker_push;` declaration. A mismatch (e.g., `docker-push.rs` with a hyphen) will cause a compilation error.
+
+4. **Tokio runtime flavor:** The `current_thread` flavor is intentional -- MCP tool servers are single-threaded by design in this project. Using the default multi-thread flavor would work but would be inconsistent with the established pattern.
+
+## Verification
+
+1. **Compilation:** `cargo check -p docker-push` succeeds with no errors (requires the handler module and `Cargo.toml` to exist).
+2. **Lint:** `cargo clippy -p docker-push` produces no warnings.
+3. **Line count:** `wc -l tools/docker-push/src/main.rs` is under 10 lines.
+4. **Diff check:** The file differs from `tools/cargo-build/src/main.rs` in exactly three lines (module declaration, use statement, serve call arguments).
+5. **Server starts:** `cargo run -p docker-push` starts without errors and waits for MCP client input on stdin (verified by checking stderr log output shows "Starting docker-push MCP server").
+6. **Workspace tests:** `cargo test` across the full workspace still passes (no regressions).

--- a/.claude/tasks/issue-49.md
+++ b/.claude/tasks/issue-49.md
@@ -1,0 +1,125 @@
+# Task Breakdown: Implement docker_push MCP tool
+
+> Implement `docker_push` as a standalone Rust MCP server binary that pushes a tagged Docker image to a container registry, following the echo-tool and cargo-build reference patterns.
+
+## Group 1 — Scaffold the crate
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Create `tools/docker-push/Cargo.toml`** `[S]`
+      Copy and adapt `tools/cargo-build/Cargo.toml`. Change `name = "docker-push"`. Keep the same dependencies: `mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }`, `rmcp` with `transport-io`, `server`, `macros` features; `tokio` with `macros`, `rt`, `io-std`; `serde` with `derive`; `serde_json`. Add the same `[dev-dependencies]` block: `mcp-test-utils = { path = "../../crates/mcp-test-utils" }`, `tokio` with `macros`, `rt`, `rt-multi-thread`; `rmcp` with `client` and `transport-child-process`; `serde_json`.
+      Files: `tools/docker-push/Cargo.toml`
+      Blocking: "Implement `DockerPushTool` struct and handler", "Write `main.rs`", "Write integration tests"
+
+- [x] **Add `"tools/docker-push"` to workspace `Cargo.toml`** `[S]`
+      Add `"tools/docker-push"` to the `members` list in the root `Cargo.toml`, after the existing `"tools/cargo-build"` entry.
+      Files: `Cargo.toml`
+      Blocking: "Run verification suite"
+
+## Group 2 — Core implementation
+
+_Depends on: Group 1_
+
+- [x] **Implement `DockerPushTool` struct and handler in `src/docker_push.rs`** `[M]`
+      Create `tools/docker-push/src/docker_push.rs`. Follow the `cargo-build` pattern exactly since both tools invoke an external command and return structured JSON.
+
+      Define `DockerPushRequest` with `#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]` containing two fields:
+      - `image: String` with doc comment `/// Full image reference (e.g., ghcr.io/spore/spore-agent:0.1)`
+      - `registry_url: Option<String>` with doc comment `/// Override registry URL; falls back to REGISTRY_URL env var`
+
+      Define `DockerPushTool { tool_router: ToolRouter<Self> }` with `new()` calling `Self::tool_router()`.
+
+      **Input validation**: Before invoking `docker push`, validate the `image` string. It must not be empty, must not contain shell metacharacters (`;`, `|`, `&`, `$`, `` ` ``, `(`, `)`, `{`, `}`, `<`, `>`, `!`, `\n`), and must contain only valid image reference characters (alphanumeric, `.`, `-`, `_`, `/`, `:`). Use a simple character check (no regex dependency). If validation fails, return `{"success": false, "image": "<input>", "digest": "", "push_log": "Invalid image reference: <reason>"}`.
+
+      **Registry URL resolution**: If `registry_url` is `Some`, use it. Otherwise, read `REGISTRY_URL` from the environment via `std::env::var("REGISTRY_URL")`. If the registry URL is available and the `image` string does not already start with it, prepend the registry URL with a `/` separator. If neither is provided and the image has no registry prefix, proceed with the image as-is (Docker will use the default registry).
+
+      **Docker push invocation**: Use `std::process::Command::new("docker")` with args `["push", &final_image_ref]`. Capture output with `.output()`.
+
+      **Digest extraction**: After a successful push, parse stdout+stderr for the digest. `docker push` outputs a line like `<tag>: digest: sha256:<hex> size: <n>`. Search the combined output (stdout then stderr) line by line for a substring matching `digest: sha256:`. Extract the full `sha256:<hex>` value. If no digest is found in the output, set digest to an empty string.
+
+      **Return format**: Return `serde_json::json!` containing:
+      - `"success"`: `output.status.success()`
+      - `"image"`: the final image reference used
+      - `"digest"`: extracted digest string or `""`
+      - `"push_log"`: combined stdout + stderr (both via `String::from_utf8_lossy`)
+
+      On `Command` spawn failure, return `{"success": false, "image": "<input>", "digest": "", "push_log": "Failed to execute docker: <error>"}`.
+
+      Implement `ServerHandler` with `#[tool_handler]` returning tools-enabled capabilities.
+
+      Add `#[cfg(test)] mod tests` with unit tests:
+      (1) `rejects_empty_image` — call with `""`, assert `success: false` and push_log contains "Invalid image reference"
+      (2) `rejects_image_with_shell_metachar` — call with `"foo;bar"`, assert `success: false`
+      (3) `rejects_image_with_pipe` — call with `"foo|bar"`, assert `success: false`
+      (4) `accepts_valid_image_reference` — call with `"ghcr.io/spore/spore-agent:0.1"`, assert the result is valid JSON containing all four expected fields (`success`, `image`, `digest`, `push_log`). Note: this test will fail if Docker is not installed, but it validates the code path up to Command invocation.
+      (5) `registry_url_is_prepended` — test the registry URL prepending logic. Create a helper function that resolves the final image reference, call it with `image = "spore-agent:0.1"` and `registry_url = Some("ghcr.io/spore")`, assert the result is `"ghcr.io/spore/spore-agent:0.1"`. Also test that if the image already starts with the registry URL, it is not doubled.
+      (6) `digest_extraction_from_output` — test the digest parsing logic in isolation. Create a helper function that extracts digest from a string, call it with sample docker push output containing `"latest: digest: sha256:abc123def456 size: 1234"`, assert it returns `"sha256:abc123def456"`. Also test with output lacking a digest line, assert empty string.
+
+      Files: `tools/docker-push/src/docker_push.rs`
+      Blocked by: "Create `tools/docker-push/Cargo.toml`"
+      Blocking: "Write `main.rs`", "Write integration tests"
+
+- [x] **Write `src/main.rs`** `[S]`
+      Create `tools/docker-push/src/main.rs`. Mirror `tools/cargo-build/src/main.rs` exactly: declare `mod docker_push;`, use `DockerPushTool`, call `mcp_tool_harness::serve_stdio_tool(DockerPushTool::new(), "docker-push").await`. The file should be under 10 lines.
+      Files: `tools/docker-push/src/main.rs`
+      Blocked by: "Implement `DockerPushTool` struct and handler"
+      Blocking: "Write integration tests"
+
+## Group 3 — Integration tests and documentation
+
+_Depends on: Group 2_
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Write integration tests in `tests/docker_push_server_test.rs`** `[M]`
+      Create `tools/docker-push/tests/docker_push_server_test.rs`. Mirror the pattern from `tools/cargo-build/tests/cargo_build_server_test.rs`. Use `env!("CARGO_BIN_EXE_docker-push")` to spawn the binary via `mcp_test_utils::spawn_mcp_client!`. Write these tests (each `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`):
+
+      (1) `tools_list_returns_docker_push_tool` — use `mcp_test_utils::assert_single_tool` to verify the tool name is `"docker_push"`, description contains `"Push"` (case-sensitive from the tool description), and parameters include `["image", "registry_url"]`.
+
+      (2) `tools_call_with_invalid_image_returns_error` — call the tool with `{"image": "foo;bar"}`, parse the response text as JSON, assert `success` is `false` and `push_log` contains "Invalid image reference".
+
+      (3) `tools_call_with_valid_image_returns_structured_json` — call the tool with `{"image": "nonexistent-image:latest"}`. Since Docker daemon may or may not be available in CI, only assert that the response is valid JSON containing all four expected fields (`success`, `image`, `digest`, `push_log`). Do not assert `success: true` since the image does not exist.
+
+      (4) `tools_call_with_empty_image_returns_error` — call with `{"image": ""}`, assert `success: false`.
+
+      Each test must end with `client.cancel().await.expect("failed to cancel client");`.
+
+      Files: `tools/docker-push/tests/docker_push_server_test.rs`
+      Blocked by: "Write `main.rs`"
+      Blocking: "Run verification suite"
+
+- [x] **Write README** `[S]`
+      Create `tools/docker-push/README.md`. Model after `tools/echo-tool/README.md`. Include: build/run/test commands (`cargo build -p docker-push`, `cargo run -p docker-push`, `cargo test -p docker-push`), description of the `image` and `registry_url` input parameters, description of the JSON output format (`success`, `image`, `digest`, `push_log`), note about `REGISTRY_URL` environment variable fallback, MCP Inspector test command, and a note that Docker must be available in the environment for the push to succeed.
+      Files: `tools/docker-push/README.md`
+      Blocked by: "Implement `DockerPushTool` struct and handler"
+      Blocking: None
+
+## Group 4 — Verification
+
+_Depends on: Groups 1–3_
+
+- [x] **Run verification suite** `[S]`
+      Run `cargo build -p docker-push`, then `cargo test -p docker-push`, then `cargo clippy -p docker-push`, then `cargo check` (workspace-wide) to confirm no regressions. All acceptance criteria from the issue must pass: build succeeds, tests pass, returns structured JSON with `success`/`image`/`digest`/`push_log`, returns structured errors on auth/network/validation failure, tool is named `docker_push` in MCP `tools/list`.
+      Files: (none — command-line verification only)
+      Blocked by: All previous tasks
+      Blocking: None
+
+---
+
+## Implementation Notes
+
+1. **No new dependencies**: All dependencies (`rmcp`, `tokio`, `serde`, `serde_json`, `mcp-tool-harness`) are already used by `tools/cargo-build/Cargo.toml`. No additional crates are needed.
+
+2. **Security — input validation**: The `image` input is validated to reject shell metacharacters before being passed to `std::process::Command`. The command is invoked directly via `Command::new("docker")` (not via a shell), providing additional safety. This mirrors the `validate_package_name` pattern in `tools/cargo-build/src/cargo_build.rs`.
+
+3. **Security — no secrets in output**: The tool does not log or return authentication credentials. Docker auth is assumed to be pre-configured via `docker login` or credential helpers.
+
+4. **Registry URL resolution**: The `registry_url` optional parameter overrides the `REGISTRY_URL` environment variable. The tool prepends the registry URL to the image only if the image does not already include it.
+
+5. **Digest extraction**: `docker push` outputs digest information in stderr. The format is `<tag>: digest: sha256:<hex> size: <n>`. The tool searches both stdout and stderr for this pattern. This logic is extracted into a testable helper function.
+
+6. **Binary vs tool name**: Package name `docker-push` produces binary `docker-push` and env macro `CARGO_BIN_EXE_docker-push`. The MCP tool name is `docker_push` (snake_case method name from `#[tool_router]`).
+
+7. **Docker availability in tests**: Integration tests that invoke the tool with a real image reference should not assert `success: true` because Docker may not be available in all CI environments. Unit tests for validation, registry URL resolution, and digest extraction do not require Docker.
+
+8. **Reference pattern**: `tools/cargo-build/src/cargo_build.rs` is the primary reference since it also invokes an external command via `std::process::Command` and returns structured JSON.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker-push"
+version = "0.1.0"
+dependencies = [
+ "mcp-test-utils",
+ "mcp-tool-harness",
+ "rmcp 1.2.0",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "tools/write-file",
     "tools/validate-skill",
     "tools/cargo-build",
+    "tools/docker-push",
 ]
 
 [profile.release]

--- a/tools/docker-push/Cargo.toml
+++ b/tools/docker-push/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "docker-push"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }
+rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
+tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+rmcp = { version = "1", features = ["client", "transport-child-process"] }
+serde_json = "1"

--- a/tools/docker-push/README.md
+++ b/tools/docker-push/README.md
@@ -1,0 +1,74 @@
+# docker-push
+
+An MCP tool server that pushes a tagged Docker image to a container registry, returning structured JSON with push status, digest, and logs.
+
+## Build
+
+```sh
+cargo build -p docker-push
+```
+
+## Run
+
+```sh
+cargo run -p docker-push
+```
+
+The server uses stdio transport: it reads MCP messages from stdin and writes responses to stdout. All logging output is directed to stderr so it does not interfere with the MCP protocol stream.
+
+## Test
+
+```sh
+cargo test -p docker-push
+```
+
+## Input Parameters
+
+| Parameter      | Type   | Required | Description                                                         |
+|----------------|--------|----------|---------------------------------------------------------------------|
+| `image`        | string | yes      | Full image reference (e.g., `ghcr.io/spore/spore-agent:0.1`)       |
+| `registry_url` | string | no       | Override registry URL; falls back to the `REGISTRY_URL` env var     |
+
+## Output Format
+
+JSON object with the following fields:
+
+| Field      | Type   | Description                                      |
+|------------|--------|--------------------------------------------------|
+| `success`  | bool   | Whether the push succeeded                       |
+| `image`    | string | The resolved image reference that was pushed      |
+| `digest`   | string | sha256 digest extracted from docker push output, or empty string |
+| `push_log` | string | Combined stdout/stderr from `docker push`        |
+
+Example response:
+
+```json
+{
+  "success": true,
+  "image": "ghcr.io/spore/spore-agent:0.1",
+  "digest": "sha256:abc123def456...",
+  "push_log": "The push refers to repository..."
+}
+```
+
+## Environment Variables
+
+| Variable       | Description                                                                                           |
+|----------------|-------------------------------------------------------------------------------------------------------|
+| `REGISTRY_URL` | Fallback registry URL used when `registry_url` is not provided as a parameter                         |
+
+Resolution order: the `registry_url` parameter takes precedence over the `REGISTRY_URL` environment variable. If neither is provided and the image has no registry prefix, Docker's default registry is used.
+
+## Test with MCP Inspector
+
+```sh
+npx @modelcontextprotocol/inspector cargo run -p docker-push
+```
+
+This launches the MCP Inspector, which connects to the docker-push server and provides an interactive UI for sending requests and viewing responses. Use it to verify that the tool advertises its capabilities and handles calls correctly.
+
+## Prerequisites
+
+- Docker must be installed and the `docker` command must be available on PATH.
+- Authentication to the target registry must be pre-configured via `docker login` or credential helpers before invoking the tool. The tool does not handle login.
+- Input validation rejects shell metacharacters; only alphanumeric characters, `.`, `-`, `_`, `/`, and `:` are allowed in image references and registry URLs.

--- a/tools/docker-push/src/docker_push.rs
+++ b/tools/docker-push/src/docker_push.rs
@@ -64,7 +64,9 @@ fn resolve_image_ref(image: &str, registry_url: Option<&str>) -> Result<String, 
 
     validate_registry_url(&url)?;
     let url = url.trim_end_matches('/');
-    if image.starts_with(url) {
+    if image.starts_with(url)
+        && (image.len() == url.len() || image.as_bytes().get(url.len()) == Some(&b'/'))
+    {
         Ok(image.to_string())
     } else {
         Ok(format!("{url}/{image}"))
@@ -74,9 +76,12 @@ fn resolve_image_ref(image: &str, registry_url: Option<&str>) -> Result<String, 
 fn extract_digest(output: &str) -> String {
     for line in output.lines() {
         if let Some(pos) = line.find("digest: sha256:") {
-            let token_start = pos + "digest: ".len();
-            let token = &line[token_start..];
-            return token.split_whitespace().next().unwrap_or("").to_string();
+            let digest_part = &line[pos + "digest: ".len()..];
+            if let Some(digest) = digest_part.split_whitespace().next() {
+                if digest.starts_with("sha256:") && digest.len() > "sha256:".len() {
+                    return digest.to_string();
+                }
+            }
         }
     }
     String::new()
@@ -210,6 +215,12 @@ mod tests {
         let result =
             resolve_image_ref("ghcr.io/spore/spore-agent:0.1", Some("ghcr.io/spore")).unwrap();
         assert_eq!(result, "ghcr.io/spore/spore-agent:0.1");
+    }
+
+    #[test]
+    fn registry_url_partial_prefix_does_not_match() {
+        let result = resolve_image_ref("myreg-app/image:latest", Some("myreg")).unwrap();
+        assert_eq!(result, "myreg/myreg-app/image:latest");
     }
 
     #[test]

--- a/tools/docker-push/src/docker_push.rs
+++ b/tools/docker-push/src/docker_push.rs
@@ -1,0 +1,235 @@
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct DockerPushRequest {
+    /// Full image reference (e.g., ghcr.io/spore/spore-agent:0.1)
+    pub image: String,
+    /// Override registry URL; falls back to REGISTRY_URL env var
+    pub registry_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DockerPushTool {
+    tool_router: ToolRouter<Self>,
+}
+
+impl DockerPushTool {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+fn is_valid_ref_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_' | '/' | ':')
+}
+
+fn validate_image_ref(image: &str) -> Result<(), String> {
+    if image.is_empty() {
+        return Err("image must not be empty".to_string());
+    }
+    for ch in image.chars() {
+        if !is_valid_ref_char(ch) {
+            return Err(format!("invalid character '{ch}' in image reference"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_registry_url(url: &str) -> Result<(), String> {
+    if url.is_empty() {
+        return Err("registry URL must not be empty".to_string());
+    }
+    for ch in url.chars() {
+        if !is_valid_ref_char(ch) {
+            return Err(format!("invalid character '{ch}' in registry URL"));
+        }
+    }
+    Ok(())
+}
+
+fn resolve_image_ref(image: &str, registry_url: Option<&str>) -> Result<String, String> {
+    let effective_url = registry_url
+        .map(|s| s.to_string())
+        .or_else(|| std::env::var("REGISTRY_URL").ok());
+
+    let Some(url) = effective_url else {
+        return Ok(image.to_string());
+    };
+
+    validate_registry_url(&url)?;
+    let url = url.trim_end_matches('/');
+    if image.starts_with(url) {
+        Ok(image.to_string())
+    } else {
+        Ok(format!("{url}/{image}"))
+    }
+}
+
+fn extract_digest(output: &str) -> String {
+    for line in output.lines() {
+        if let Some(pos) = line.find("digest: sha256:") {
+            let token_start = pos + "digest: ".len();
+            let token = &line[token_start..];
+            return token.split_whitespace().next().unwrap_or("").to_string();
+        }
+    }
+    String::new()
+}
+
+fn build_error_json(image: &str, reason: &str) -> String {
+    serde_json::json!({
+        "success": false,
+        "image": image,
+        "digest": "",
+        "push_log": reason,
+    })
+    .to_string()
+}
+
+#[tool_router]
+impl DockerPushTool {
+    #[tool(description = "Push a tagged Docker image to a container registry")]
+    fn docker_push(&self, Parameters(request): Parameters<DockerPushRequest>) -> String {
+        if let Err(reason) = validate_image_ref(&request.image) {
+            return build_error_json(
+                &request.image,
+                &format!("Invalid image reference: {reason}"),
+            );
+        }
+
+        let final_ref = match resolve_image_ref(&request.image, request.registry_url.as_deref()) {
+            Ok(r) => r,
+            Err(reason) => {
+                return build_error_json(
+                    &request.image,
+                    &format!("Invalid registry URL: {reason}"),
+                );
+            }
+        };
+
+        match std::process::Command::new("docker")
+            .args(["push", &final_ref])
+            .output()
+        {
+            Ok(output) => {
+                let combined = format!(
+                    "{}{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr),
+                );
+                let digest = extract_digest(&combined);
+                serde_json::json!({
+                    "success": output.status.success(),
+                    "image": final_ref,
+                    "digest": digest,
+                    "push_log": combined,
+                })
+                .to_string()
+            }
+            Err(e) => build_error_json(&final_ref, &format!("Failed to execute docker: {e}")),
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for DockerPushTool {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call_docker_push(tool: &DockerPushTool, image: &str, registry_url: Option<&str>) -> String {
+        tool.docker_push(Parameters(DockerPushRequest {
+            image: image.to_string(),
+            registry_url: registry_url.map(|s| s.to_string()),
+        }))
+    }
+
+    #[test]
+    fn rejects_empty_image() {
+        let tool = DockerPushTool::new();
+        let result = call_docker_push(&tool, "", None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["push_log"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid image reference"));
+    }
+
+    #[test]
+    fn rejects_image_with_shell_metachar() {
+        let tool = DockerPushTool::new();
+        let result = call_docker_push(&tool, "foo;bar", None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["push_log"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid image reference"));
+    }
+
+    #[test]
+    fn rejects_image_with_pipe() {
+        let tool = DockerPushTool::new();
+        let result = call_docker_push(&tool, "foo|bar", None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["push_log"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid image reference"));
+    }
+
+    #[test]
+    fn accepts_valid_image_reference() {
+        let tool = DockerPushTool::new();
+        let result = call_docker_push(&tool, "ghcr.io/spore/spore-agent:0.1", None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(json.get("success").is_some());
+        assert!(json.get("image").is_some());
+        assert!(json.get("digest").is_some());
+        assert!(json.get("push_log").is_some());
+    }
+
+    #[test]
+    fn registry_url_is_prepended() {
+        let result = resolve_image_ref("spore-agent:0.1", Some("ghcr.io/spore")).unwrap();
+        assert_eq!(result, "ghcr.io/spore/spore-agent:0.1");
+
+        let result =
+            resolve_image_ref("ghcr.io/spore/spore-agent:0.1", Some("ghcr.io/spore")).unwrap();
+        assert_eq!(result, "ghcr.io/spore/spore-agent:0.1");
+    }
+
+    #[test]
+    fn rejects_invalid_registry_url() {
+        let tool = DockerPushTool::new();
+        let result = call_docker_push(&tool, "my-image:latest", Some("evil;registry"));
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["push_log"]
+            .as_str()
+            .unwrap()
+            .contains("Invalid registry URL"));
+    }
+
+    #[test]
+    fn digest_extraction_from_output() {
+        let output = "latest: digest: sha256:abc123def456 size: 1234";
+        assert_eq!(extract_digest(output), "sha256:abc123def456");
+
+        let output = "Pushing image...\nDone.";
+        assert_eq!(extract_digest(output), "");
+    }
+}

--- a/tools/docker-push/src/main.rs
+++ b/tools/docker-push/src/main.rs
@@ -1,0 +1,7 @@
+mod docker_push;
+use docker_push::DockerPushTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(DockerPushTool::new(), "docker-push").await
+}

--- a/tools/docker-push/tests/docker_push_server_test.rs
+++ b/tools/docker-push/tests/docker_push_server_test.rs
@@ -1,0 +1,109 @@
+use rmcp::model::CallToolRequestParams;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_returns_docker_push_tool() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_docker-push")).await;
+    mcp_test_utils::assert_single_tool(
+        &client,
+        "docker_push",
+        "Push",
+        &["image", "registry_url"],
+    )
+    .await;
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_with_invalid_image_returns_error() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_docker-push")).await;
+
+    let params = CallToolRequestParams::new("docker_push").with_arguments(
+        serde_json::json!({ "image": "foo;bar" })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
+    assert_eq!(json["success"], false, "should fail for invalid image");
+    assert!(
+        json["push_log"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Invalid image reference"),
+        "push_log should contain 'Invalid image reference', got: {}",
+        json["push_log"]
+    );
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_with_valid_image_returns_structured_json() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_docker-push")).await;
+
+    let params = CallToolRequestParams::new("docker_push").with_arguments(
+        serde_json::json!({ "image": "nonexistent-image:latest" })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
+    assert!(json.get("success").is_some(), "response should have 'success' field");
+    assert!(json.get("image").is_some(), "response should have 'image' field");
+    assert!(json.get("digest").is_some(), "response should have 'digest' field");
+    assert!(json.get("push_log").is_some(), "response should have 'push_log' field");
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_with_empty_image_returns_error() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_docker-push")).await;
+
+    let params = CallToolRequestParams::new("docker_push").with_arguments(
+        serde_json::json!({ "image": "" })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
+    assert_eq!(json["success"], false, "should fail for empty image");
+
+    client.cancel().await.expect("failed to cancel client");
+}


### PR DESCRIPTION
## Summary

Adds a standalone `docker-push` MCP server binary that pushes tagged Docker images to a container registry over stdio transport. Accepts an `image` parameter and optional `registry_url` override (falls back to `REGISTRY_URL` env var). Returns structured JSON with `success`, `image`, `digest`, and `push_log` fields. Includes input validation to reject shell metacharacters and digest extraction from docker push output.

## Changes

### Group 1 — Scaffold the crate
- ✅ Create `tools/docker-push/Cargo.toml`
- ✅ Add `"tools/docker-push"` to workspace `Cargo.toml`

### Group 2 — Core implementation
- ✅ Implement `DockerPushTool` struct and handler in `src/docker_push.rs`
- ✅ Write `src/main.rs`

### Group 3 — Integration tests and documentation
- ✅ Write integration tests in `tests/docker_push_server_test.rs`
- ✅ Write README

### Group 4 — Verification
- ✅ Run verification suite

## Test plan

- `cargo build -p docker-push` — binary builds cleanly
- `cargo test -p docker-push` — all 11 tests pass (7 unit + 4 integration)
- `cargo clippy -p docker-push` — no warnings
- `cargo check` — no workspace-wide regressions

## Issue

Closes #49