### PR TITLE
feat(tools): implement register_agent MCP tool (#50)

### DIFF
--- a/.claude/specs/issue-20/add-integration-test-for-tool-coder-skill.md
+++ b/.claude/specs/issue-20/add-integration-test-for-tool-coder-skill.md
@@ -1,0 +1,116 @@
+# Spec: Add integration test for tool-coder skill
+
+> From: .claude/tasks/issue-20.md
+
+## Objective
+
+Add an integration test (`load_tool_coder_skill`) to the existing example skills test suite that verifies the `tool-coder.md` skill file can be loaded by `SkillLoader` and that all frontmatter fields and preamble content match expected values. This ensures the tool-coder skill is well-formed and consistent with the project's skill contract before it is used at runtime.
+
+## Current State
+
+The integration test file `crates/skill-loader/tests/example_skills_test.rs` already contains four tests following an identical pattern:
+
+- `load_cogs_analyst_skill`
+- `load_echo_skill`
+- `load_skill_writer_skill`
+- `load_orchestrator_skill`
+
+Each test:
+1. Calls `skills_dir()` to resolve the `skills/` directory at the repo root.
+2. Calls `make_loader(&dir)` to create a `SkillLoader` with an `AllToolsExist` checker (bypasses real tool validation).
+3. Calls `loader.load("<skill-name>").await.unwrap()` to parse the markdown file and produce a `SkillManifest`.
+4. Asserts exact values for all frontmatter fields: `name`, `version`, `description`, `model.provider`, `model.name`, `model.temperature`, `tools`, `constraints.max_turns`, `constraints.confidence_threshold`, `constraints.escalate_to`, `constraints.allowed_actions`, `output.format`, `output.schema`.
+5. Asserts the preamble is non-empty and contains domain-relevant keywords.
+
+The `SkillManifest` struct (from `crates/agent-sdk/src/skill_manifest.rs`) has these fields: `name: String`, `version: String`, `description: String`, `model: ModelConfig`, `preamble: String`, `tools: Vec<String>`, `constraints: Constraints`, `output: OutputSchema`.
+
+The `skills/` directory currently has: `cogs-analyst.md`, `echo.md`, `orchestrator.md`, `skill-writer.md`. The `tool-coder.md` file does not yet exist (blocked by upstream tasks).
+
+## Requirements
+
+- Add a single `#[tokio::test]` async function named `load_tool_coder_skill` to `crates/skill-loader/tests/example_skills_test.rs`.
+- Reuse the existing `skills_dir()` and `make_loader()` helpers (no new helpers needed).
+- Call `loader.load("tool-coder").await.unwrap()` to load `skills/tool-coder.md`.
+- Assert exact equality for all frontmatter fields. The exact values depend on whatever the upstream task ("Create `skills/tool-coder.md` with YAML frontmatter") defines, but the test must cover every field:
+  - `manifest.name` == `"tool-coder"`
+  - `manifest.version` (exact value from frontmatter)
+  - `manifest.description` (exact value from frontmatter)
+  - `manifest.model.provider` (expected: `"anthropic"`)
+  - `manifest.model.name` (exact model name from frontmatter)
+  - `manifest.model.temperature` (use `(value - expected).abs() < f64::EPSILON` pattern)
+  - `manifest.tools` (exact vec of tool name strings from frontmatter)
+  - `manifest.constraints.max_turns` (exact u32 from frontmatter)
+  - `manifest.constraints.confidence_threshold` (use epsilon comparison)
+  - `manifest.constraints.escalate_to` (exact `Option<String>` from frontmatter)
+  - `manifest.constraints.allowed_actions` (exact vec from frontmatter)
+  - `manifest.output.format` (exact string from frontmatter)
+  - `manifest.output.schema` (assert `.len()` and each key-value pair)
+- Assert `!manifest.preamble.is_empty()`.
+- Assert keyword presence in the preamble using `contains` checks with `||` alternatives and descriptive panic messages, following the `load_skill_writer_skill` pattern:
+  - Contains `"MCP"` or `"mcp"` (tool-coder works with MCP tool servers)
+  - Contains `"Rust"` or `"rust"` (the tool-coder writes Rust code)
+  - Contains `"cargo"` or `"build"` (build/compile verification)
+  - Contains `"tool-registry"` or `"missing tool"` (references tool registry concerns)
+
+## Implementation Details
+
+- **File to modify:** `crates/skill-loader/tests/example_skills_test.rs`
+- **No new files to create.** The test is appended to the existing file.
+- **No new dependencies required.**
+
+### Test function signature
+
+```rust
+#[tokio::test]
+async fn load_tool_coder_skill() {
+    let dir = skills_dir();
+    let loader = make_loader(&dir);
+    let manifest = loader.load("tool-coder").await.unwrap();
+
+    // Exact frontmatter assertions (values TBD from upstream skill file)
+    assert_eq!(manifest.name, "tool-coder");
+    // ... all other field assertions ...
+
+    // Preamble assertions
+    assert!(!manifest.preamble.is_empty());
+    assert!(
+        manifest.preamble.contains("MCP") || manifest.preamble.contains("mcp"),
+        "preamble should reference MCP tool protocol"
+    );
+    assert!(
+        manifest.preamble.contains("Rust") || manifest.preamble.contains("rust"),
+        "preamble should reference Rust as the implementation language"
+    );
+    assert!(
+        manifest.preamble.contains("cargo") || manifest.preamble.contains("build"),
+        "preamble should reference cargo build or build verification"
+    );
+    assert!(
+        manifest.preamble.contains("tool-registry") || manifest.preamble.contains("missing tool"),
+        "preamble should reference tool-registry or missing tool handling"
+    );
+}
+```
+
+### Notes for the implementer
+
+- The exact frontmatter field values (`version`, `description`, `model.name`, `model.temperature`, `tools`, `constraints.*`, `output.*`) must be filled in after the upstream task creates `skills/tool-coder.md`. The test must match the file exactly.
+- Follow the epsilon comparison pattern for float fields: `assert!((manifest.model.temperature - EXPECTED).abs() < f64::EPSILON);`
+- Follow the `output.schema` pattern from other tests: assert `.len()` first, then assert each key-value pair with `.get("key").unwrap()`.
+
+## Dependencies
+
+- **Blocked by:** "Create `skills/tool-coder.md` with YAML frontmatter", "Write tool-coder preamble body" -- the exact assertion values cannot be finalized until the skill file exists.
+- **Blocking:** "Run verification suite" -- the test must pass before verification is complete.
+
+## Risks & Edge Cases
+
+- **Frontmatter value mismatch:** If the skill file changes after the test is written, the test will fail. This is intentional -- the test acts as a contract test. The implementer should write the test and skill file in coordination.
+- **Preamble keyword drift:** The `contains` checks use `||` alternatives to be somewhat resilient to wording changes, but if the preamble is rewritten significantly, these assertions may need updating.
+- **Float comparison:** Using `f64::EPSILON` works for values that are exact in IEEE 754 (like 0.0, 0.1, 0.2, 0.5, 1.0 when parsed from YAML). If the temperature uses a value like 0.3 that has no exact representation, consider using a small tolerance like `1e-10` instead.
+
+## Verification
+
+- `cargo test --test example_skills_test load_tool_coder_skill` passes (requires `skills/tool-coder.md` to exist).
+- `cargo test --test example_skills_test` passes (all existing tests still pass, confirming no regressions).
+- `cargo clippy` reports no new warnings in the test file.

--- a/.claude/specs/issue-20/create-tool-coder-md-with-yaml-frontmatter.md
+++ b/.claude/specs/issue-20/create-tool-coder-md-with-yaml-frontmatter.md
@@ -1,0 +1,125 @@
+# Spec: Create `skills/tool-coder.md` with YAML frontmatter
+
+> From: .claude/tasks/issue-20.md
+
+## Objective
+
+Create the skill file `skills/tool-coder.md` with valid YAML frontmatter that conforms to the `SkillManifest` schema. This establishes the tool-coder agent's identity, model configuration, tool access, execution constraints, and output schema. The tool-coder is one of the two seed agents (alongside skill-writer) that form the foundation of Spore's self-bootstrapping capability. This task covers only the frontmatter; the preamble body is handled by the subsequent blocking task "Write tool-coder preamble body."
+
+## Current State
+
+Two skill files already exist and serve as reference implementations:
+
+- `skills/skill-writer.md` -- The skill-writer seed agent. Uses `write_file` and `validate_skill` tools, temperature 0.2, max_turns 10, confidence_threshold 0.9, no `escalate_to` field, output schema with `skill_yaml` and `validation_result` keys.
+- `skills/orchestrator.md` -- The orchestrator agent. Uses `list_agents` and `route_to_agent` tools, temperature 0.1, max_turns 3, confidence_threshold 0.9, no `escalate_to` field, output schema with `target_agent` and `reasoning` keys.
+
+The `SkillManifest` struct is defined in `crates/agent-sdk/src/skill_manifest.rs` with 8 fields: `name`, `version`, `description`, `model` (`ModelConfig`), `preamble`, `tools` (`Vec<String>`), `constraints` (`Constraints`), and `output` (`OutputSchema`).
+
+The `Constraints` struct (`crates/agent-sdk/src/constraints.rs`) has `escalate_to` as `Option<String>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`, meaning the field can be included or omitted in YAML.
+
+Validation rules in `crates/skill-loader/src/validation.rs` enforce: non-empty required strings, non-empty preamble, confidence_threshold in [0.0, 1.0], max_turns > 0, tools must exist in the tool registry, output format must be one of `json`/`structured_json`/`text`, and escalate_to must not be empty if provided.
+
+## Requirements
+
+1. **Create file `skills/tool-coder.md`** with YAML frontmatter delimited by `---` lines and a minimal placeholder preamble body (to be replaced by the blocking task).
+
+2. **Frontmatter field values must be exactly:**
+   - `name: tool-coder`
+   - `version: "0.1"` (quoted to prevent YAML float coercion)
+   - `description:` A concise one-line summary of the tool-coder agent's purpose (e.g., "Generates, compiles, and validates Rust MCP tool implementations from specifications")
+   - `model.provider: anthropic`
+   - `model.name: claude-sonnet-4-6`
+   - `model.temperature: 0.1`
+   - `tools:` list containing `read_file`, `write_file`, `cargo_build`
+   - `constraints.max_turns: 15`
+   - `constraints.confidence_threshold: 0.85`
+   - `constraints.escalate_to: human_reviewer`
+   - `constraints.allowed_actions:` list containing `read`, `write`, `execute`
+   - `output.format: structured_json`
+   - `output.schema:` map with keys `tools_generated` (string), `compilation_result` (string), `implementation_paths` (string)
+
+3. **The preamble (markdown body after closing `---`)** must be non-empty to pass validation. Use a single-line placeholder such as `Placeholder: preamble body to be written in the next task.` This will be fully replaced by the blocking task "Write tool-coder preamble body."
+
+4. **YAML structure must match the existing skill files** in indentation style (2-space indent), field ordering, and list formatting (hyphenated items).
+
+5. **All validation rules must pass** when the file is loaded by `SkillLoader`, with the caveat that tool existence checks depend on the tool registry containing `read_file`, `write_file`, and `cargo_build` (these tools may not exist in the registry yet; validation will pass with `AllToolsExist` stub).
+
+## Implementation Details
+
+### File to create: `skills/tool-coder.md`
+
+The complete file content should be:
+
+```yaml
+---
+name: tool-coder
+version: "0.1"
+description: Generates, compiles, and validates Rust MCP tool implementations from specifications
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+  temperature: 0.1
+tools:
+  - read_file
+  - write_file
+  - cargo_build
+constraints:
+  max_turns: 15
+  confidence_threshold: 0.85
+  escalate_to: human_reviewer
+  allowed_actions:
+    - read
+    - write
+    - execute
+output:
+  format: structured_json
+  schema:
+    tools_generated: string
+    compilation_result: string
+    implementation_paths: string
+---
+Placeholder: preamble body to be written in the next task.
+```
+
+### Key differences from existing skill files
+
+- **`escalate_to` is present.** Neither `skill-writer.md` nor `orchestrator.md` uses `escalate_to`. The tool-coder is the first skill to include it. The value `human_reviewer` must be a non-empty string (validated by `check_escalate_to`).
+- **Three tools** instead of two. The `cargo_build` tool implies the agent can trigger compilation, which is a new capability compared to the other seed agents.
+- **`allowed_actions` includes `execute`.** The other skills use `read`/`write` or `route`/`discover`. The `execute` action reflects the tool-coder's ability to run build commands.
+- **`max_turns: 15`** is higher than the other skills (10 for skill-writer, 3 for orchestrator), reflecting the iterative compile-fix cycle expected during tool implementation.
+- **`confidence_threshold: 0.85`** is slightly lower than the 0.9 used by the other skills, allowing the agent more latitude before escalating.
+
+### No code changes required
+
+This task creates only a markdown skill file. No Rust code is added or modified.
+
+## Dependencies
+
+- **Blocked by:** None
+- **Blocking:** "Write tool-coder preamble body" -- that task will replace the placeholder preamble with the full behavioral instructions for the tool-coder agent.
+
+## Risks & Edge Cases
+
+1. **YAML float coercion on `version`.** If `version` is written as `0.1` without quotes, YAML parsers will interpret it as a float (0.1), and serde deserialization into `String` will fail. Mitigation: the spec explicitly requires `"0.1"` with quotes, and the existing skill files demonstrate this pattern.
+
+2. **`escalate_to: human_reviewer` references a non-existent agent.** The current `check_escalate_to` validation only verifies the string is non-empty; it does not verify the target agent exists (see the TODO comment in `validation.rs` line 94). This means the file will pass validation today, but a future cross-agent validation pass could flag it. Mitigation: the `human_reviewer` target is intentional as an escape hatch and should be registered when the escalation system is built.
+
+3. **Tools `read_file`, `write_file`, `cargo_build` may not be registered yet.** The tool registry validation (`check_tools_exist`) will fail if these tool names are not in the registry. Mitigation: during development and testing, the `AllToolsExist` stub can be used. The tool names should be registered in the tool registry as part of the tool-coder implementation work.
+
+4. **Placeholder preamble is intentionally minimal.** The preamble satisfies the non-empty validation rule but provides no behavioral guidance. The agent should not be deployed with this placeholder; the blocking task must be completed first.
+
+5. **No standalone `---` lines in preamble.** The placeholder text contains no triple-dash lines, so there is no risk of frontmatter delimiter collision.
+
+## Verification
+
+1. **File exists** at `skills/tool-coder.md` with correct path and filename.
+2. **YAML frontmatter parses successfully** -- run `cargo test -p skill-loader` to confirm the frontmatter can be deserialized into `SkillFrontmatter` (requires a test that loads the file, or manual verification with `serde_yaml`).
+3. **All required fields are present and non-empty** -- `name`, `version`, `model.provider`, `model.name` are all non-empty strings.
+4. **`version` is a string, not a float** -- confirm the YAML value is quoted (`"0.1"`).
+5. **`confidence_threshold` is in [0.0, 1.0]** -- 0.85 satisfies this.
+6. **`max_turns` is greater than 0** -- 15 satisfies this.
+7. **`output.format` is a valid value** -- `structured_json` is in `ALLOWED_OUTPUT_FORMATS`.
+8. **`escalate_to` is non-empty** -- `human_reviewer` satisfies this.
+9. **Preamble is non-empty** -- the placeholder line satisfies this.
+10. **`cargo build` succeeds** -- no Rust code is changed, so existing compilation should be unaffected.
+11. **Field ordering and indentation** visually matches the style of `skills/skill-writer.md` and `skills/orchestrator.md`.

--- a/.claude/specs/issue-20/run-verification-suite.md
+++ b/.claude/specs/issue-20/run-verification-suite.md
@@ -1,0 +1,97 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-20.md
+
+## Objective
+
+Run the full Rust workspace verification suite (`cargo check`, `cargo clippy`, `cargo test`) to confirm that the new `skills/tool-coder.md` skill file and its corresponding integration test are correct and that no regressions were introduced. This is the final gate before the issue can be closed.
+
+## Current State
+
+The workspace contains six crates defined in the root `Cargo.toml`:
+- `crates/agent-sdk`
+- `crates/skill-loader`
+- `crates/tool-registry`
+- `crates/agent-runtime`
+- `crates/orchestrator`
+- `tools/echo-tool`
+
+Existing integration tests in `crates/skill-loader/tests/example_skills_test.rs` cover four skills:
+- `load_cogs_analyst_skill`
+- `load_echo_skill`
+- `load_skill_writer_skill`
+- `load_orchestrator_skill`
+
+After the preceding tasks in issue-20 are complete, there will be:
+- A new skill file at `skills/tool-coder.md` with YAML frontmatter and a preamble body.
+- A new test `load_tool_coder_skill` appended to `crates/skill-loader/tests/example_skills_test.rs`.
+
+## Requirements
+
+- `cargo check` must exit 0 with no errors across the entire workspace.
+- `cargo clippy` must exit 0 with no warnings treated as errors across the entire workspace.
+- `cargo test` must exit 0 with all tests passing across the entire workspace.
+- The new `load_tool_coder_skill` test must appear in the test output and pass.
+- All four pre-existing `example_skills_test` tests must continue to pass (no regressions).
+- `SkillLoader::load("tool-coder")` (exercised by the new test) must succeed when using `AllToolsExist` as the tool checker, confirming the YAML frontmatter parses correctly and all validation rules pass.
+- The test must confirm the preamble contains keywords related to MCP/Rust tool implementation guidance (e.g., "MCP" or "mcp", "Rust" or "rust", "cargo" or "build").
+
+## Implementation Details
+
+### Commands to run (in order)
+
+1. **Type check:**
+   ```
+   cargo check --workspace
+   ```
+   Expected: exits 0 with no errors.
+
+2. **Lint:**
+   ```
+   cargo clippy --workspace -- -D warnings
+   ```
+   Expected: exits 0 with no warnings. The `-D warnings` flag ensures any clippy warning is treated as a hard failure.
+
+3. **Test:**
+   ```
+   cargo test --workspace
+   ```
+   Expected: exits 0 with all tests passing. Look for the line:
+   ```
+   test load_tool_coder_skill ... ok
+   ```
+   in the `example_skills_test` test binary output.
+
+### What constitutes a pass
+
+- All three commands exit with code 0.
+- The `cargo test` output includes `load_tool_coder_skill ... ok`.
+- The `cargo test` output includes all four existing example skill tests as `ok`.
+- No `FAILED` lines appear in any output.
+
+### What constitutes a fail
+
+- Any command exits with a non-zero code.
+- Any test shows `FAILED`.
+- The `load_tool_coder_skill` test is missing from output (meaning it was not added or not compiled).
+- Clippy produces warnings (with `-D warnings`).
+
+## Dependencies
+
+- Blocked by: "Create `skills/tool-coder.md` with YAML frontmatter", "Write tool-coder preamble body", "Add integration test for tool-coder skill"
+- Blocking: None (this is the final task)
+
+## Risks & Edge Cases
+
+- **YAML parsing edge cases:** If `version` in `tool-coder.md` is not quoted (e.g., `0.1` instead of `"0.1"`), YAML may parse it as a float, which could cause the version string assertion to fail. The frontmatter task spec requires quoting.
+- **Preamble contains bare `---`:** If the preamble body contains a standalone `---` on a line by itself, the YAML frontmatter parser may interpret it as a second delimiter, truncating the preamble. The preamble task spec explicitly prohibits standalone `---` lines.
+- **Clippy lint regressions in unrelated crates:** A new Rust toolchain update could introduce new clippy lints that fail on existing code. If this happens, the issue is unrelated to the tool-coder changes and should be fixed separately.
+- **Stub tools (`read_file`, `write_file`, `cargo_build`):** These tools are declared in the tool-coder frontmatter but do not exist in the tool registry. The test uses `AllToolsExist` to bypass tool existence checks. If the test were mistakenly written with a real registry check, it would fail.
+- **Test name collision:** Ensure the new test function is named exactly `load_tool_coder_skill` (with underscores, not hyphens) to match Rust naming conventions and the expected test output.
+
+## Verification
+
+- All three commands (`cargo check --workspace`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`) exit 0.
+- `cargo test --workspace 2>&1 | grep "load_tool_coder_skill"` returns `test load_tool_coder_skill ... ok`.
+- `cargo test --workspace 2>&1 | grep -c "FAILED"` returns `0`.
+- The five example skill tests all show as `ok`: `load_cogs_analyst_skill`, `load_echo_skill`, `load_skill_writer_skill`, `load_orchestrator_skill`, `load_tool_coder_skill`.

--- a/.claude/specs/issue-20/write-tool-coder-preamble-body.md
+++ b/.claude/specs/issue-20/write-tool-coder-preamble-body.md
@@ -1,0 +1,180 @@
+# Spec: Write tool-coder preamble body
+
+> From: .claude/tasks/issue-20.md
+
+## Objective
+
+Write the markdown body (preamble) for `skills/tool-coder.md` after the closing `---` frontmatter delimiter. This preamble is the behavioral instruction set that teaches an LLM how to generate working Rust MCP tool server binaries. It must encode the complete echo-tool reference pattern in enough detail that the LLM can produce compilable Rust crates without seeing the actual echo-tool source code. The tool-coder is the second seed agent in Spore's self-bootstrapping factory, partnered with skill-writer (issue #19).
+
+## Current State
+
+### Existing skill preamble pattern (skill-writer.md)
+
+The `skills/skill-writer.md` preamble follows this structure:
+- Opening paragraph establishing the agent's role and relationship to the factory
+- A **Skill File Format Specification** section with detailed field tables
+- A **Validation Rules** section with numbered rules
+- A **Process** section with numbered steps
+- An **Output** section describing the structured JSON response
+
+The tool-coder preamble should mirror this depth and structure, but focused on Rust MCP tool generation instead of skill file generation.
+
+### Echo-tool reference pattern (the pattern the preamble must encode)
+
+**File structure**: Each tool lives in `tools/<tool-name>/` with:
+- `Cargo.toml` - package definition and dependencies
+- `src/main.rs` - entrypoint with logging and stdio transport
+- `src/<tool_name>.rs` - tool module with struct, router, handler
+- `README.md` - usage documentation
+- Optional: `#[cfg(test)] mod tests` within the tool module
+
+**Cargo.toml dependencies**:
+```toml
+[dependencies]
+rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
+tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+rmcp = { version = "1", features = ["client", "transport-child-process"] }
+serde_json = "1"
+```
+
+**Key rmcp imports**:
+```rust
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+```
+
+**Tool struct pattern**:
+- Define a request struct deriving `Debug, serde::Deserialize, schemars::JsonSchema`
+- Define a tool struct with a `tool_router: ToolRouter<Self>` field
+- Constructor calls `Self::tool_router()` to initialize the router
+- `#[tool_router]` on the impl block; `#[tool(description = "...")]` on each method
+- Methods accept `Parameters<RequestType>` and return `String`
+
+**ServerHandler pattern**:
+- `#[tool_handler]` on `impl ServerHandler for ToolStruct`
+- `get_info()` returns `ServerInfo::new(ServerCapabilities::builder().enable_tools().build())`
+
+**main.rs pattern**:
+- `use rmcp::ServiceExt;`
+- `#[tokio::main(flavor = "current_thread")]`
+- Initialize `tracing_subscriber` writing to stderr with ansi disabled
+- Create tool, call `.serve(rmcp::transport::stdio()).await`
+- Call `service.waiting().await`
+
+**Workspace integration**: New crate path must be added to root `Cargo.toml` workspace `members` list.
+
+### Root workspace Cargo.toml
+
+Current workspace members:
+- `crates/agent-sdk`
+- `crates/skill-loader`
+- `crates/tool-registry`
+- `crates/agent-runtime`
+- `crates/orchestrator`
+- `tools/echo-tool`
+
+## Requirements
+
+1. The preamble must begin with an introductory paragraph establishing the tool-coder as the second seed agent in Spore's self-bootstrapping factory, partnered with skill-writer.
+2. The preamble must include a **MCP Tool Implementation Pattern** section that documents:
+   - The file structure: `tools/<tool-name>/` with `Cargo.toml`, `src/main.rs`, tool module, README
+   - The `rmcp` crate imports and macros: `#[tool_router]`, `#[tool_handler]`, `#[tool(...)]`
+   - The `ServerHandler` trait implementation with `get_info()` and `ServerCapabilities`
+   - The `ToolRouter<Self>` field pattern and `Parameters<T>` wrapper
+   - The stdio transport via `rmcp::transport::stdio()` and `ServiceExt`
+   - The `Cargo.toml` dependency pattern with exact feature flags
+   - The `main.rs` boilerplate with tracing to stderr
+   - The request struct pattern with `serde::Deserialize` and `schemars::JsonSchema` derives
+3. The preamble must include a **Process** section with numbered steps: parse skill file for `tools: Vec<String>`, query tool-registry for missing tools, infer input/output schemas, generate Rust crate per tool, write files to `tools/<tool-name>/`, run `cargo build`, return results.
+4. The preamble must include a **Workspace Integration** note about adding new crates to root `Cargo.toml` members.
+5. The preamble must include an **Output** section describing the structured JSON response with fields: `tools_generated` (list of tool names), `compilation_result` (build success/failure), `implementation_paths` (file paths for each generated tool).
+6. The preamble must NOT contain any standalone `---` lines (use `----` for horizontal rules if needed).
+7. Code examples in the preamble must be accurate reproductions of the echo-tool patterns, not approximations.
+8. The preamble must be detailed enough that an LLM can generate a compilable Rust MCP tool without access to the echo-tool source.
+
+## Implementation Details
+
+### File to modify
+
+- `/workspaces/spore/skills/tool-coder.md` -- append the preamble body after the closing `---` of the YAML frontmatter (the frontmatter itself is created by the sibling task "Create skills/tool-coder.md with YAML frontmatter").
+
+### Preamble structure (sections in order)
+
+1. **Introduction paragraph**: Establish the tool-coder as the second seed agent, partnered with skill-writer, responsible for generating Rust MCP tool server binaries from skill file tool requirements.
+
+2. **MCP Tool Implementation Pattern** section with these subsections:
+   - **File Structure**: describe the `tools/<tool-name>/` layout with `Cargo.toml`, `src/main.rs`, `src/<tool_name>.rs`, and `README.md`
+   - **Cargo.toml**: show the exact dependency block (rmcp with features `transport-io`, `server`, `macros`; tokio with `macros`, `rt`, `io-std`; serde with `derive`; serde_json; tracing; tracing-subscriber with `env-filter`). Also show dev-dependencies for testing.
+   - **Tool Module**: show the request struct pattern with `#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]`, tool struct with `tool_router: ToolRouter<Self>` field, `#[tool_router]` impl with `#[tool(description = "...")]` methods accepting `Parameters<T>`, and `#[tool_handler]` on `impl ServerHandler` with `get_info()` returning `ServerInfo::new(ServerCapabilities::builder().enable_tools().build())`
+   - **Main Entrypoint**: show the `main.rs` pattern with `use rmcp::ServiceExt`, `#[tokio::main(flavor = "current_thread")]`, tracing to stderr with `.with_ansi(false)`, and `.serve(rmcp::transport::stdio()).await` followed by `service.waiting().await`
+   - **README**: note that each tool should have a README with build/run/test instructions
+   - All code examples should use generic placeholder names (e.g., `MyTool`, `MyRequest`) not echo-specific names
+
+3. **Process** section (numbered steps):
+   1. Parse the input skill file to extract the `tools: Vec<String>` field
+   2. Query the tool-registry to identify which tools are missing (not yet implemented)
+   3. For each missing tool, infer the input/output schema from the skill's context and the tool name
+   4. Generate a complete Rust crate for each missing tool following the MCP Tool Implementation Pattern
+   5. Write all generated files to `tools/<tool-name>/`
+   6. Add the new crate to the root `Cargo.toml` workspace members list
+   7. Run `cargo build -p <tool-name>` to verify compilation
+   8. Return structured results
+
+4. **Workspace Integration** section:
+   - Instruct the agent to add `"tools/<tool-name>"` to the `[workspace] members` array in the root `Cargo.toml`
+   - Note that this must happen before `cargo build` will recognize the new crate
+
+5. **Output** section:
+   - `tools_generated`: list of tool name strings that were created
+   - `compilation_result`: string describing build outcome (success or error details)
+   - `implementation_paths`: map of tool name to list of file paths created for that tool
+
+### Key patterns that MUST appear in code examples
+
+- `#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]` on request structs
+- `tool_router: ToolRouter<Self>` field in tool struct
+- `Self::tool_router()` call in constructor
+- `#[tool_router]` attribute on impl block
+- `#[tool(description = "...")]` attribute on methods
+- `Parameters(request): Parameters<RequestType>` method signature
+- `#[tool_handler]` attribute on `impl ServerHandler`
+- `ServerInfo::new(ServerCapabilities::builder().enable_tools().build())`
+- `rmcp::transport::stdio()` in main
+- `#[tokio::main(flavor = "current_thread")]`
+- `.with_writer(std::io::stderr)` and `.with_ansi(false)` for tracing
+
+## Dependencies
+
+- Blocked by: None (same file as frontmatter, but logically follows it)
+- Blocking: "Add integration test for tool-coder skill"
+
+## Risks & Edge Cases
+
+- **Preamble contains standalone `---`**: The frontmatter parser uses `---` as a delimiter. Any standalone `---` line in the markdown body would break parsing. Mitigation: use `----` for horizontal rules, and review the final output for accidental `---` lines.
+- **Code examples drift from actual echo-tool**: If the echo-tool pattern changes, the preamble becomes stale. Mitigation: the preamble references the echo-tool as canonical and the integration test verifies keyword presence.
+- **Preamble too vague for code generation**: If the pattern is described abstractly rather than with concrete code, LLMs may produce non-compiling output. Mitigation: include full code blocks with exact import paths, derives, and macro usage.
+- **Missing dev-dependencies pattern**: The preamble should mention dev-dependencies for testing (rmcp client features, transport-child-process) so generated tools are testable.
+- **Community skills unavailable**: `npx` was not available in the build environment, so community skill search (`npx skills find mcp-server-rust` and `npx skills find rust-tool-generation`) could not be executed. No community skills were added. This should be retried when npx becomes available.
+
+## Verification
+
+1. The file `skills/tool-coder.md` has non-empty markdown content after the closing `---` frontmatter delimiter.
+2. The preamble contains the string "second seed agent" or equivalent introduction.
+3. The preamble contains a section heading for "MCP Tool Implementation Pattern" (or similar).
+4. The preamble contains code blocks showing `#[tool_router]`, `#[tool_handler]`, `Parameters<`, `ServerCapabilities::builder().enable_tools().build()`, and `rmcp::transport::stdio()`.
+5. The preamble contains a "Process" section with numbered steps including "tool-registry" and "cargo build".
+6. The preamble contains a "Workspace Integration" section referencing root `Cargo.toml` members.
+7. The preamble contains an "Output" section listing `tools_generated`, `compilation_result`, and `implementation_paths`.
+8. The preamble contains NO standalone `---` lines (grep for `^---$` in the body should return zero matches, excluding the frontmatter delimiters).
+9. The integration test `load_tool_coder_skill` (created by the blocking task) passes, confirming the preamble contains expected keywords like "MCP", "Rust", "cargo", and "tool-registry".
+10. `cargo test -p skill-loader` passes with the new test included.

--- a/.claude/specs/issue-21/add-integration-test-for-deploy-agent-skill.md
+++ b/.claude/specs/issue-21/add-integration-test-for-deploy-agent-skill.md
@@ -1,0 +1,107 @@
+# Spec: Add integration test for deploy-agent skill
+
+> From: .claude/tasks/issue-21.md
+
+## Objective
+
+Add a `load_deploy_agent_skill` integration test to `crates/skill-loader/tests/example_skills_test.rs` that validates the `deploy-agent` skill file loads correctly and all frontmatter fields and preamble keywords match expected values. This ensures the deploy-agent skill file is well-formed and parseable by the skill-loader before it reaches production.
+
+## Current State
+
+The file `crates/skill-loader/tests/example_skills_test.rs` contains five existing integration tests that all follow an identical pattern:
+
+1. Call `skills_dir()` to get the path to the `skills/` directory.
+2. Call `make_loader(&dir)` to create a `SkillLoader` with a `ToolRegistry` and `AllToolsExist` validator.
+3. Call `loader.load("<skill-name>").await.unwrap()` to parse the skill markdown file.
+4. Assert every field on the returned `SkillManifest`:
+   - `name`, `version`, `description` (exact string equality)
+   - `model.provider`, `model.name`, `model.temperature` (float comparison with epsilon)
+   - `tools` (exact `Vec<String>` equality)
+   - `constraints.max_turns`, `constraints.confidence_threshold` (float with epsilon), `constraints.escalate_to` (`Option<String>`), `constraints.allowed_actions`
+   - `output.format`, `output.schema` (check `.len()` then individual keys)
+   - `preamble` (non-empty check, then keyword `contains` assertions)
+
+Existing tests: `load_cogs_analyst_skill`, `load_echo_skill`, `load_skill_writer_skill`, `load_orchestrator_skill`, `load_tool_coder_skill`.
+
+## Requirements
+
+- Add a new `#[tokio::test]` async function named `load_deploy_agent_skill`.
+- Use the same `skills_dir()` and `make_loader()` helpers.
+- Load the skill via `loader.load("deploy-agent").await.unwrap()`.
+- Assert **all** `SkillManifest` fields with exact expected values (these values will be defined by the blocked-by task "Create `skills/deploy-agent.md` with YAML frontmatter"):
+  - `manifest.name` == `"deploy-agent"`
+  - `manifest.version` (exact value from frontmatter)
+  - `manifest.description` (exact value from frontmatter)
+  - `manifest.model.provider` (exact value)
+  - `manifest.model.name` (exact value)
+  - `manifest.model.temperature` (float comparison using `(val - expected).abs() < f64::EPSILON`)
+  - `manifest.tools` (exact vec of tool name strings)
+  - `manifest.constraints.max_turns` (exact integer)
+  - `manifest.constraints.confidence_threshold` (float with epsilon)
+  - `manifest.constraints.escalate_to` (exact `Option<String>`)
+  - `manifest.constraints.allowed_actions` (exact vec of strings)
+  - `manifest.output.format` (exact string)
+  - `manifest.output.schema` -- assert `.len()` then each key-value pair
+- Assert `manifest.preamble` is non-empty.
+- Assert preamble contains the following keyword groups (using `contains` with `||` alternatives and descriptive failure messages):
+  - `"Docker"` or `"docker"` or `"container"` -- preamble should reference containerization
+  - `"registry"` or `"push"` -- preamble should reference pushing to a registry
+  - `"orchestrator"` or `"register"` -- preamble should reference registering with the orchestrator
+  - `"health"` or `"verify"` -- preamble should reference health checks or verification
+  - `"scratch"` or `"minimal"` -- preamble should reference minimal/scratch-based images
+
+## Implementation Details
+
+### Test function signature and structure
+
+```
+#[tokio::test]
+async fn load_deploy_agent_skill() {
+    let dir = skills_dir();
+    let loader = make_loader(&dir);
+    let manifest = loader.load("deploy-agent").await.unwrap();
+
+    // 1. Identity fields
+    // 2. Model config fields
+    // 3. Tools list
+    // 4. Constraints fields
+    // 5. Output fields
+    // 6. Preamble non-empty + keyword checks
+}
+```
+
+### Field assertions
+
+Exact values for `version`, `description`, `model.*`, `tools`, `constraints.*`, `output.*` depend on the frontmatter defined in the blocked-by task. The implementer must read `skills/deploy-agent.md` at implementation time to extract these values.
+
+### Preamble keyword checks
+
+Each keyword check should follow the pattern used in `load_tool_coder_skill` and `load_skill_writer_skill`: an `assert!` with a `contains` call (or `||` of multiple `contains` calls) and a descriptive trailing string message. For example:
+
+```
+assert!(
+    manifest.preamble.contains("Docker") || manifest.preamble.contains("docker") || manifest.preamble.contains("container"),
+    "preamble should reference Docker or containerization"
+);
+```
+
+Five such assertions are required, one per keyword group listed in Requirements.
+
+## Dependencies
+
+- **Blocked by:** "Create `skills/deploy-agent.md` with YAML frontmatter", "Write deploy-agent preamble body" -- the skill file must exist with finalized frontmatter values before exact assertions can be written.
+- **Blocking:** "Run verification suite" -- the test must be in place before the full verification pass.
+
+## Risks & Edge Cases
+
+- If the `deploy-agent.md` frontmatter values change after this test is written, the test will fail. The implementer should verify the test against the actual file at implementation time.
+- The skill name `"deploy-agent"` contains a hyphen; this is consistent with other skills (e.g., `"cogs-analyst"`, `"skill-writer"`, `"tool-coder"`) so no special handling is needed.
+- The `AllToolsExist` validator is used in tests, meaning tool names in the frontmatter do not need to actually exist in the `ToolRegistry`. No additional setup is required.
+- Preamble keyword checks use case-insensitive alternatives (e.g., `"Docker"` or `"docker"`) to avoid brittleness from capitalization changes.
+
+## Verification
+
+- `cargo test --test example_skills_test load_deploy_agent_skill` passes.
+- All five preamble keyword assertions are present in the test.
+- All `SkillManifest` fields are asserted (no field left unchecked).
+- The test follows the exact structural pattern of the existing tests -- no new helpers, no new imports, no deviations.

--- a/.claude/specs/issue-21/create-deploy-agent-md-with-yaml-frontmatter.md
+++ b/.claude/specs/issue-21/create-deploy-agent-md-with-yaml-frontmatter.md
@@ -1,0 +1,100 @@
+# Spec: Create `skills/deploy-agent.md` with YAML frontmatter
+
+> From: .claude/tasks/issue-21.md
+
+## Objective
+
+Create the skill file for the deploy-agent, which packages a runtime binary and skill file into a minimal Docker image, pushes it to a container registry, and registers the agent with the orchestrator. This file establishes the deploy-agent's identity, model configuration, tool requirements, execution constraints, and output contract via YAML frontmatter conforming to the SkillManifest schema.
+
+## Current State
+
+- Two seed skill files already exist: `skills/skill-writer.md` and `skills/tool-coder.md`. Both follow the markdown-with-YAML-frontmatter format parsed by the skill-loader crate.
+- The `SkillManifest` struct in `crates/agent-sdk/src/skill_manifest.rs` defines 8 fields: `name`, `version`, `description`, `model` (ModelConfig), `preamble` (from the markdown body), `tools` (Vec<String>), `constraints` (Constraints), and `output` (OutputSchema).
+- Validation in `crates/skill-loader/src/validation.rs` enforces: non-empty required strings, preamble non-empty, confidence_threshold in [0.0, 1.0], max_turns > 0, tool existence in registry, output format in {"json", "structured_json", "text"}, and escalate_to non-empty when present.
+- The `skills/` directory is the canonical location for skill files. No `deploy-agent.md` exists yet.
+
+## Requirements
+
+1. Create `skills/deploy-agent.md` with YAML frontmatter delimited by `---` lines.
+2. `name` must be `deploy-agent`.
+3. `version` must be `"0.1"` (quoted to prevent YAML float coercion).
+4. `description` must summarize the agent's purpose: packages a runtime binary and skill file into a minimal Docker image, pushes to a registry, and registers the agent with the orchestrator.
+5. `model` must contain `provider: anthropic`, `name: claude-sonnet-4-6`, `temperature: 0.1`.
+6. `tools` must list exactly: `docker_build`, `docker_push`, `register_agent`.
+7. `constraints` must contain `max_turns: 10`, `confidence_threshold: 0.9`, `escalate_to: human_reviewer`, and `allowed_actions: [read, execute, deploy]`.
+8. `output` must contain `format: structured_json` and `schema` with keys `image_uri: string`, `endpoint_url: string`, `health_check: string`.
+9. The markdown body (preamble) must be left as a placeholder for the next task ("Write deploy-agent preamble body"). It must be non-empty to pass validation -- use a single-line placeholder such as `TODO: preamble body to be written in the next task.`
+10. The file must pass all validation rules defined in `crates/skill-loader/src/validation.rs`, except for tool existence (the tools `docker_build`, `docker_push`, `register_agent` do not yet exist in the registry).
+11. No standalone `---` lines in the preamble (validation rule 9 from skill-writer).
+
+## Implementation Details
+
+### File to create: `skills/deploy-agent.md`
+
+Exact content:
+
+```yaml
+---
+name: deploy-agent
+version: "0.1"
+description: Packages a runtime binary and skill file into a minimal Docker image, pushes to a registry, and registers the agent with the orchestrator
+model:
+  provider: anthropic
+  name: claude-sonnet-4-6
+  temperature: 0.1
+tools:
+  - docker_build
+  - docker_push
+  - register_agent
+constraints:
+  max_turns: 10
+  confidence_threshold: 0.9
+  escalate_to: human_reviewer
+  allowed_actions:
+    - read
+    - execute
+    - deploy
+output:
+  format: structured_json
+  schema:
+    image_uri: string
+    endpoint_url: string
+    health_check: string
+---
+TODO: preamble body to be written in the next task.
+```
+
+### Design decisions
+
+- **Temperature 0.1**: Matches `tool-coder.md` and reflects the deterministic nature of deployment operations where precision matters more than creativity.
+- **max_turns 10**: Matches `skill-writer.md`. Deployment involves a bounded sequence of steps (build, push, register, health-check), so 10 turns provides adequate headroom without being wasteful.
+- **confidence_threshold 0.9**: Matches `skill-writer.md`. Deployment actions are consequential (pushing images, registering endpoints) and warrant high confidence before proceeding.
+- **escalate_to human_reviewer**: Consistent with both existing skill files. Deployment failures or ambiguous situations should involve a human.
+- **allowed_actions [read, execute, deploy]**: `read` for inspecting Dockerfiles and configs, `execute` for running docker build/push commands, `deploy` for the registration step. Notably does not include `write` since the deploy-agent should not be modifying source files.
+- **Placeholder preamble**: The preamble is intentionally minimal because the next task ("Write deploy-agent preamble body") is responsible for writing the full behavioral instructions. The placeholder satisfies the non-empty preamble validation rule.
+
+## Dependencies
+
+- Blocked by: None
+- Blocking: "Write deploy-agent preamble body"
+
+## Risks & Edge Cases
+
+- **Tool existence validation failure**: The tools `docker_build`, `docker_push`, and `register_agent` do not yet exist in the tool registry. Loading this skill file through the standard validation pipeline will fail the `check_tools_exist` validation. This is expected and consistent with how `tool-coder.md` and `skill-writer.md` were bootstrapped before their tools existed. The tool-coder agent is responsible for generating these tool implementations separately.
+- **Version float coercion**: The version `"0.1"` must be quoted in YAML. Without quotes, YAML parsers interpret `0.1` as a float, which will fail deserialization into the `String` type. The spec mandates quoting.
+- **Preamble placeholder**: The placeholder text must not be accidentally left in place when the blocking task is completed. The next task should fully replace it.
+- **`deploy` action novelty**: The existing skill files use `read`, `write`, `execute`, and `query` as allowed actions. The `deploy` action is new and may need to be recognized by the orchestrator or constraint-checking logic if action validation is added in the future. Currently, `allowed_actions` is a `Vec<String>` with no whitelist enforcement.
+
+## Verification
+
+1. **Parse check**: Run the skill-loader's YAML frontmatter parser against `skills/deploy-agent.md` and confirm it deserializes into a valid `SkillManifest` struct without errors (using `AllToolsExist` stub to bypass tool registry checks).
+2. **Field-by-field confirmation**: Verify each frontmatter field matches the values specified in the Requirements section above.
+3. **Validation rules**: Confirm the file passes all validation checks in `crates/skill-loader/src/validation.rs`:
+   - `name`, `version`, `model.provider`, `model.name` are non-empty strings.
+   - Preamble is non-empty.
+   - `confidence_threshold` (0.9) is in [0.0, 1.0].
+   - `max_turns` (10) is greater than 0.
+   - `output.format` ("structured_json") is in the allowed formats list.
+   - `escalate_to` ("human_reviewer") is non-empty.
+4. **No standalone `---` in preamble**: Confirm the markdown body contains no lines that are exactly `---`.
+5. **Cargo test**: Run `cargo test` to ensure no existing tests are broken by the addition of the new file.

--- a/.claude/specs/issue-21/run-verification-suite.md
+++ b/.claude/specs/issue-21/run-verification-suite.md
@@ -1,0 +1,78 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-21.md
+
+## Objective
+Run the full Cargo verification suite (check, clippy, test) across the entire workspace to confirm that all existing code compiles, passes linting, and that every test -- including the new `load_deploy_agent_skill` test -- passes. This is the final gate before the issue can be considered complete.
+
+## Current State
+The workspace contains six crates:
+- `crates/agent-sdk`
+- `crates/skill-loader`
+- `crates/tool-registry`
+- `crates/agent-runtime`
+- `crates/orchestrator`
+- `tools/echo-tool`
+
+Existing integration tests in `crates/skill-loader/tests/example_skills_test.rs`:
+- `load_cogs_analyst_skill`
+- `load_echo_skill`
+- `load_skill_writer_skill`
+- `load_orchestrator_skill`
+- `load_tool_coder_skill`
+
+The new test expected after all other issue-21 tasks are complete:
+- `load_deploy_agent_skill`
+
+## Requirements
+- `cargo check --workspace` must exit 0 with no errors.
+- `cargo clippy --workspace -- -D warnings` must exit 0 with no warnings treated as errors.
+- `cargo test --workspace` must exit 0 with all tests passing.
+- The test `load_deploy_agent_skill` must appear in the test output and pass.
+
+## Implementation Details
+Run the following commands in order from the workspace root (`/workspaces/spore`):
+
+1. **Type check**
+   ```bash
+   cargo check --workspace
+   ```
+   Expected: exit code 0, no errors.
+
+2. **Lint**
+   ```bash
+   cargo clippy --workspace -- -D warnings
+   ```
+   Expected: exit code 0, no warnings.
+
+3. **Test**
+   ```bash
+   cargo test --workspace
+   ```
+   Expected: exit code 0, all tests pass. Output must include a passing result for `load_deploy_agent_skill`.
+
+4. **Targeted confirmation** (optional, for explicit proof)
+   ```bash
+   cargo test --package skill-loader --test example_skills_test load_deploy_agent_skill
+   ```
+   Expected: `test load_deploy_agent_skill ... ok`
+
+### Pass/fail criteria
+- All three commands must exit 0.
+- Zero test failures across the workspace.
+- The `load_deploy_agent_skill` test is present and passes.
+
+## Dependencies
+- Blocked by: All other issue-21 tasks (the deploy-agent skill file, its test, and any supporting code changes must already be merged/committed).
+- Blocking: None -- this is the final task.
+
+## Risks & Edge Cases
+- **Missing skill file**: If the `skills/deploy-agent/skill.yaml` file was not created by a prior task, the `load_deploy_agent_skill` test will fail with a file-not-found or parse error.
+- **Tool validation failures**: If the skill references tools that do not satisfy the `AllToolsExist` validator at test time, the loader will return an error. The test helper currently uses `AllToolsExist` (always-true stub), so this is low risk.
+- **Flaky async tests**: Tests use `#[tokio::test]`. Failures due to filesystem timing are unlikely but possible on very slow I/O; a simple re-run confirms.
+- **Clippy version drift**: A newer Rust toolchain may introduce new lints. If clippy fails on pre-existing code unrelated to this issue, that should be reported but not block the verification of the new test.
+
+## Verification
+- All three commands (`cargo check`, `cargo clippy`, `cargo test`) exit with code 0.
+- `cargo test` output contains the line `test load_deploy_agent_skill ... ok`.
+- No test in the workspace reports `FAILED`.

--- a/.claude/specs/issue-21/write-deploy-agent-preamble-body.md
+++ b/.claude/specs/issue-21/write-deploy-agent-preamble-body.md
@@ -1,0 +1,117 @@
+# Spec: Write deploy-agent preamble body
+
+> From: .claude/tasks/issue-21.md
+
+## Objective
+
+Write the markdown preamble body for `skills/deploy-agent.md`, the section after the closing `---` frontmatter delimiter. This preamble is the core instruction set that teaches an LLM how to build, push, and register agent containers. The deploy-agent is the third agent in Spore's self-bootstrapping factory and the first agent produced BY the factory (skill-writer + tool-coder), closing the self-extension loop so that new agents can be described, written, tooled, and deployed entirely within the platform.
+
+## Current State
+
+- **Dockerfile** (`/workspaces/spore/Dockerfile`): Implements a two-stage build pattern:
+  - Stage 1 (`rust:latest AS builder`): Installs musl-tools and cmake, adds `x86_64-unknown-linux-musl` target, creates stub source files for dependency caching, runs `cargo build --release --target x86_64-unknown-linux-musl -p agent-runtime` twice (first for cached deps, then with real sources), and verifies the binary is statically linked.
+  - Stage 2 (`FROM scratch`): Copies only the static `agent-runtime` binary, the `skills/` directory, and CA certificates. Sets `SKILL_NAME` and `SKILL_DIR` env vars, exposes port 8080, runs as non-root user 1000.
+- **SkillManifest** (`crates/agent-sdk/src/skill_manifest.rs`): Has `name: String` and `version: String` fields, which are the source for image tagging (`spore-{name}:{version}`).
+- **agent-runtime** (`crates/agent-runtime/src/main.rs`): The binary packaged into containers. It loads config from env, registers tools, connects tool servers, loads the skill manifest from `SKILL_DIR`, builds a provider-backed agent, applies constraint enforcement, and starts an HTTP server on the configured bind address (default port 8080).
+- **Orchestrator** (`skills/orchestrator.md`): Uses `list_agents` and `route_to_agent` tools. New agents must be registered so the orchestrator can discover and route to them.
+- **Existing preamble pattern** (`skills/tool-coder.md`): Establishes the structure: introductory paragraph establishing lineage, detailed reference sections, a numbered Process section, and an Output section. The deploy-agent preamble must follow this same depth and structure.
+- **README lines 109-118**: Describes the self-bootstrapping factory: skill-writer and tool-coder are seed agents; deploy-agent is the third agent they produce together, packaging runtime + skill into a Docker image and registering the endpoint.
+
+## Requirements
+
+Each requirement maps to a numbered section from the task description:
+
+1. **Introduction paragraph**: Must establish the deploy-agent as the third agent in Spore's factory and the first produced by the factory itself (skill-writer + tool-coder). Must explain that this closes the self-extension loop. Must not use standalone `---` lines.
+
+2. **Docker Build Process section**: Must document the multi-stage build from the project Dockerfile:
+   - Stage 1: `rust:latest` builder with musl-tools, `cargo build --release --target x86_64-unknown-linux-musl` for fully static binary, dependency caching via stub sources.
+   - Stage 2: `FROM scratch` final image containing only the `agent-runtime` binary, the skill file, and CA certificates (`/etc/ssl/certs/ca-certificates.crt`).
+   - Port 8080 exposed, non-root user 1000.
+   - Reference that final images should be 1-5MB.
+   - Must note Docker-in-Docker consideration (socket mounting or remote builder if deploy-agent itself runs in a container).
+
+3. **Image Tagging Convention section**: Tag format `spore-{agent-name}:{version}`, derived from `SkillManifest.name` and `SkillManifest.version` fields. Example: `spore-deploy-agent:0.1`.
+
+4. **Registry Push section**: Push built image to configured container registry. Registry endpoint sourced from environment variable or configuration.
+
+5. **Orchestrator Registration section**: Call the orchestrator's agent registry API to register the new agent's HTTP endpoint. Reference that the orchestrator uses `list_agents` and `route_to_agent` tools so the new agent becomes discoverable and routable.
+
+6. **Health Verification section**: After deployment, call `/health` on the new agent endpoint. Verify successful response before reporting success.
+
+7. **Process section**: Numbered steps covering the full workflow:
+   - Receive skill name and version
+   - Locate compiled agent-runtime binary and skill file
+   - Build Docker image following the scratch-based pattern
+   - Tag with naming convention
+   - Push to registry
+   - Register endpoint with orchestrator
+   - Verify health
+   - Return results
+
+8. **Output section**: Structured JSON with three fields:
+   - `image_uri`: registry path of the pushed image
+   - `endpoint_url`: HTTP endpoint where the agent is reachable
+   - `health_check`: result of post-deployment health verification
+
+9. **No standalone `---` lines**: Use `----` (four dashes) for horizontal rules if needed.
+
+## Implementation Details
+
+### Preamble Structure (in order)
+
+The preamble should follow this exact section ordering, matching the depth of `skills/tool-coder.md`:
+
+1. **Opening paragraph** (no heading): "You are the deploy-agent..." establishing identity, lineage (third agent, first factory-produced), and the self-extension loop closure.
+
+2. **`## Docker Build Process`**: Document the two-stage Dockerfile pattern in detail. Include the exact cargo build command (`cargo build --release --target x86_64-unknown-linux-musl -p agent-runtime`), the `FROM scratch` pattern, what gets copied (binary, skill file, CA certs), env vars (`SKILL_NAME`, `SKILL_DIR`, `SSL_CERT_FILE`), port 8080, user 1000. Note expected image size (1-5MB). Include Docker-in-Docker caveat.
+
+3. **`## Image Tagging Convention`**: Format is `spore-{agent-name}:{version}`. Values come from `SkillManifest` fields `name` and `version`. Provide concrete example.
+
+4. **`## Registry Push`**: Push tagged image to configured registry. Registry URL from `REGISTRY_URL` environment variable or equivalent config. Full image reference becomes `{registry}/spore-{agent-name}:{version}`.
+
+5. **`## Orchestrator Registration`**: After the image is running, register the agent's endpoint with the orchestrator so it appears in `list_agents` results and can be targeted by `route_to_agent`. Include the information needed for registration (agent name, endpoint URL, capabilities/description from the skill manifest).
+
+6. **`## Health Verification`**: HTTP GET to `{endpoint_url}/health`. Expect 200 OK. Retry with backoff if the container is still starting. Only report success after health check passes.
+
+7. **`## Process`**: Numbered list (8 steps as enumerated in requirements).
+
+8. **`## Output`**: Describe the three structured JSON fields with explanations matching the `output.schema` in the frontmatter.
+
+### Key Patterns from Dockerfile
+
+- Dependency caching: stub `lib.rs`/`main.rs` files created first, then `cargo build` to cache deps, then real sources copied and rebuilt.
+- Static linking verification: `file ... | grep -qE 'static(-pie)? linked'`
+- Scratch base: zero OS layer, only the binary, skill files, and CA certs.
+- Environment: `SKILL_NAME=${SKILL_NAME}`, `SKILL_DIR=/skills`, `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
+- Security: `USER 1000` (non-root), `EXPOSE 8080`
+
+### Integration Points
+
+- The deploy-agent's three tools (`docker_build`, `docker_push`, `register_agent`) are declared in frontmatter but not yet implemented. The preamble must provide enough detail that these tools' implementations can be derived from it.
+- The orchestrator registration API shape is implied by the orchestrator skill's `list_agents` and `route_to_agent` tools.
+
+## Dependencies
+
+- Blocked by: None (logically follows the frontmatter task but can be written independently since the structure is fully specified)
+- Blocking: "Add integration test for deploy-agent skill" (the integration test checks preamble keyword presence: "Docker"/"docker"/"container", "registry"/"push", "orchestrator"/"register", "health"/"verify", "scratch"/"minimal")
+
+## Risks & Edge Cases
+
+- **Keyword coverage for tests**: The integration test checks for specific keywords in the preamble. The preamble must naturally include: "Docker" or "docker" or "container", "registry" or "push", "orchestrator" or "register", "health" or "verify", "scratch" or "minimal". Missing any of these will cause test failure.
+- **Standalone `---` lines**: YAML parsers may interpret `---` in the body as a new frontmatter block. The body must not contain any line that is exactly `---`. Use `----` if a horizontal rule is needed.
+- **Preamble depth**: Like tool-coder's preamble (which is approximately 200 lines of detailed instructions), the deploy-agent preamble must encode enough detail for an LLM to orchestrate the full deployment without seeing the Dockerfile or runtime source. Insufficient detail would make the agent non-functional.
+- **Docker-in-Docker**: The preamble should note that if the deploy-agent itself runs inside a container, Docker socket access or a remote builder is required. This is a documentation concern, not something to solve in this issue.
+- **Future tool implementation**: The preamble describes how `docker_build`, `docker_push`, and `register_agent` should behave, which effectively serves as a spec for their eventual implementation by tool-coder. Inaccuracies here propagate to tool implementation.
+
+## Verification
+
+- The file `skills/deploy-agent.md` contains a preamble body after the closing `---` delimiter.
+- The preamble is non-empty and contains all nine required sections/elements.
+- The preamble contains the keywords checked by the integration test: at least one of "Docker"/"docker"/"container", "registry"/"push", "orchestrator"/"register", "health"/"verify", "scratch"/"minimal".
+- No line in the preamble body is exactly `---` (three dashes alone).
+- The Docker build pattern described matches the actual `Dockerfile` (multi-stage, musl static linking, scratch base, CA certs, port 8080, user 1000).
+- The image tagging convention uses `spore-{agent-name}:{version}` derived from `SkillManifest.name` and `SkillManifest.version`.
+- The Output section documents exactly three fields: `image_uri`, `endpoint_url`, `health_check`.
+- The Process section has numbered steps covering the full workflow.
+- `cargo test` passes, including the `load_deploy_agent_skill` integration test (once that test is implemented by the blocking task).
+- The preamble style and depth are comparable to `skills/tool-coder.md`.

--- a/.claude/specs/issue-22/add-rust-integration-test-wrapper.md
+++ b/.claude/specs/issue-22/add-rust-integration-test-wrapper.md
@@ -1,0 +1,172 @@
+# Spec: Add Rust integration test wrapper for E2E bootstrap
+
+> From: .claude/tasks/issue-22.md
+
+## Objective
+
+Create a Rust integration test that wraps the `scripts/e2e-test.sh` shell script, providing a `cargo test` entry point for the end-to-end bootstrap test. The test is gated behind a Cargo feature flag (`e2e`) and marked `#[ignore]` so it never runs in the default `cargo test` invocation. This allows CI or developers to explicitly opt in with `cargo test --features e2e -- --ignored` while keeping the normal test suite fast and free of external dependencies.
+
+## Current State
+
+- **Workspace `Cargo.toml`:** Defines a virtual workspace with `resolver = "2"` and six member crates. There is no `[package]` or `[features]` section at the workspace level.
+- **`scripts/e2e-test.sh`:** Does not exist yet. This task is blocked by the E2E shell script task, which will create this script. The test wrapper assumes the script exists at the workspace root-relative path `scripts/e2e-test.sh`, is executable, and returns exit code 0 on success and non-zero on failure.
+- **No workspace-level integration tests exist yet.** The `tests/` directory at the workspace root does not exist. Existing integration tests live inside individual crates (e.g., `crates/skill-loader/tests/`).
+- **Workspace test conventions:**
+  - Integration tests use `#[tokio::test]` for async or `#[test]` for sync.
+  - Assertions use `assert!`, `assert_eq!`, and pattern matching.
+  - Test functions have descriptive names that state the expected behavior.
+  - No mocking frameworks are used.
+
+## Requirements
+
+1. **Add `[package]` section to workspace `Cargo.toml`:** Since the current root `Cargo.toml` is a pure virtual workspace (no `[package]`), a minimal `[package]` section must be added so that `[features]` can be defined and `tests/` at the workspace root belongs to a package. This is a standard Cargo pattern for workspaces that also need root-level tests or features.
+
+2. **Add `e2e` feature to workspace `Cargo.toml`:** Add a `[features]` section to the root `Cargo.toml` with an `e2e` feature that has no dependencies (empty array). This feature acts as a compile-time gate for the E2E test.
+
+3. **Create `tests/e2e_bootstrap_test.rs`:** Create a workspace-level integration test file at the repository root. This file contains a single test function that shells out to `scripts/e2e-test.sh`.
+
+4. **Feature gate:** The entire test file must be gated with `#![cfg(feature = "e2e")]` so that the test is not even compiled unless the `e2e` feature is enabled.
+
+5. **`#[ignore]` attribute:** The test function must be annotated with both `#[test]` and `#[ignore]`. The `#[ignore]` attribute provides a second layer of protection: even when compiled with `--features e2e`, the test only runs when explicitly requested with `--ignored` or `--include-ignored`.
+
+6. **Script execution:** The test must:
+   - Locate `scripts/e2e-test.sh` relative to the workspace root using `env!("CARGO_MANIFEST_DIR")`.
+   - Spawn the script using `std::process::Command`.
+   - Set the working directory to the workspace root.
+   - Capture stdout/stderr and print them on failure for debugging.
+   - Assert that the exit code is 0.
+
+7. **No async runtime needed:** A plain `#[test]` is sufficient. No additional dependencies are required.
+
+8. **No new crate dependencies:** Only `std::process::Command` from the standard library is needed.
+
+## Implementation Details
+
+### File to modify: `Cargo.toml` (workspace root)
+
+Add a `[package]` section and a `[features]` section. The resulting file should look like:
+
+```toml
+[package]
+name = "spore"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+resolver = "2"
+members = [
+    "crates/agent-sdk",
+    "crates/skill-loader",
+    "crates/tool-registry",
+    "crates/agent-runtime",
+    "crates/orchestrator",
+    "tools/echo-tool",
+]
+
+[features]
+e2e = []
+
+[profile.release]
+lto = true
+opt-level = "z"
+codegen-units = 1
+strip = true
+panic = "abort"
+```
+
+**Key points:**
+- `[package]` must appear before `[workspace]` for Cargo to parse it correctly as a package that is also a workspace root.
+- `publish = false` prevents accidental publishing to crates.io.
+- `version = "0.0.0"` signals this is not a real publishable package.
+- The root package is implicitly a workspace member when `[package]` and `[workspace]` coexist; no changes to the `members` array are needed.
+
+### File to create: `tests/e2e_bootstrap_test.rs`
+
+```rust
+#![cfg(feature = "e2e")]
+
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+#[ignore]
+fn e2e_bootstrap_runs_successfully() {
+    let workspace_root = env!("CARGO_MANIFEST_DIR");
+    let script_path = Path::new(workspace_root).join("scripts/e2e-test.sh");
+
+    assert!(
+        script_path.exists(),
+        "E2E test script not found at: {}",
+        script_path.display()
+    );
+
+    let output = Command::new(&script_path)
+        .current_dir(workspace_root)
+        .output()
+        .unwrap_or_else(|e| panic!(
+            "Failed to execute E2E test script at {}: {e}",
+            script_path.display()
+        ));
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!(
+            "E2E bootstrap test failed with exit code {:?}\n\n--- stdout ---\n{stdout}\n\n--- stderr ---\n{stderr}",
+            output.status.code()
+        );
+    }
+}
+```
+
+### Design decisions
+
+- **`#![cfg(feature = "e2e")]` at crate level:** Using a crate-level inner attribute gates the entire file so nothing compiles without the feature. This prevents any compilation overhead when the feature is off.
+
+- **`#[ignore]` as double gate:** The feature flag prevents compilation; `#[ignore]` prevents execution even when compiled. This two-layer approach means:
+  - `cargo test` -- does not compile or run the E2E test.
+  - `cargo test --features e2e` -- compiles but skips (shows "ignored").
+  - `cargo test --features e2e -- --ignored` -- compiles and runs the E2E test.
+  - `cargo test --features e2e -- --include-ignored` -- runs all tests including the E2E test.
+
+- **`Command::output()` over `Command::status()`:** Captures stdout and stderr, which are printed on failure for easier CI debugging.
+
+- **`env!("CARGO_MANIFEST_DIR")`:** Compile-time macro that resolves to the directory containing the `Cargo.toml` owning the test. For workspace-root integration tests, this is the workspace root. More reliable than `std::env::current_dir()`.
+
+- **Existence check before execution:** The `assert!(script_path.exists(), ...)` provides a clear error message if the script is missing, rather than an opaque OS error.
+
+- **Plain `#[test]`, not `#[tokio::test]`:** No async operations needed. `std::process::Command` blocks synchronously until the child process exits.
+
+## Dependencies
+
+- **Blocked by:**
+  - "E2E shell script" -- the `scripts/e2e-test.sh` script must exist for the test to pass. The Rust test file and Cargo.toml changes can be created before the script exists; the test will fail with the "script not found" assertion until the script is in place.
+
+- **Blocking:**
+  - "README section" -- the README documentation for E2E testing depends on this test wrapper existing so it can document the `cargo test --features e2e -- --ignored` invocation.
+
+## Risks & Edge Cases
+
+1. **Script not executable:** If `scripts/e2e-test.sh` lacks the executable bit (`chmod +x`), `Command` will fail with a permission error. The E2E shell script task should ensure the file is executable. The `unwrap_or_else` panic message will clearly indicate the problem.
+
+2. **Windows compatibility:** Running a `.sh` script via `std::process::Command` will not work on Windows without a shell interpreter. This is acceptable because the E2E test targets Linux/macOS CI. If Windows support is needed later, the script can be invoked via `bash scripts/e2e-test.sh` instead.
+
+3. **Long-running script:** The E2E bootstrap script may take significant time (building, spawning servers, HTTP requests). The `#[test]` harness has no default timeout. If the script hangs, the test hangs. A `timeout` wrapper could be added later if needed.
+
+4. **Adding `[package]` to root `Cargo.toml`:** Converting from a pure virtual workspace to a package+workspace is a well-supported Cargo pattern, but it changes semantics slightly: `cargo build` in the root will now also consider the root package (which has no `src/`). Since there is no `src/lib.rs` or `src/main.rs`, Cargo will not try to build a library or binary for the root package -- it will only compile tests when `cargo test` is run. This is the desired behavior. If Cargo complains about a missing `src/`, an empty `src/lib.rs` can be created, but this should not be necessary for a package with only `tests/`.
+
+5. **Feature leakage:** The `e2e` feature is defined on the root package only and has no downstream effects on member crates. It only controls conditional compilation within the root package's test files.
+
+6. **Cargo workspace member list:** The root package is automatically a workspace member when `[package]` and `[workspace]` coexist in the same file. No changes to the `members` array are needed.
+
+## Verification
+
+1. `cargo check --features e2e` compiles successfully (including the test file).
+2. `cargo check` (without `--features e2e`) does not compile the test file.
+3. `cargo test` does not show `e2e_bootstrap_runs_successfully` in output at all.
+4. `cargo test --features e2e` shows `e2e_bootstrap_runs_successfully` as `ignored`.
+5. `cargo test --features e2e -- --ignored` runs the E2E test (passes once `scripts/e2e-test.sh` exists and works).
+6. `cargo clippy --features e2e --tests` reports no warnings on the test file.
+7. `cargo clippy --tests` (without `--features e2e`) does not lint the test file.
+8. The existing `cargo test` suite across all workspace members continues to pass with no regressions.

--- a/.claude/specs/issue-22/create-docker-compose-e2e-yml.md
+++ b/.claude/specs/issue-22/create-docker-compose-e2e-yml.md
@@ -1,0 +1,207 @@
+# Spec: Create `docker-compose.e2e.yml`
+
+> From: .claude/tasks/issue-22.md
+
+## Objective
+
+Create a Docker Compose file at the repository root that defines four services (skill-writer, tool-coder, deploy-agent, orchestrator) for end-to-end testing. Each service builds from the project's existing `Dockerfile` using the `SKILL_NAME` build arg to select its skill file. The orchestrator service receives environment variables pointing it at the three agent services. The deploy-agent service mounts the Docker socket for container operations. All services share a single Docker network and expose unique host-mapped ports for external access and health-check probing.
+
+## Current State
+
+### Dockerfile (`Dockerfile`)
+
+The project has a single multi-stage Dockerfile that:
+1. Builds a statically-linked `agent-runtime` binary (musl target).
+2. Produces a `FROM scratch` final image containing only the binary, the `/skills/` directory, and CA certificates.
+3. Accepts a build arg `SKILL_NAME` (default: `echo`) which becomes the `SKILL_NAME` environment variable at runtime.
+4. Sets `SKILL_DIR=/skills` and `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`.
+5. Exposes port `8080` and runs as user `1000`.
+6. Entrypoint is `/agent-runtime`.
+
+### Runtime Configuration (`crates/agent-runtime/src/config.rs`)
+
+`RuntimeConfig::from_env()` reads:
+- `SKILL_NAME` (required) -- which skill file to load.
+- `SKILL_DIR` (optional, default `./skills`) -- directory containing skill markdown files.
+- `BIND_ADDR` (optional, default `0.0.0.0:8080`) -- socket address for the HTTP server.
+
+### HTTP Server (`crates/agent-runtime/src/http.rs`)
+
+The agent-runtime exposes two endpoints:
+- `GET /health` -- returns JSON with `name`, `version`, `status` fields. This is the health-check target.
+- `POST /invoke` -- forwards requests to the agent.
+
+### Tool Endpoints (`crates/agent-runtime/src/main.rs`)
+
+`TOOL_ENDPOINTS` env var: comma-separated `name=endpoint` pairs (e.g., `echo-tool=mcp://localhost:7001`). Falls back to `echo-tool=mcp://localhost:7001` when unset.
+
+### Orchestrator Configuration (`crates/orchestrator/src/config.rs`)
+
+`OrchestratorConfig::from_env()` reads:
+- `AGENT_ENDPOINTS` (required) -- comma-separated `name=url` pairs (e.g., `skill-writer=http://skill-writer:8080`).
+- `AGENT_DESCRIPTIONS` (optional) -- comma-separated `name=description` pairs.
+- `EMBEDDING_PROVIDER` (optional) -- embedding provider name.
+- `EMBEDDING_MODEL` (optional) -- embedding model name.
+- `SIMILARITY_THRESHOLD` (optional) -- float for routing similarity.
+
+### Skill Files (`skills/`)
+
+Four skill files exist for the four services:
+- `skills/skill-writer.md` -- name: `skill-writer`, version: `0.1`
+- `skills/tool-coder.md` -- name: `tool-coder`, version: `0.1`
+- `skills/deploy-agent.md` -- name: `deploy-agent`, version: `0.1`
+- `skills/orchestrator.md` -- name: `orchestrator`, version: `1.0`
+
+### Note on the Orchestrator Binary
+
+The orchestrator crate (`crates/orchestrator/`) is currently a library crate with no `main.rs`. The `agent-runtime` binary loads the `orchestrator` skill file the same way it loads any other skill -- via the `SKILL_NAME` env var. Therefore all four services use the same `agent-runtime` binary and the same Dockerfile; only the `SKILL_NAME` build arg differs.
+
+## Requirements
+
+1. **File location**: Create `docker-compose.e2e.yml` at the repository root (`/workspaces/spore/docker-compose.e2e.yml`).
+
+2. **Four services**: `skill-writer`, `tool-coder`, `deploy-agent`, `orchestrator`.
+
+3. **Shared build context**: All services build from the same `Dockerfile` at `.` (repository root), each passing a different `SKILL_NAME` build arg matching its skill file name.
+
+4. **Unique host-mapped ports**: Each service listens internally on `8080` (the default `BIND_ADDR`). Map to unique host ports:
+   - `skill-writer`: host port `8081`
+   - `tool-coder`: host port `8082`
+   - `deploy-agent`: host port `8083`
+   - `orchestrator`: host port `8084`
+
+5. **Health checks**: Do not define `healthcheck` directives in the compose file. The `FROM scratch` image contains no shell, `curl`, or `wget`, so container-internal health check commands cannot execute. The E2E shell script (which this file blocks) will handle health polling from the host side by curling each service's `GET /health` endpoint on its host-mapped port.
+
+6. **Shared network**: All services join a single custom bridge network named `spore-e2e` so they can reach each other by service name (e.g., `http://skill-writer:8080`).
+
+7. **Docker socket mount for deploy-agent**: The `deploy-agent` service mounts `/var/run/docker.sock:/var/run/docker.sock` so it can build and push Docker images from inside its container. This requires overriding the default user (scratch image runs as `1000`) -- set `user: "0"` (root) on the deploy-agent service only, since accessing the Docker socket typically requires root or docker-group membership.
+
+8. **Orchestrator environment variables**: The orchestrator service needs `AGENT_ENDPOINTS` set to the comma-separated list of the three agent services:
+   ```
+   AGENT_ENDPOINTS=skill-writer=http://skill-writer:8080,tool-coder=http://tool-coder:8080,deploy-agent=http://deploy-agent:8080
+   ```
+   Optionally set `AGENT_DESCRIPTIONS` with each agent's description from their skill files (descriptions must not contain commas or equals signs due to the parser's `parse_comma_pairs` format).
+
+9. **Orchestrator depends_on**: The orchestrator service should declare `depends_on` on the three agent services so Docker Compose starts them first.
+
+10. **Container naming**: Use `container_name` matching the service name for predictable DNS and log identification: `skill-writer`, `tool-coder`, `deploy-agent`, `orchestrator`.
+
+## Implementation Details
+
+### File to create
+
+**`docker-compose.e2e.yml`**
+
+```yaml
+version: "3.8"
+
+networks:
+  spore-e2e:
+    driver: bridge
+
+services:
+  skill-writer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SKILL_NAME: skill-writer
+    container_name: skill-writer
+    ports:
+      - "8081:8080"
+    networks:
+      - spore-e2e
+
+  tool-coder:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SKILL_NAME: tool-coder
+    container_name: tool-coder
+    ports:
+      - "8082:8080"
+    networks:
+      - spore-e2e
+
+  deploy-agent:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SKILL_NAME: deploy-agent
+    container_name: deploy-agent
+    ports:
+      - "8083:8080"
+    user: "0"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - spore-e2e
+
+  orchestrator:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SKILL_NAME: orchestrator
+    container_name: orchestrator
+    ports:
+      - "8084:8080"
+    environment:
+      AGENT_ENDPOINTS: "skill-writer=http://skill-writer:8080,tool-coder=http://tool-coder:8080,deploy-agent=http://deploy-agent:8080"
+      AGENT_DESCRIPTIONS: "skill-writer=Produces validated skill files from plain-language descriptions,tool-coder=Generates compiles and validates Rust MCP tool implementations,deploy-agent=Packages runtime binary and skill file into Docker image and registers agent"
+    depends_on:
+      - skill-writer
+      - tool-coder
+      - deploy-agent
+    networks:
+      - spore-e2e
+```
+
+### Key design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| No `healthcheck` directives in compose | The `FROM scratch` image contains no shell, `curl`, or `wget`. Health polling is delegated to the E2E test script that consumes this compose file. |
+| `user: "0"` on deploy-agent only | Docker socket access requires root or docker-group membership. Other services remain at user `1000` (Dockerfile default). |
+| `depends_on` without condition | Since there are no health checks in compose, `depends_on` only controls startup order, not readiness. The E2E script must wait for health before running tests. |
+| `AGENT_DESCRIPTIONS` values avoid commas | The orchestrator's `parse_comma_pairs` function splits on `,` then on `=`. Descriptions must not contain commas or equals signs, so they are simplified from the original skill file descriptions. |
+| Single Dockerfile for all services | The `SKILL_NAME` build arg is the only differentiator. This matches the project's architecture where `agent-runtime` is a generic binary parameterized by skill file. |
+| Host ports 8081-8084 | Sequential and memorable. Avoids conflict with any service binding to 8080 on the host. |
+
+### Files to modify
+
+None. This is a new file.
+
+## Dependencies
+
+- **Blocked by**: Nothing. The Dockerfile and skill files already exist.
+- **Blocking**: E2E shell script -- the test script will reference `docker-compose.e2e.yml` to bring up the services, poll health endpoints, run tests, and tear down.
+
+## Risks & Edge Cases
+
+1. **Docker socket security**: Mounting the Docker socket gives the deploy-agent container full control of the host Docker daemon. This is acceptable for local E2E testing but must not be used in production without scoping (e.g., Docker socket proxy).
+
+2. **Port conflicts**: If host ports 8081-8084 are already in use, `docker compose up` will fail. The E2E script should handle this gracefully or document the port requirements.
+
+3. **Build cache sharing**: All four services build from the same Dockerfile with different `SKILL_NAME` args. Docker Compose builds them sequentially by default. The builder stage (dependency compilation) is shared across builds since the `SKILL_NAME` arg is only used in the final stage. This means only the first build is slow; subsequent builds reuse the cached builder layer.
+
+4. **`AGENT_DESCRIPTIONS` parsing**: The comma-separated format means descriptions cannot contain literal commas. The descriptions in the compose file are simplified versions of the original skill file descriptions with commas removed.
+
+5. **Orchestrator startup race**: `depends_on` only ensures containers start in order, not that they are ready. The orchestrator may attempt to connect to agent endpoints before they are listening. The E2E script must poll all four health endpoints before running tests.
+
+6. **`FROM scratch` limitations**: No shell means `docker exec` into containers is impossible. Debugging must rely on `docker logs` output only. The agent-runtime logs to stderr via `tracing_subscriber`.
+
+## Verification
+
+1. **File exists**: `docker-compose.e2e.yml` is present at the repository root.
+2. **Valid YAML**: `docker compose -f docker-compose.e2e.yml config` parses without errors.
+3. **Four services defined**: Config output shows exactly four services: `skill-writer`, `tool-coder`, `deploy-agent`, `orchestrator`.
+4. **Build args correct**: Each service's build section specifies `SKILL_NAME` matching its service name.
+5. **Port mappings unique**: Each service maps a unique host port (8081-8084) to container port 8080.
+6. **Network shared**: All services are on the `spore-e2e` network.
+7. **Docker socket mounted**: Only `deploy-agent` has the `/var/run/docker.sock` volume mount.
+8. **Orchestrator env vars**: `AGENT_ENDPOINTS` contains all three agent service URLs using Docker DNS names.
+9. **Orchestrator depends_on**: Lists all three agent services.
+10. **No healthcheck directives**: No service defines a `healthcheck` block (scratch image incompatibility).

--- a/.claude/specs/issue-22/create-orchestrator-config-file-for-e2e.md
+++ b/.claude/specs/issue-22/create-orchestrator-config-file-for-e2e.md
@@ -1,0 +1,93 @@
+# Spec: Create orchestrator config file for E2E
+
+> From: .claude/tasks/issue-22.md
+
+## Objective
+
+Create `tests/e2e/orchestrator-config.yml`, a YAML configuration file that the orchestrator can load via `OrchestratorConfig::from_file()` during end-to-end tests. The file declares seed agent entries following the `OrchestratorConfig` schema defined in `crates/orchestrator/src/config.rs`. This is the static configuration that tells the orchestrator which agents exist and how to reach them within the docker-compose E2E network.
+
+## Current State
+
+- The `tests/e2e/` directory does not exist yet.
+- `OrchestratorConfig` supports loading from a YAML file via `from_file()` (see `crates/orchestrator/src/config.rs:57-65`). The schema expects a top-level `agents` array and optional `embedding_provider`, `embedding_model`, and `similarity_threshold` fields.
+- Each agent entry (`AgentConfig`) has three required string fields: `name`, `description`, and `url`.
+- The orchestrator resolves agent URLs by appending `/invoke` and `/health` to the base `url` field (see `crates/orchestrator/src/agent_endpoint.rs`).
+- Six seed skill files exist under `skills/`: `echo`, `skill-writer`, `orchestrator`, `cogs-analyst`, `tool-coder`, and `deploy-agent`.
+- The orchestrator skill (`skills/orchestrator.md`) is the router itself and should NOT appear as a routable agent entry in the config.
+
+## Requirements
+
+- Create directory `tests/e2e/` if it does not exist.
+- Create `tests/e2e/orchestrator-config.yml` that deserializes cleanly into `OrchestratorConfig`.
+- The `agents` array must contain entries for the five seed agents (excluding `orchestrator` itself): `echo`, `skill-writer`, `cogs-analyst`, `tool-coder`, and `deploy-agent`.
+- Each agent entry must have:
+  - `name`: matching the skill file's `name` field exactly.
+  - `description`: a concise sentence describing the agent's capability, suitable for semantic routing.
+  - `url`: a docker-compose service URL using the pattern `http://<service-name>:8080` where `<service-name>` matches the agent name (with hyphens for multi-word names). Port 8080 is the conventional agent-runtime HTTP port.
+- Include `similarity_threshold: 0.8` as a reasonable default for semantic routing in E2E tests.
+- Do NOT include `embedding_provider` or `embedding_model` -- these are optional and will be configured via environment variables in docker-compose if needed.
+
+## Implementation Details
+
+### Files to create
+
+1. **`tests/e2e/orchestrator-config.yml`** with the following content:
+
+   ```yaml
+   agents:
+     - name: echo
+       description: "Echoes input back for testing"
+       url: "http://echo:8080"
+
+     - name: skill-writer
+       description: "Produces validated skill files from plain-language descriptions"
+       url: "http://skill-writer:8080"
+
+     - name: cogs-analyst
+       description: "Analyzes cost-of-goods-sold data and produces financial reports"
+       url: "http://cogs-analyst:8080"
+
+     - name: tool-coder
+       description: "Generates MCP tool implementations from specifications"
+       url: "http://tool-coder:8080"
+
+     - name: deploy-agent
+       description: "Handles deployment workflows and infrastructure provisioning"
+       url: "http://deploy-agent:8080"
+
+   similarity_threshold: 0.8
+   ```
+
+### Files NOT modified by this task
+
+- `crates/orchestrator/src/config.rs` -- no schema changes needed.
+- `docker-compose.yml` -- service definitions are a separate task that this spec blocks.
+
+### Key design decisions
+
+- **Agent descriptions match skill frontmatter:** The `description` values are drawn from each skill's frontmatter `description` field to ensure consistency between the skill definitions and the orchestrator's routing metadata.
+- **Docker-compose service names as hostnames:** In a docker-compose network, service names resolve as DNS hostnames. The URL pattern `http://<service-name>:8080` assumes each agent runs as a separate docker-compose service on port 8080, which is the standard port used by `agent-runtime`.
+- **Orchestrator excluded from agents list:** The orchestrator is the router, not a routable target. Including it would create a self-referential routing loop.
+- **Similarity threshold at 0.8:** A threshold of 0.8 is strict enough to avoid false routing in E2E tests while permitting reasonable semantic matches. This can be tuned later based on test results.
+- **No embedding config in YAML:** Embedding provider and model are environment-specific settings better suited to environment variables or docker-compose env files, not a static config committed to the repo.
+
+## Dependencies
+
+- Blocked by: Nothing (can be created independently).
+- Blocking: docker-compose setup (needs to know the agent service names and config file location).
+
+## Risks & Edge Cases
+
+- **Port mismatch:** If agent-runtime binds to a port other than 8080, all URLs in this config will be wrong. Mitigation: confirm the default port in agent-runtime's `main.rs` or config during implementation. Adjust if needed.
+- **Service name mismatch with docker-compose:** The service names used here (`echo`, `skill-writer`, `cogs-analyst`, `tool-coder`, `deploy-agent`) must exactly match the service names defined in the docker-compose file. Any discrepancy will cause DNS resolution failures at runtime. The docker-compose task should reference this config file as the source of truth for service naming.
+- **YAML parsing strictness:** `serde_yaml` will reject unknown fields by default unless `#[serde(deny_unknown_fields)]` is absent (it is absent on `OrchestratorConfig`). Extra whitespace or comments are fine. However, any typos in field names (e.g., `agent` instead of `agents`) will cause deserialization to fail.
+- **Trailing slashes on URLs:** The `AgentEndpoint::new()` constructor trims trailing slashes, so `http://echo:8080/` and `http://echo:8080` are equivalent. The config uses the no-trailing-slash form for consistency.
+
+## Verification
+
+- `tests/e2e/orchestrator-config.yml` exists and is valid YAML.
+- The file contains exactly five agent entries with names: `echo`, `skill-writer`, `cogs-analyst`, `tool-coder`, `deploy-agent`.
+- Each entry has all three required fields: `name`, `description`, `url`.
+- The `similarity_threshold` field is present and set to `0.8`.
+- No `embedding_provider` or `embedding_model` fields are present.
+- The file can be loaded by `OrchestratorConfig::from_file("tests/e2e/orchestrator-config.yml")` without error (verifiable once the crate is available in a test harness).

--- a/.claude/specs/issue-22/define-the-test-scenario-document.md
+++ b/.claude/specs/issue-22/define-the-test-scenario-document.md
@@ -1,0 +1,175 @@
+# Spec: Define the test scenario document
+
+> From: issue #22
+
+## Objective
+
+Create `tests/e2e/SCENARIO.md`, a test scenario document that defines the temperature-conversion agent as the canonical end-to-end test case for the Spore pipeline. The document specifies the natural-language input, the expected outputs at each pipeline stage (skill-writer, tool-coder, deploy-agent, orchestrator), and the success criteria validators must check. This file is the single source of truth that step validators and the E2E test script depend on.
+
+## Current State
+
+- The `tests/e2e/` directory does not exist yet; it must be created along with the scenario file.
+- The Spore pipeline consists of four agents executed in sequence:
+  1. **skill-writer** -- accepts a plain-language description and produces a validated skill file (markdown with YAML frontmatter). Output: `{ skill_yaml: string, validation_result: string }`.
+  2. **tool-coder** -- accepts a skill file or tool list and generates Rust MCP tool crate(s). Output: `{ tools_generated: string, compilation_result: string, implementation_paths: string }`.
+  3. **deploy-agent** -- packages the runtime binary and skill file into a Docker image, pushes to a registry, and registers with the orchestrator. Output: `{ image_uri: string, endpoint_url: string, health_check: string }`.
+  4. **orchestrator** -- routes incoming requests to the best-matching agent. Output: `{ target_agent: string, reasoning: string }`.
+- The `/invoke` API (`POST /invoke`) accepts `AgentRequest { id: Uuid, input: String, context: Option<Value>, caller: Option<String> }` and returns `AgentResponse { id: Uuid, output: Value, confidence: f32, escalated: bool, escalate_to: Option<String>, tool_calls: Vec<ToolCallRecord> }`.
+- The `SkillManifest` struct has 8 fields: `name`, `version`, `description`, `model` (ModelConfig), `preamble`, `tools` (Vec<String>), `constraints` (Constraints), `output` (OutputSchema).
+
+## Requirements
+
+- The scenario document must be a markdown file at `tests/e2e/SCENARIO.md`.
+- It must define the **seed input**: a natural-language prompt describing a temperature-conversion agent (e.g., "Create an agent that converts temperatures between Celsius, Fahrenheit, and Kelvin").
+- It must specify expected outputs and success criteria for each of the four pipeline stages, structured so that automated validators can reference specific field names and value patterns.
+- It must define the expected **skill file structure**: the SkillManifest fields and their expected values or value patterns for a temperature-conversion skill.
+- It must define the expected **MCP tool**: the tool name, its request schema (input parameters), and its output behavior.
+- It must be purely a specification document -- no executable code, no implementation.
+- The document must be usable as a reference by both human reviewers and automated test scripts.
+
+## Implementation Details
+
+### File to create
+
+**`tests/e2e/SCENARIO.md`**
+
+The document should contain the following sections:
+
+#### 1. Overview
+
+Brief description of the test scenario: a single natural-language request flows through the full Spore pipeline to produce a deployed temperature-conversion agent.
+
+#### 2. Seed Input
+
+The exact `AgentRequest.input` string to feed into the pipeline:
+
+```
+Create an agent that converts temperatures between Celsius, Fahrenheit, and Kelvin
+```
+
+The full `AgentRequest` payload:
+- `id`: auto-generated UUID
+- `input`: the seed string above
+- `context`: `null`
+- `caller`: `null`
+
+#### 3. Stage 1: skill-writer
+
+**Input**: The seed input string.
+
+**Expected skill file structure** (SkillManifest fields):
+- `name`: `"temperature-converter"` (or close variant like `"temp-converter"`)
+- `version`: a quoted string, e.g., `"0.1"`
+- `description`: contains the words "temperature" and "convert" (case-insensitive)
+- `model.provider`: `"anthropic"`
+- `model.name`: a valid model identifier (non-empty string)
+- `model.temperature`: a float between 0.0 and 1.0
+- `tools`: list containing exactly one tool name: `"convert_temperature"`
+- `constraints.max_turns`: integer > 0
+- `constraints.confidence_threshold`: float in [0.0, 1.0]
+- `constraints.allowed_actions`: non-empty list
+- `output.format`: one of `"json"`, `"structured_json"`, or `"text"`
+- `output.schema`: non-empty map with at least a result field
+- `preamble`: non-empty string containing behavioral instructions
+
+**Success criteria**:
+- `validation_result` indicates no errors
+- The skill YAML parses into a valid `SkillManifest`
+- All 9 validation rules from the skill-writer spec pass (required non-empty strings, confidence range, max turns positive, tool existence, output format validity, version quoting, no standalone triple-dash in preamble)
+
+#### 4. Stage 2: tool-coder
+
+**Input**: The skill file produced by Stage 1 (specifically the `tools` list: `["convert_temperature"]`).
+
+**Expected tool crate structure**:
+- Crate directory: `tools/convert-temperature/`
+- Files: `Cargo.toml`, `src/main.rs`, `src/convert_temperature.rs`, `README.md`
+- `Cargo.toml` dependencies: `rmcp`, `tokio`, `serde`, `serde_json`, `tracing`, `tracing-subscriber`
+- Request struct fields: at minimum `value: f64`, `from_unit: String`, `to_unit: String` (or equivalent)
+- Tool method: `#[tool(description = "...")]` annotated method that performs the conversion
+- The tool implements the MCP `ServerHandler` trait
+
+**Expected tool behavior**:
+- Converts between Celsius (C), Fahrenheit (F), and Kelvin (K)
+- Formulas: C-to-F = C * 9/5 + 32, F-to-C = (F - 32) * 5/9, C-to-K = C + 273.15, K-to-C = K - 273.15
+- Returns a string representation of the converted value
+
+**Success criteria**:
+- `tools_generated` contains `"convert_temperature"`
+- `compilation_result` is `"success"` (the crate compiles with `cargo build -p convert-temperature`)
+- `implementation_paths` contains `"tools/convert-temperature"`
+- The generated crate follows the MCP tool implementation pattern (two-file structure with tool_router and tool_handler macros)
+
+#### 5. Stage 3: deploy-agent
+
+**Input**: The skill name `"temperature-converter"` and version from Stage 1.
+
+**Expected outputs**:
+- `image_uri`: matches pattern `{REGISTRY_URL}/spore-temperature-converter:{version}`
+- `endpoint_url`: a valid HTTP URL (e.g., `http://temperature-converter:8080`)
+- `health_check`: `"healthy"`
+
+**Success criteria**:
+- Docker image builds successfully (two-stage build, final image FROM scratch)
+- Image is tagged following the `spore-{name}:{version}` convention
+- Image is pushed to the registry
+- Agent is registered with the orchestrator via `register_agent`
+- Health endpoint (`GET /health`) returns 200 OK with `status: "Healthy"`
+
+#### 6. Stage 4: orchestrator
+
+**Input**: A user request routed through the orchestrator, e.g.:
+```
+Convert 100 degrees Celsius to Fahrenheit
+```
+
+**Expected outputs**:
+- `target_agent`: `"temperature-converter"`
+- `reasoning`: non-empty string explaining why this agent was selected
+
+**Success criteria**:
+- The orchestrator identifies the temperature-converter agent via `list_agents`
+- Routes the request to the correct agent with confidence >= 0.9
+- The routed request reaches the deployed agent and returns the correct conversion result (212 degrees Fahrenheit)
+
+#### 7. End-to-End Success Criteria
+
+The full pipeline passes if and only if all four stages pass their individual success criteria AND:
+- The pipeline completes without any escalation (`escalated: false` at each stage)
+- No `AgentError` variants are returned at any stage
+- The final output contains the correct temperature conversion result
+- Total pipeline latency is recorded (no hard threshold, but logged for regression tracking)
+
+#### 8. Validator Reference Table
+
+A summary table mapping each stage to its validator script (to be implemented) and the key assertions:
+
+| Stage | Validator | Key Assertions |
+|---|---|---|
+| skill-writer | `validate_skill_output.rs` | valid SkillManifest, tool name = `convert_temperature`, no validation errors |
+| tool-coder | `validate_tool_output.rs` | crate compiles, correct file structure, MCP pattern followed |
+| deploy-agent | `validate_deploy_output.rs` | image built, health check healthy, agent registered |
+| orchestrator | `validate_routing.rs` | correct target agent, confidence >= threshold, correct final answer |
+
+## Dependencies
+
+- Blocked by: nothing (this is a specification document with no code dependencies)
+- Blocking: step validators (`validate_skill_output.rs`, `validate_tool_output.rs`, `validate_deploy_output.rs`, `validate_routing.rs`) and the E2E test script -- these will reference the scenario document for expected values and success criteria
+
+## Risks & Edge Cases
+
+- **Skill name variability**: The skill-writer LLM may produce a name like `temp-converter` instead of `temperature-converter`. The scenario document should specify an acceptable pattern (contains "temp" and "convert") rather than requiring an exact string, while noting that downstream stages depend on the actual name produced.
+- **Tool name variability**: Similarly, the tool could be named `temperature_converter` instead of `convert_temperature`. The document should specify the expected name but note that validators should accept reasonable variants.
+- **Formula precision**: Floating-point conversion results may differ slightly. Validators should use approximate equality (epsilon = 0.01) rather than exact comparison.
+- **Deployment environment**: Stage 3 (deploy-agent) requires Docker. The scenario document should note that the E2E test may skip Stage 3 in environments without Docker access, falling back to a mock deployment validator.
+- **Orchestrator agent discovery**: Stage 4 depends on the temperature-converter agent being registered. If Stage 3 is skipped, the orchestrator test must use a pre-seeded agent registry.
+
+## Verification
+
+- The file `tests/e2e/SCENARIO.md` exists and is valid markdown.
+- The document covers all four pipeline stages with explicit success criteria.
+- The seed input is a concrete string (not a placeholder).
+- Expected SkillManifest field values are specified with enough precision for automated validation.
+- Expected tool crate structure matches the MCP tool implementation pattern from `tool-coder.md`.
+- The validator reference table lists all four validators with their key assertions.
+- A human reviewer can read the document and understand exactly what the E2E test should verify at each stage.

--- a/.claude/specs/issue-22/run-verification-suite.md
+++ b/.claude/specs/issue-22/run-verification-suite.md
@@ -1,0 +1,94 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-22.md
+
+## Objective
+Verify that all new and existing code compiles cleanly, passes linting without warnings, and all tests pass. Confirm shell scripts are executable. Validate the docker-compose E2E configuration file syntax. Do NOT run the full E2E test.
+
+## Current State
+The workspace at `/workspaces/spore/Cargo.toml` contains six members: `agent-sdk`, `skill-loader`, `tool-registry`, `agent-runtime`, `orchestrator`, and `echo-tool`. By the time this task runs, all prior issue-22 tasks will have added:
+- `docker-compose.e2e.yml` at the project root
+- `tests/e2e/SCENARIO.md`
+- `tests/e2e/orchestrator-config.yml`
+- `tests/e2e/validate_step1_skill.sh`
+- `tests/e2e/validate_step2_tools.sh`
+- `tests/e2e/validate_step3_deploy.sh`
+- `tests/e2e/validate_step4_route.sh`
+- `scripts/e2e-test.sh`
+- `tests/e2e_bootstrap_test.rs`
+- Updates to `README.md`
+
+Shell scripts live under `scripts/`, `tests/e2e/`, and `.claude/hooks/`.
+
+## Requirements
+- `cargo check` (full workspace) exits with code 0.
+- `cargo clippy` (full workspace) exits with code 0 with warnings treated as errors.
+- `cargo test` (full workspace) exits with code 0 with all non-`#[ignore]` tests passing.
+- All shell scripts (`*.sh`) under `scripts/`, `tests/e2e/`, and `.claude/hooks/` have the executable bit set.
+- `docker compose -f docker-compose.e2e.yml config` exits with code 0, confirming valid compose syntax.
+- Any failures must be diagnosed and fixed before the task is marked complete.
+
+## Implementation Details
+Run the following commands in order. Each must succeed before proceeding to the next.
+
+1. **Type-check the full workspace**
+   ```
+   cargo check
+   ```
+   Expected: clean exit, no errors across all workspace members.
+
+2. **Lint the full workspace with clippy**
+   ```
+   cargo clippy -- -D warnings
+   ```
+   Expected: clean exit, zero warnings. The `-D warnings` flag promotes warnings to errors so the command fails if any lint fires.
+
+3. **Run full workspace tests**
+   ```
+   cargo test
+   ```
+   Expected: all compiled test binaries run, all non-ignored tests pass. Tests marked `#[ignore]` (e.g., the E2E wrapper requiring Docker and API keys) are skipped automatically and do not count as failures.
+
+4. **Verify shell scripts are executable**
+   ```
+   for f in scripts/e2e-test.sh tests/e2e/validate_step1_skill.sh tests/e2e/validate_step2_tools.sh tests/e2e/validate_step3_deploy.sh tests/e2e/validate_step4_route.sh; do
+     test -x "$f" || { echo "FAIL: $f is not executable"; exit 1; }
+   done
+   echo "All shell scripts are executable."
+   ```
+   Expected: all listed scripts have the executable bit set. If any script is missing the executable bit, fix it with `chmod +x <file>` and re-verify.
+
+5. **Validate docker-compose configuration (dry run)**
+   ```
+   docker compose -f docker-compose.e2e.yml config
+   ```
+   Expected: the command parses and resolves the compose file, printing the fully resolved YAML to stdout and exiting with code 0. This catches syntax errors, invalid service definitions, missing required fields, and unresolved variable references without starting any containers.
+
+If any step fails:
+- Read the error output carefully.
+- Diagnose the root cause (type error, missing import, failing assertion, clippy lint, permission issue, YAML syntax error, etc.).
+- Fix the issue in the appropriate file.
+- Re-run from step 1 to confirm the fix does not introduce new problems.
+
+## Dependencies
+- Blocked by: "Define the test scenario document", "Create `docker-compose.e2e.yml`", "Create orchestrator config file for E2E", "Write step 1 validator", "Write step 2 validator", "Write step 3 validator", "Write step 4 validator", "Write the E2E shell script orchestrator", "Add Rust integration test wrapper", "Write README section for E2E testing"
+- Blocking: none (this is the final task in issue-22)
+
+## Risks & Edge Cases
+- **Docker not installed**: The `docker compose config` command requires Docker to be installed on the machine. If Docker is unavailable, this step should be skipped with a warning rather than failing the entire verification. Check for `docker` in `$PATH` before running step 5.
+- **Clippy version drift**: Different Rust toolchain versions may introduce new clippy lints. If a new lint fires that is clearly a false positive or stylistic disagreement, suppress it with an `#[allow(...)]` attribute and a comment explaining why, rather than restructuring code.
+- **Ignored tests miscounted as failures**: `cargo test` does not fail on `#[ignore]` tests by default. The E2E wrapper test should be `#[ignore]` and optionally gated behind `#[cfg(feature = "e2e")]`. Verify it does not run during normal `cargo test`.
+- **Shell script paths**: The script list in step 4 is based on expected files from prior tasks. If a file was created at a different path, adjust the check accordingly.
+- **Compose file variable resolution**: The compose file may reference environment variables (e.g., `SKILL_NAME`). `docker compose config` resolves these using defaults or `.env` files. If variables are unset and have no defaults, the command will fail. Ensure all variables have default values in the compose file or in a `.env` file.
+
+## Pass/Fail Criteria
+- PASS: All five steps exit with code 0 (or step 5 is skipped with a documented reason).
+- FAIL: Any step exits non-zero and the root cause cannot be resolved by fixing project files.
+
+## Verification
+- `cargo check` exits with code 0.
+- `cargo clippy -- -D warnings` produces no output other than compilation and "Finished" lines.
+- `cargo test` summary line shows 0 failures across all crates (ignored tests are acceptable).
+- Every `*.sh` file under `scripts/` and `tests/e2e/` is executable.
+- `docker compose -f docker-compose.e2e.yml config` exits with code 0 (or is skipped if Docker is unavailable).
+- No source files were left with commented-out code or debug `println!` statements as part of fixes.

--- a/.claude/specs/issue-22/write-readme-section-for-e2e-testing.md
+++ b/.claude/specs/issue-22/write-readme-section-for-e2e-testing.md
@@ -1,0 +1,136 @@
+# Spec: Write README section for E2E testing
+
+> From: .claude/tasks/issue-22.md
+
+## Objective
+
+Add a new section to `README.md` that documents how to run the end-to-end self-bootstrapping pipeline test. The section should cover prerequisites, commands, expected runtime, debugging guidance, the `--no-cleanup` flag, and cost considerations.
+
+## Current State
+
+### README.md
+
+The README currently has the following top-level sections in order:
+
+1. Why
+2. How It Works
+3. Architecture
+4. Self-Bootstrapping Factory
+5. Tech Stack
+6. Docker (with subsections: Build, Run, Image Size, Environment Variables, Debugging)
+7. Key Properties
+8. Analogy
+9. License
+
+There is no mention of testing, E2E validation, or the self-bootstrapping pipeline test anywhere in the README.
+
+### E2E infrastructure (created by prior tasks)
+
+- `scripts/e2e-test.sh` -- top-level shell script test driver with `--no-cleanup` and `--timeout` flags
+- `docker-compose.e2e.yml` -- multi-container test environment definition
+- `tests/e2e/SCENARIO.md` -- test scenario document (temperature-conversion agent)
+- `tests/e2e/validate_step{1-4}_*.sh` -- per-step validators
+- `tests/e2e_bootstrap_test.rs` -- Rust integration test wrapper gated behind `#[ignore]` and `#[cfg(feature = "e2e")]`
+
+## Requirements
+
+- Add a new `## E2E Testing` section to `README.md`.
+- Insert it after the `Docker` section (after the `Debugging` subsection, before `Key Properties`). This placement groups all operational/runtime concerns together.
+- The section must cover the following subsections:
+
+### Prerequisites subsection
+
+Document what is needed before running the E2E test:
+- Docker and Docker Compose installed and running
+- A valid `ANTHROPIC_API_KEY` environment variable (the seed agents use Anthropic models)
+- Sufficient API credits (see Cost Considerations below)
+- All project crates building successfully (`cargo build`)
+
+### Running the test subsection
+
+Document two ways to run the E2E test:
+
+1. **Shell script directly**: `./scripts/e2e-test.sh`
+2. **Via cargo**: `cargo test --features e2e -- --ignored e2e_bootstrap_test`
+
+Note that the cargo approach requires the `e2e` feature flag and the `--ignored` flag since the test is marked `#[ignore]`.
+
+### Expected runtime subsection
+
+State that the full pipeline takes approximately 5-10 minutes. Factors that affect runtime: Docker image build time, LLM response latency, and tool compilation. The `--timeout` flag on the shell script controls the overall timeout (default: 10 minutes).
+
+### Debugging failures subsection
+
+Document the debugging workflow:
+- All intermediate artifacts are saved to `tests/e2e/artifacts/` (generated skill file, tool code, step responses, Docker build logs)
+- On failure, the script automatically dumps container logs
+- Use the `--no-cleanup` flag (`./scripts/e2e-test.sh --no-cleanup`) to keep Docker containers running after the test finishes, enabling manual inspection with `docker compose -f docker-compose.e2e.yml logs <service>` and direct `curl` calls against the running services
+- Each step's output can be examined independently in the artifacts directory
+
+### Cost considerations subsection
+
+Document that each E2E run makes multiple LLM API calls:
+- Minimum 4 calls: skill-writer, tool-coder, deploy-agent, and the generated temperature-agent
+- With retries (e.g., tool-coder may retry up to 3 times if generated code fails to compile), this could be 8-12 calls per run
+- Advise running the E2E test deliberately rather than as part of routine development iteration
+
+## Implementation Details
+
+### Files to modify
+
+**`README.md`**
+
+Insert a new `## E2E Testing` section between the existing `### Debugging` subsection (line 184, end of Docker section) and the `## Key Properties` section (line 186). The new section should use the following structure:
+
+```
+## E2E Testing
+
+<brief intro paragraph explaining what the E2E test validates: the full self-bootstrapping pipeline from natural language description to a running, routable agent>
+
+### Prerequisites
+
+<bulleted list>
+
+### Running the Test
+
+<two approaches with code blocks>
+
+### Expected Runtime
+
+<paragraph>
+
+### Debugging Failures
+
+<bulleted list with code blocks for commands>
+
+### Cost Considerations
+
+<paragraph with bullet points>
+```
+
+### Style guidance
+
+- Match the existing README tone: concise, technical, no filler
+- Use code blocks for all commands
+- Use the same heading hierarchy as the Docker section (h2 for the section, h3 for subsections)
+- Keep the entire section under 60 lines of markdown to avoid bloating the README
+
+## Dependencies
+
+- Blocked by: "Add Rust integration test wrapper" (the cargo command and feature flag must exist before documenting them)
+- Blocking: None
+
+## Risks & Edge Cases
+
+- **Premature documentation**: Since this task is blocked by the Rust integration test wrapper, the documented cargo command (`cargo test --features e2e -- --ignored e2e_bootstrap_test`) must match whatever the wrapper task actually implements. If the feature name or test name changes, the README must be updated accordingly.
+- **Cost estimates may drift**: The "8-12 calls" estimate is based on the current pipeline design. If steps are added or retry logic changes, the cost section should be updated.
+- **No CI integration yet**: The README should not claim CI support since there is no `.github/workflows/` directory. Avoid mentioning CI pipelines.
+
+## Verification
+
+- `README.md` parses as valid markdown (no broken links, no unclosed code blocks).
+- The new section appears between `Docker` and `Key Properties`.
+- All six topics are covered: prerequisites, commands, runtime, debugging, `--no-cleanup` flag, cost considerations.
+- No new files are created -- this task only modifies `README.md`.
+- The section uses h2 (`##`) for the top-level heading and h3 (`###`) for subsections, consistent with the Docker section pattern.
+- The section is under 60 lines of markdown.

--- a/.claude/specs/issue-22/write-step-1-validator-skill-writer-invocation.md
+++ b/.claude/specs/issue-22/write-step-1-validator-skill-writer-invocation.md
@@ -1,0 +1,242 @@
+# Spec: Write step 1 validator — skill-writer invocation
+
+> From: .claude/tasks/issue-22.md
+
+## Objective
+
+Create `tests/e2e/validate_step1_skill.sh`, a shell script that POSTs an `AgentRequest` to the skill-writer agent's `/invoke` endpoint, validates that the response contains a well-formed skill file (valid YAML frontmatter with all required `SkillManifest` fields, at least one tool, non-empty preamble), and saves the extracted skill file to `tests/e2e/artifacts/generated-skill.md` for use by downstream pipeline steps.
+
+## Current State
+
+### `/invoke` endpoint (`crates/agent-runtime/src/http.rs`)
+
+The `POST /invoke` handler accepts a JSON `AgentRequest` body and returns a JSON `AgentResponse` (or an `AgentError` serialized as JSON with an appropriate HTTP status code).
+
+### AgentRequest (`crates/agent-sdk/src/agent_request.rs`)
+
+```rust
+pub struct AgentRequest {
+    pub id: Uuid,
+    pub input: String,
+    pub context: Option<Value>,
+    pub caller: Option<String>,
+}
+```
+
+### AgentResponse (`crates/agent-sdk/src/agent_response.rs`)
+
+```rust
+pub struct AgentResponse {
+    pub id: Uuid,
+    pub output: Value,
+    pub confidence: f32,
+    pub escalated: bool,
+    pub escalate_to: Option<String>,
+    pub tool_calls: Vec<ToolCallRecord>,
+}
+```
+
+The `output` field is a `serde_json::Value`. For the skill-writer agent, this is a JSON object with two keys (per the skill-writer's `output.schema`):
+- `skill_yaml`: `string` -- the complete skill file content in markdown-with-frontmatter format
+- `validation_result`: `string` -- description of the validation outcome
+
+### SkillManifest (`crates/agent-sdk/src/skill_manifest.rs`)
+
+```rust
+pub struct SkillManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub model: ModelConfig,       // sub-fields: provider, name, temperature
+    pub preamble: String,
+    pub tools: Vec<String>,
+    pub constraints: Constraints, // sub-fields: max_turns, confidence_threshold, escalate_to, allowed_actions
+    pub output: OutputSchema,     // sub-fields: format, schema
+}
+```
+
+The YAML frontmatter in a skill file contains all fields except `preamble`. The `preamble` is the markdown body after the closing `---` delimiter. Together they map to all 8 `SkillManifest` fields.
+
+### Required YAML frontmatter fields (from skill file format)
+
+The YAML block between `---` delimiters must contain these top-level keys:
+- `name` (String, non-empty)
+- `version` (String, must be quoted in YAML)
+- `description` (String)
+- `model` (object with `provider`, `name`, `temperature`)
+- `tools` (list of strings, at least one entry)
+- `constraints` (object with `max_turns`, `confidence_threshold`, `allowed_actions`, optional `escalate_to`)
+- `output` (object with `format`, `schema`)
+
+### Skill-writer output (`skills/skill-writer.md`)
+
+The skill-writer agent returns structured JSON with `skill_yaml` (the complete markdown-with-frontmatter skill file) and `validation_result` (a description of validation outcomes). The `skill_yaml` value is a string containing the full skill file content, starting with `---` and including the YAML frontmatter, closing `---`, and the markdown preamble body.
+
+### Test scenario (from `tests/e2e/SCENARIO.md`, defined by prerequisite)
+
+The scenario uses a temperature-conversion agent. The natural language input is: "An agent that converts temperatures between Fahrenheit, Celsius, and Kelvin". The validator must not check for exact content (due to LLM non-determinism) but must validate structural correctness.
+
+## Requirements
+
+1. **Create `tests/e2e/validate_step1_skill.sh`** as an executable Bash script.
+
+2. **Accept the skill-writer base URL** via the `SKILL_WRITER_URL` environment variable, defaulting to `http://skill-writer:8080` (the docker-compose service name). This allows running the script both inside the docker-compose network and against a manually started service.
+
+3. **Construct an `AgentRequest` JSON body** with:
+   - `id`: a valid UUID v4 (generate via `uuidgen` or a hardcoded test UUID)
+   - `input`: the natural language description from the scenario ("An agent that converts temperatures between Fahrenheit, Celsius, and Kelvin")
+   - `context`: `null`
+   - `caller`: `"e2e-test"`
+
+4. **POST to `${SKILL_WRITER_URL}/invoke`** using `curl`:
+   - Set `Content-Type: application/json`
+   - Use a generous timeout (120 seconds minimum) since the LLM call may be slow
+   - Capture the HTTP status code and response body separately
+   - Fail if the HTTP status is not 200
+
+5. **Parse the `AgentResponse` JSON** using `jq`:
+   - Extract `.output.skill_yaml` as the raw skill file content string
+   - Fail if `.output.skill_yaml` is null or empty
+   - Optionally log `.output.validation_result` for debugging
+
+6. **Validate the extracted skill file** by parsing its structure. Validations (all structural, not content-exact):
+
+   a. **YAML frontmatter is parseable**: The content starts with `---`, contains a second `---` delimiter, and the text between them is valid YAML. Use a lightweight YAML check (e.g., pipe to `python3 -c "import yaml; yaml.safe_load(open('/dev/stdin'))"` or use `yq` if available).
+
+   b. **Required top-level YAML keys present**: The frontmatter YAML contains all 7 required keys: `name`, `version`, `description`, `model`, `tools`, `constraints`, `output`. Check using `yq` or equivalent YAML query tool.
+
+   c. **`name` is non-empty**: The `name` field is a non-empty, non-whitespace-only string.
+
+   d. **`version` is non-empty**: The `version` field is a non-empty string.
+
+   e. **`model` has required sub-fields**: `model.provider` and `model.name` are present and non-empty.
+
+   f. **`tools` has at least one entry**: The `tools` field is a YAML list with length >= 1.
+
+   g. **`constraints` has required sub-fields**: `constraints.max_turns` and `constraints.confidence_threshold` are present. `constraints.allowed_actions` is a non-empty list.
+
+   h. **`output` has required sub-fields**: `output.format` is present and is one of `json`, `structured_json`, or `text`. `output.schema` is present and non-empty.
+
+   i. **Preamble is non-empty**: The markdown body after the closing `---` delimiter is non-empty and not whitespace-only.
+
+7. **Save the skill file** to `tests/e2e/artifacts/generated-skill.md`. Create the `artifacts/` directory if it does not exist.
+
+8. **Exit codes and output**:
+   - Exit 0 on success, printing a summary of what was validated.
+   - Exit non-zero on any validation failure, printing the specific failure reason to stderr.
+   - Print the full `AgentResponse` JSON to a log file at `tests/e2e/artifacts/step1-response.json` for debugging.
+
+9. **Script conventions**:
+   - Use `set -euo pipefail` at the top.
+   - Use `#!/usr/bin/env bash` as the shebang line.
+   - Define a helper function for each validation check to keep the main flow readable.
+   - Each helper function should print a check name, run the check, and print PASS/FAIL.
+   - Keep functions under 50 lines per project rules.
+
+## Implementation Details
+
+### File to create
+
+**`tests/e2e/validate_step1_skill.sh`**
+
+The script follows this high-level flow:
+
+1. **Setup**: Set `SKILL_WRITER_URL` default, define `ARTIFACTS_DIR` as `tests/e2e/artifacts`, create the artifacts directory with `mkdir -p`, define `SCRIPT_DIR` using `dirname` for path portability.
+
+2. **Helper: `fail()`**: Print the message to stderr and exit 1. Used by all validation helpers.
+
+3. **Helper: `check_http_response()`**: Run `curl` with `--silent --show-error --max-time 120 --write-out "%{http_code}"` to POST the `AgentRequest`. Capture HTTP status code and body. Fail if status is not `200`. Save response body to `${ARTIFACTS_DIR}/step1-response.json`.
+
+4. **Helper: `extract_skill_yaml()`**: Use `jq -r '.output.skill_yaml'` to extract the skill file content from the response JSON. Fail if the result is null or empty. Save to `${ARTIFACTS_DIR}/generated-skill.md`.
+
+5. **Helper: `extract_frontmatter()`**: Given the skill file content, extract the YAML between the first and second `---` delimiters. Use `sed` or `awk` to isolate the frontmatter block. Save to a temp file for subsequent YAML queries.
+
+6. **Helper: `validate_yaml_parseable()`**: Attempt to parse the extracted frontmatter as YAML. Use `python3 -c "import sys, yaml; yaml.safe_load(sys.stdin)"` or `yq eval '.' -` to verify it is valid YAML. Fail with an error message if parsing fails.
+
+7. **Helper: `validate_required_keys()`**: Check that each of the 7 required top-level keys (`name`, `version`, `description`, `model`, `tools`, `constraints`, `output`) exists in the YAML. Use `yq` to query each key and fail if any returns null.
+
+8. **Helper: `validate_non_empty_strings()`**: Check that `name` and `version` are non-empty strings. Use `yq` to extract each value and test it is not empty or whitespace-only.
+
+9. **Helper: `validate_model_config()`**: Check that `model.provider` and `model.name` exist and are non-empty.
+
+10. **Helper: `validate_tools()`**: Check that `tools` is a list and has at least one entry. Use `yq eval '.tools | length'` and assert the result is >= 1.
+
+11. **Helper: `validate_constraints()`**: Check that `constraints.max_turns`, `constraints.confidence_threshold`, and `constraints.allowed_actions` are present. Verify `allowed_actions` is a non-empty list.
+
+12. **Helper: `validate_output_schema()`**: Check that `output.format` is one of `json`, `structured_json`, or `text`. Check that `output.schema` is present and non-empty (has at least one key).
+
+13. **Helper: `validate_preamble()`**: Extract the content after the second `---` delimiter from the skill file. Trim whitespace and fail if the result is empty.
+
+14. **Main flow**: Call each helper in sequence, printing a status line for each check (e.g., `[PASS] YAML frontmatter is parseable`). On success, print a summary line: `Step 1 validation PASSED: skill file saved to ${ARTIFACTS_DIR}/generated-skill.md`.
+
+### External tool dependencies
+
+The script requires these tools, all standard in a Docker-based CI environment:
+- `bash` (4.x+)
+- `curl` (for HTTP requests)
+- `jq` (for JSON parsing)
+- `yq` (for YAML parsing -- Mike Farah's `yq` v4+; alternatively fall back to `python3` with PyYAML)
+- `uuidgen` (for generating the request UUID; from `uuid-runtime` package, or use a hardcoded UUID)
+
+The script should check for the presence of `jq` and `yq` (or `python3`) at startup and fail early with a clear error message if missing.
+
+### Sample `AgentRequest` payload
+
+```json
+{
+  "id": "<uuid>",
+  "input": "An agent that converts temperatures between Fahrenheit, Celsius, and Kelvin",
+  "context": null,
+  "caller": "e2e-test"
+}
+```
+
+### Sample expected `AgentResponse` structure (illustrative, not exact)
+
+```json
+{
+  "id": "<uuid>",
+  "output": {
+    "skill_yaml": "---\nname: temperature-converter\nversion: \"1.0\"\ndescription: Converts temperatures...\nmodel:\n  provider: anthropic\n  name: claude-sonnet-4-6\n  temperature: 0.2\ntools:\n  - convert_temperature\nconstraints:\n  max_turns: 5\n  confidence_threshold: 0.9\n  allowed_actions:\n    - read\n    - query\noutput:\n  format: structured_json\n  schema:\n    result: string\n---\nYou are a temperature conversion agent...\n",
+    "validation_result": "All checks passed."
+  },
+  "confidence": 0.95,
+  "escalated": false,
+  "tool_calls": [...]
+}
+```
+
+The validator must NOT check for specific values (like `temperature-converter` or `convert_temperature`) since LLM output is non-deterministic. Only structural validity matters.
+
+## Dependencies
+
+- **Blocked by**: "Define the test scenario document" (`tests/e2e/SCENARIO.md`) -- provides the agreed-upon input description and success criteria.
+- **Blocking**: "Write the E2E shell script orchestrator" (`scripts/e2e-test.sh`) -- calls this script as step 1 of the pipeline.
+
+## Risks & Edge Cases
+
+1. **`yq` availability**: Not all environments have `yq` installed. The script should attempt `yq` first and fall back to `python3 -c "import yaml; ..."` if `yq` is not available. If neither is available, fail early with an installation hint.
+
+2. **LLM non-determinism**: The skill-writer may produce different field values, different tool names, or different preamble text on each run. The validator must check only structural properties (key presence, type, non-emptiness), never exact values.
+
+3. **`skill_yaml` escaping**: The `skill_yaml` value is a string inside JSON. `jq -r` will unescape it, but the script must handle the case where the string contains embedded newlines, quotes, or special characters. Using `jq -r` to extract and piping directly to a file handles this correctly.
+
+4. **Frontmatter delimiter edge cases**: The skill file format specification (validation rule 9) forbids standalone `---` lines in the preamble. However, the validator should be robust against unexpected `---` lines: use only the first and second `---` occurrences to delimit the frontmatter, treating everything after the second `---` as preamble regardless of content.
+
+5. **Empty or error responses**: The skill-writer may return a non-200 HTTP status (e.g., 500 for internal errors, 422 for max turns exceeded). The script must handle these gracefully, printing the HTTP status and response body before exiting non-zero.
+
+6. **Large response bodies**: The `skill_yaml` string could be large if the LLM generates a verbose preamble. This is not a concern for `jq` or file I/O but the script should not attempt to pass the content as a shell variable for string comparison; use temp files instead.
+
+7. **`output` field structure**: The `AgentResponse.output` is `serde_json::Value`, so its internal structure depends on the agent. If the skill-writer returns `output` as a raw string instead of a JSON object (e.g., if the LLM does not follow the structured output schema), the `jq` extraction `.output.skill_yaml` will return null. The script should detect this and print a helpful error indicating the output structure was unexpected.
+
+8. **Timeout**: LLM inference can take 30-60+ seconds. The `curl` timeout of 120 seconds provides headroom. If the request times out, `curl` exits non-zero and the script should report a timeout rather than a parse error.
+
+## Verification
+
+1. The script file exists at `tests/e2e/validate_step1_skill.sh` and is executable (`chmod +x`).
+2. `bash -n tests/e2e/validate_step1_skill.sh` succeeds (syntax check, no parse errors).
+3. The script uses `set -euo pipefail` for strict error handling.
+4. All helper functions are under 50 lines.
+5. The script checks for required external tools (`curl`, `jq`, `yq`/`python3`) at startup.
+6. Running the script without a reachable skill-writer service produces a clear connection error (not a cryptic parse failure).
+7. The artifacts directory path and file names match what downstream scripts expect: `tests/e2e/artifacts/generated-skill.md` for the skill file and `tests/e2e/artifacts/step1-response.json` for the raw response.

--- a/.claude/specs/issue-22/write-step-2-validator-tool-coder-invocation.md
+++ b/.claude/specs/issue-22/write-step-2-validator-tool-coder-invocation.md
@@ -1,0 +1,197 @@
+# Spec: Write step 2 validator — tool-coder invocation
+
+> From: .claude/tasks/issue-22.md
+
+## Objective
+
+Create `tests/e2e/validate_step2_tools.sh`, a shell script that validates the tool-coder pipeline stage. The script sends a previously generated skill file to the tool-coder agent's `/invoke` endpoint, validates that the response indicates successful compilation with non-empty tool output and valid implementation paths, and supports up to 3 retry attempts to account for LLM non-determinism.
+
+## Current State
+
+### Agent HTTP interface (`crates/agent-runtime/src/http.rs`)
+
+The agent-runtime exposes two endpoints:
+
+- `POST /invoke` — accepts `Json<AgentRequest>`, returns `Json<AgentResponse>` on success or a JSON-serialized `AgentError` on failure.
+- `GET /health` — returns `Json<HealthResponse>` with `name`, `version`, and `status` fields.
+
+### AgentRequest schema (`crates/agent-sdk/src/agent_request.rs`)
+
+```json
+{
+  "id": "<uuid>",
+  "input": "<string>",
+  "context": null | <json-value>,
+  "caller": null | "<string>"
+}
+```
+
+- `id` — UUID v4 identifying the request.
+- `input` — the primary input string (for step 2, this is the full contents of the generated skill file).
+- `context` — optional JSON value for additional context; may be `null`.
+- `caller` — optional string identifying the calling agent; may be `null`.
+
+### AgentResponse schema (`crates/agent-sdk/src/agent_response.rs`)
+
+```json
+{
+  "id": "<uuid>",
+  "output": <json-value>,
+  "confidence": <float>,
+  "escalated": <bool>,
+  "escalate_to": null | "<string>",
+  "tool_calls": [...]
+}
+```
+
+- `output` — a `serde_json::Value` containing the agent's structured output.
+- `confidence` — float between 0.0 and 1.0.
+- `escalated` — boolean indicating whether the agent escalated.
+
+### tool-coder output schema (`skills/tool-coder.md`)
+
+The tool-coder agent returns structured JSON in the `output` field with three string fields:
+
+- `tools_generated` — comma-separated list of tool names that were generated (e.g., `"convert_temperature"`). Empty string if no tools were needed.
+- `compilation_result` — summary of build outcome; contains `"success"` if all tools compiled, or compiler error output on failure.
+- `implementation_paths` — comma-separated list of filesystem paths where tool crates were written (e.g., `"tools/convert-temperature"`).
+
+### Artifact dependency
+
+Step 1 (`validate_step1_skill.sh`) saves the generated skill file to `tests/e2e/artifacts/generated-skill.md`. This script reads that file as its input.
+
+### E2E test architecture
+
+The E2E shell script orchestrator (`scripts/e2e-test.sh`) calls each step validator in sequence. Each validator is expected to:
+- Exit 0 on success, non-zero on failure.
+- Print diagnostic messages to stdout/stderr explaining pass/fail.
+- Save its response artifacts for downstream steps and debugging.
+
+## Requirements
+
+### Script behavior
+
+- The script must be a Bash script (`#!/usr/bin/env bash`) with `set -euo pipefail`.
+- Read the generated skill file from `tests/e2e/artifacts/generated-skill.md`. Exit with error if the file does not exist or is empty.
+- Construct an `AgentRequest` JSON payload with:
+  - `id` — a generated UUID v4 (use `uuidgen` or a fallback method).
+  - `input` — the full contents of the generated skill file.
+  - `context` — `null`.
+  - `caller` — `"e2e-test"`.
+- Send `POST` to `${TOOL_CODER_URL:-http://tool-coder:8080}/invoke` with `Content-Type: application/json`. Use an environment variable for the base URL so the script works both inside docker-compose (default) and in local testing.
+- Use a generous timeout for the HTTP request (at least 120 seconds per attempt) since the tool-coder must generate code, write files, and run `cargo build`.
+- On HTTP-level failure (non-2xx status or connection error), treat the attempt as failed.
+
+### Retry logic
+
+- Allow up to 3 attempts total (configurable via `${MAX_RETRIES:-3}`).
+- On each failed attempt, print the attempt number, failure reason, and the response body (if available).
+- Wait between retries with a short backoff (e.g., 5 seconds between attempts).
+- If all attempts fail, exit non-zero with a summary of all failures.
+
+### Response validation
+
+After receiving a 200 response, validate the following using `jq`:
+
+1. **HTTP status**: The response status code is 200.
+2. **`output.compilation_result` contains "success"**: Extract `.output.compilation_result` from the response JSON and check that it contains the substring `success` (case-insensitive). This accounts for variations like `"success"`, `"Build success"`, `"compilation success"`, etc.
+3. **`output.tools_generated` is non-empty**: Extract `.output.tools_generated` and verify it is a non-empty string (not `""`, not `null`).
+4. **`output.implementation_paths` lists valid paths**: Extract `.output.implementation_paths` and verify:
+   - It is a non-empty string (not `""`, not `null`).
+   - Each comma-separated entry starts with `tools/` (validating they are under the expected directory).
+
+If any validation check fails, the attempt counts as a failure (triggering a retry if attempts remain).
+
+### Artifact output
+
+- Save the raw response JSON to `tests/e2e/artifacts/step2-response.json` on each attempt (overwriting previous attempt).
+- On success, the final saved response is the successful one.
+
+### Output messages
+
+- Print a clear header at the start: `"=== Step 2: Tool-coder invocation ==="`.
+- On each attempt, print `"Attempt N/3..."`.
+- On validation failure, print which specific check failed and the actual value.
+- On final success, print `"Step 2 PASSED: tools generated and compiled successfully"` along with the tool names from `tools_generated`.
+- On final failure (all retries exhausted), print `"Step 2 FAILED: tool-coder did not produce valid output after N attempts"` and exit with code 1.
+
+## Implementation Details
+
+### File to create
+
+**`tests/e2e/validate_step2_tools.sh`**
+
+The script structure should follow this outline:
+
+1. **Header and setup** — shebang, `set -euo pipefail`, define constants (`ARTIFACTS_DIR`, `SKILL_FILE`, `RESPONSE_FILE`, `MAX_RETRIES`, `TOOL_CODER_URL`, `REQUEST_TIMEOUT`).
+
+2. **`generate_uuid` helper** — produce a UUID v4 using `uuidgen` if available, falling back to reading from `/proc/sys/kernel/random/uuid`, or constructing from random hex as a last resort. Keep this under 10 lines.
+
+3. **`validate_response` function** — accepts a file path to the response JSON, runs all three validation checks using `jq`, returns 0 on success or 1 on failure. Print which check failed. Keep this under 40 lines. Checks:
+   - Extract `compilation_result` from `.output.compilation_result`, verify it matches `success` (case-insensitive grep or jq `test`).
+   - Extract `tools_generated` from `.output.tools_generated`, verify non-empty and non-null.
+   - Extract `implementation_paths` from `.output.implementation_paths`, verify non-empty and that all comma-separated entries start with `tools/`.
+
+4. **Input validation** — verify `SKILL_FILE` exists and is non-empty.
+
+5. **Retry loop** — `for attempt in $(seq 1 "$MAX_RETRIES"); do ... done`. Each iteration:
+   - Build the JSON payload using `jq -n` with `--arg` for `input` (read from skill file) and `id` (from `generate_uuid`).
+   - Call `curl -s -w '\n%{http_code}' --max-time "$REQUEST_TIMEOUT" -X POST ...` to capture both the response body and HTTP status code.
+   - Parse out the HTTP status code from the last line.
+   - If status is not 200, print error and continue to next attempt.
+   - Save the response body to `RESPONSE_FILE`.
+   - Call `validate_response "$RESPONSE_FILE"`. If it returns 0, print success and exit 0.
+   - Otherwise, print failure details and sleep before the next attempt.
+
+6. **Final failure** — if the loop completes without success, print failure summary and `exit 1`.
+
+### Dependencies (CLI tools)
+
+- `bash` (4.0+)
+- `curl` — for HTTP requests
+- `jq` — for JSON construction and parsing
+- `uuidgen` or `/proc/sys/kernel/random/uuid` — for UUID generation
+
+No additional tools or dependencies are required.
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `TOOL_CODER_URL` | `http://tool-coder:8080` | Base URL of the tool-coder service |
+| `MAX_RETRIES` | `3` | Maximum number of attempts |
+| `REQUEST_TIMEOUT` | `120` | Curl timeout in seconds per attempt |
+| `ARTIFACTS_DIR` | `tests/e2e/artifacts` | Directory for input/output artifacts |
+
+## Dependencies
+
+- Blocked by: "Define the test scenario document" (provides the test scenario reference and establishes the artifact directory structure)
+- Blocking: "Write the E2E shell script orchestrator" (which calls this script as step 2 in the pipeline)
+
+## Risks & Edge Cases
+
+- **tool-coder `output` field structure**: The tool-coder output schema defines `tools_generated`, `compilation_result`, and `implementation_paths` as strings, but the `AgentResponse.output` field is `serde_json::Value`. The tool-coder agent should produce a JSON object at `.output` with these three string fields. If the agent wraps them differently (e.g., nested under another key, or returns the whole thing as a string), the `jq` extraction paths will need adjustment. The validation should log the raw `.output` value on failure to aid debugging.
+
+- **LLM non-determinism in `compilation_result`**: The tool-coder prompt says to include `"success"` if all tools compiled, but the exact wording may vary (e.g., `"Success"`, `"Build succeeded"`, `"All tools compiled successfully"`). The validation uses case-insensitive substring matching to handle this.
+
+- **Empty `tools_generated` when tools already exist**: The tool-coder checks the tool-registry for existing tools and only generates missing ones. If the test scenario's tool (`convert_temperature`) already exists in the registry, `tools_generated` could be empty and `implementation_paths` could be empty — which would fail validation. This is unlikely in a clean E2E environment but worth noting. The test scenario document should clarify that the E2E environment starts with a clean state.
+
+- **Large skill file in JSON payload**: The skill file contents are embedded as a string in the JSON `input` field. Special characters (quotes, backslashes, newlines) must be properly escaped. Using `jq --arg` for payload construction handles this automatically.
+
+- **Curl timeout**: Tool-coder may take a long time if it needs multiple compile-fix cycles (up to 15 turns per its `max_turns` constraint). The 120-second timeout should be sufficient, but if the agent is slow due to LLM latency, retries provide additional runway. Total worst-case wall time: 3 attempts x 120s = 360s (6 minutes).
+
+- **`implementation_paths` format**: The spec says paths are comma-separated strings like `"tools/read-file, tools/write-file"`. Validation should handle optional whitespace around commas when splitting.
+
+## Verification
+
+- `bash -n tests/e2e/validate_step2_tools.sh` succeeds (syntax check).
+- `shellcheck tests/e2e/validate_step2_tools.sh` produces no errors (if shellcheck is available).
+- The script is executable (`chmod +x`).
+- Manual review confirms:
+  - All three validation checks are implemented (compilation_result, tools_generated, implementation_paths).
+  - Retry logic attempts up to 3 times with sleep between attempts.
+  - The script reads from `tests/e2e/artifacts/generated-skill.md` and writes to `tests/e2e/artifacts/step2-response.json`.
+  - Environment variables are used for configurable values with sensible defaults.
+  - Diagnostic output clearly identifies which check failed and the actual value received.
+  - No functions exceed 50 lines.
+  - No hardcoded URLs (uses `TOOL_CODER_URL` env var).

--- a/.claude/specs/issue-22/write-step-3-validator-deploy-agent-invocation.md
+++ b/.claude/specs/issue-22/write-step-3-validator-deploy-agent-invocation.md
@@ -1,0 +1,197 @@
+# Spec: Write step 3 validator — deploy-agent invocation
+
+> From: .claude/tasks/issue-22.md
+
+## Objective
+
+Create `tests/e2e/validate_step3_deploy.sh`, a shell script that sends the skill file path and tool implementation paths from steps 1-2 to the deploy-agent's `/invoke` endpoint, then validates the structured JSON response contains a correctly formatted image URI, a valid HTTP endpoint URL, and a healthy health-check status. The script uses generous timeouts to accommodate slow Docker builds.
+
+## Current State
+
+### Deploy-agent output schema (`skills/deploy-agent.md`)
+
+The deploy-agent returns structured JSON with three fields:
+
+- `image_uri` (string): Full image reference pushed to the registry, following the convention `{REGISTRY_URL}/spore-{agent-name}:{version}` (e.g., `ghcr.io/spore/spore-deploy-agent:0.1`).
+- `endpoint_url` (string): HTTP address where the deployed agent is reachable (e.g., `http://deploy-agent:8080`).
+- `health_check` (string): `"healthy"` if the agent responded with 200 OK to a post-deployment health verification, or an error description if the health check failed.
+
+### HTTP API (`crates/agent-runtime/src/http.rs`)
+
+- `POST /invoke` accepts `Json<AgentRequest>` and returns `Json<AgentResponse>` on success or a JSON-serialized `AgentError` on failure.
+- `GET /health` returns `Json<HealthResponse>` with fields `name`, `version`, `status`.
+
+### AgentRequest (`crates/agent-sdk/src/agent_request.rs`)
+
+```json
+{
+  "id": "<uuid>",
+  "input": "<string>",
+  "context": <optional json value>,
+  "caller": <optional string>
+}
+```
+
+### AgentResponse (`crates/agent-sdk/src/agent_response.rs`)
+
+```json
+{
+  "id": "<uuid>",
+  "output": <json value>,
+  "confidence": <float>,
+  "escalated": <bool>,
+  "escalate_to": <optional string>,
+  "tool_calls": [<ToolCallRecord>, ...]
+}
+```
+
+The deploy-agent's structured output lives inside the `output` field of `AgentResponse`. Based on the skill manifest's output schema, `output` is expected to be a JSON object with keys `image_uri`, `endpoint_url`, and `health_check`.
+
+### Artifacts from prior steps
+
+- `tests/e2e/artifacts/generated-skill.md` — skill file produced by step 1 (skill-writer).
+- `tests/e2e/artifacts/step2-response.json` — response from step 2 (tool-coder), containing `output.implementation_paths` with paths to generated tool code.
+
+### Image tagging convention (`skills/deploy-agent.md`)
+
+Images are tagged as `spore-{agent-name}:{version}` where `agent-name` and `version` come from the skill manifest YAML frontmatter. The full URI includes the registry prefix: `{REGISTRY_URL}/spore-{agent-name}:{version}`.
+
+## Requirements
+
+### Script behavior
+
+- The script is a standalone bash script at `tests/e2e/validate_step3_deploy.sh` with a `#!/usr/bin/env bash` shebang and `set -euo pipefail`.
+- It reads the generated skill file from `tests/e2e/artifacts/generated-skill.md` and the step 2 response from `tests/e2e/artifacts/step2-response.json`.
+- It constructs an `AgentRequest` JSON body with:
+  - `id`: a freshly generated UUID (via `uuidgen` or equivalent).
+  - `input`: a string describing the deployment task, including the skill file path and the tool implementation paths extracted from the step 2 response. For example: `"Deploy the agent defined by skill file at /path/to/generated-skill.md with tools at /path/to/tool1, /path/to/tool2"`.
+  - `context`: an optional JSON object containing `skill_path` and `tool_paths` fields for structured access.
+  - `caller`: `"e2e-test"`.
+- It sends a `POST` to `http://deploy-agent:8080/invoke` with the constructed request body.
+- The deploy-agent host is configurable via an environment variable `DEPLOY_AGENT_HOST` (default: `deploy-agent:8080`).
+- The `curl` timeout is set to at least 300 seconds (5 minutes) to allow for Docker image builds. Use `--max-time 600` (10 minutes) as the outer bound and `--connect-timeout 30` for connection establishment.
+- On success (HTTP 200), the response is saved to `tests/e2e/artifacts/step3-response.json`.
+
+### Validation checks
+
+All validations operate on the `output` field of the `AgentResponse`. The script must perform the following checks, exiting non-zero with a diagnostic message on any failure:
+
+1. **HTTP status**: The response HTTP status code is 200. Any other status is a failure.
+2. **Response structure**: The response body is valid JSON and contains an `output` field that is a JSON object.
+3. **`image_uri` is non-empty**: `output.image_uri` exists, is a string, and is not empty.
+4. **`image_uri` follows naming convention**: `output.image_uri` matches the regex pattern `spore-[a-z0-9-]+:[0-9a-z.-]+` (the `spore-{name}:{version}` suffix). The full URI may contain a registry prefix (e.g., `ghcr.io/spore/`), so the check validates that the URI ends with or contains this pattern. Use a regex like `spore-[a-z][a-z0-9-]*:[0-9]+(\.[0-9]+)*`.
+5. **`endpoint_url` is non-empty**: `output.endpoint_url` exists, is a string, and is not empty.
+6. **`endpoint_url` is a valid HTTP URL**: `output.endpoint_url` starts with `http://` or `https://`. Validate with a regex or string prefix check.
+7. **`health_check` is "healthy"**: `output.health_check` exists, is a string, and equals `"healthy"` (exact match, case-sensitive).
+
+### Error handling
+
+- If `tests/e2e/artifacts/generated-skill.md` does not exist, exit with code 1 and a message indicating step 1 must complete first.
+- If `tests/e2e/artifacts/step2-response.json` does not exist, exit with code 1 and a message indicating step 2 must complete first.
+- If `curl` fails (network error, timeout), exit with code 1 and print the curl error.
+- If any validation check fails, print which check failed, the actual value received, and exit with code 1.
+- On non-200 HTTP responses, print the status code and response body for diagnostics.
+
+### Output
+
+- On success, print a summary: `"Step 3 PASSED: deploy-agent produced image_uri=<uri>, endpoint_url=<url>, health_check=healthy"`.
+- On failure, print: `"Step 3 FAILED: <reason>"` with the specific check that failed and the actual value.
+- Save the full response to `tests/e2e/artifacts/step3-response.json` regardless of validation outcome (as long as a response was received).
+
+## Implementation Details
+
+### Files to create
+
+**`tests/e2e/validate_step3_deploy.sh`**
+
+The script follows this structure:
+
+1. **Setup and configuration**:
+   - Shebang: `#!/usr/bin/env bash`
+   - `set -euo pipefail`
+   - Define `DEPLOY_AGENT_HOST` from environment or default to `deploy-agent:8080`.
+   - Define `ARTIFACTS_DIR` as the directory containing step artifacts (default: `tests/e2e/artifacts`).
+   - Define `INVOKE_URL="http://${DEPLOY_AGENT_HOST}/invoke"`.
+   - Define curl timeout constants: `CONNECT_TIMEOUT=30`, `MAX_TIME=600`.
+
+2. **Pre-flight checks**:
+   - Verify `tests/e2e/artifacts/generated-skill.md` exists. Exit 1 if missing.
+   - Verify `tests/e2e/artifacts/step2-response.json` exists. Exit 1 if missing.
+   - Verify `curl` and `jq` are available on `PATH`.
+
+3. **Extract inputs from prior steps**:
+   - Read the skill file path: `SKILL_PATH="${ARTIFACTS_DIR}/generated-skill.md"`.
+   - Extract tool implementation paths from step 2 response using `jq`: `TOOL_PATHS=$(jq -r '.output.implementation_paths // [] | join(", ")' "${ARTIFACTS_DIR}/step2-response.json")`.
+
+4. **Construct the request body**:
+   - Generate a UUID for the request `id` (use `uuidgen` if available, fall back to a `/proc/sys/kernel/random/uuid` read, or construct one via other means).
+   - Build the JSON request using `jq -n` with `--arg` flags to safely interpolate the skill path and tool paths into the `input` string and `context` object.
+
+5. **Send the request**:
+   - Use `curl -s -w '\n%{http_code}' --connect-timeout ${CONNECT_TIMEOUT} --max-time ${MAX_TIME} -H 'Content-Type: application/json' -d "${REQUEST_BODY}" "${INVOKE_URL}"`.
+   - Separate the HTTP body from the status code (last line of output).
+
+6. **Save response**:
+   - Write the response body to `tests/e2e/artifacts/step3-response.json`.
+
+7. **Validate HTTP status**:
+   - Check status code is `200`. If not, print diagnostics and exit 1.
+
+8. **Validate response fields** (using `jq`):
+   - Check `output` field exists and is an object.
+   - Check `output.image_uri` is a non-empty string.
+   - Check `output.image_uri` matches the `spore-` naming pattern using `jq test()` or a bash regex.
+   - Check `output.endpoint_url` is a non-empty string.
+   - Check `output.endpoint_url` starts with `http://` or `https://`.
+   - Check `output.health_check` equals `"healthy"`.
+
+9. **Print summary**:
+   - On all checks passing, print success message and exit 0.
+
+### Helper function pattern
+
+Use a `validate` helper to keep each check concise:
+
+```bash
+validate() {
+    local description="$1"
+    local actual="$2"
+    local condition="$3"
+    if ! eval "$condition"; then
+        echo "Step 3 FAILED: ${description} (got: ${actual})"
+        exit 1
+    fi
+}
+```
+
+Or use individual `jq` exit-code checks, printing diagnostics inline.
+
+### Files to modify
+
+None. This is a new file.
+
+## Dependencies
+
+- Blocked by: "Define the test scenario document" (provides the agreed-upon test scenario and success criteria).
+- Blocking: "Write the E2E shell script orchestrator" (the top-level driver runs this script as step 3).
+
+## Risks & Edge Cases
+
+- **Docker build timeouts**: Docker image builds inside the deploy-agent can take several minutes, especially on cold caches. The 10-minute `--max-time` should handle this, but CI environments with limited resources may need more. The timeout constants are defined as variables for easy adjustment.
+- **Registry URL variability**: The `image_uri` validation checks for the `spore-{name}:{version}` pattern anywhere in the string, not at a fixed position, because the registry prefix varies by environment (could be `localhost:5000/`, `ghcr.io/spore/`, or absent entirely).
+- **LLM non-determinism**: The deploy-agent is LLM-driven, so the exact format of `image_uri` and `endpoint_url` may vary. Validations check structural correctness (pattern matching, URL prefix), not exact values.
+- **Step 2 response format**: The script depends on `output.implementation_paths` being an array of strings in the step 2 response. If the tool-coder returns a different structure, the `jq` extraction will yield an empty string, which is still a valid (if less informative) input to the deploy-agent.
+- **UUID generation**: Different environments may or may not have `uuidgen`. The script should have a fallback (e.g., reading from `/proc/sys/kernel/random/uuid` on Linux, or using Python/jq to generate one).
+- **`jq` version compatibility**: The `jq` `test()` function for regex matching requires jq 1.5+. This is widely available but worth noting. If compatibility is a concern, fall back to bash `[[ =~ ]]` for regex checks.
+- **Network DNS resolution**: Inside the docker-compose network, `deploy-agent` resolves to the container. Outside docker-compose (e.g., local testing), the `DEPLOY_AGENT_HOST` override allows pointing to `localhost:<mapped-port>`.
+
+## Verification
+
+- `bash -n tests/e2e/validate_step3_deploy.sh` produces no syntax errors.
+- `shellcheck tests/e2e/validate_step3_deploy.sh` produces no errors (warnings acceptable for intentional patterns).
+- The script is executable (`chmod +x`).
+- The script exits 1 with a clear message when `tests/e2e/artifacts/generated-skill.md` does not exist.
+- The script exits 1 with a clear message when `tests/e2e/artifacts/step2-response.json` does not exist.
+- The script exits 1 with a clear message when `curl` or `jq` is not found.
+- All functions in the script are under 50 lines per project rules.
+- No hardcoded host/port values; the deploy-agent endpoint is configurable via `DEPLOY_AGENT_HOST`.

--- a/.claude/specs/issue-22/write-step-4-validator-orchestrator-routing.md
+++ b/.claude/specs/issue-22/write-step-4-validator-orchestrator-routing.md
@@ -1,0 +1,218 @@
+# Spec: Write step 4 validator — orchestrator routing
+
+> From: .claude/tasks/issue-22.md
+
+## Objective
+
+Create `tests/e2e/validate_step4_route.sh`, a shell script that sends domain-level temperature-conversion requests through the orchestrator's `/invoke` endpoint and validates that the orchestrator correctly routes them to the deployed temperature-conversion agent, which returns numerically reasonable results with high confidence and non-empty tool usage.
+
+## Current State
+
+### Endpoint contract (`crates/agent-runtime/src/http.rs`)
+
+The orchestrator exposes `POST /invoke` accepting an `AgentRequest` JSON body and returning an `AgentResponse` JSON body.
+
+**`AgentRequest`** (`crates/agent-sdk/src/agent_request.rs`):
+```
+{
+  "id": "<uuid>",
+  "input": "<string>",
+  "context": <optional json value>,
+  "caller": <optional string>
+}
+```
+
+**`AgentResponse`** (`crates/agent-sdk/src/agent_response.rs`):
+```
+{
+  "id": "<uuid>",
+  "output": <json value>,
+  "confidence": <f32>,
+  "escalated": <bool>,
+  "escalate_to": <optional string>,
+  "tool_calls": [
+    {
+      "tool_name": "<string>",
+      "input": <json value>,
+      "output": <json value>
+    }
+  ]
+}
+```
+
+- `confidence` is an `f32` in `[0.0, 1.0]`.
+- `escalate_to` is omitted from serialization when `None` (`skip_serializing_if`).
+- `tool_calls` is a `Vec<ToolCallRecord>` where each record has `tool_name`, `input`, and `output` fields (all JSON values except `tool_name` which is a string).
+
+### Orchestrator routing (`crates/orchestrator/src/orchestrator.rs`)
+
+The orchestrator implements `MicroAgent::invoke` by calling `self.dispatch(request)`. Dispatch performs routing via:
+1. **`target_agent` context field** — if the request `context` contains `{"target_agent": "<name>"}`, route directly to that agent.
+2. **Semantic routing** — if an embedding model is configured, match the request input against agent descriptions by cosine similarity.
+3. **NoRoute error** — if neither method matches, return `OrchestratorError::NoRoute`.
+
+After routing, the orchestrator calls `try_invoke` (which checks agent health before forwarding) and then handles any escalation chain. The orchestrator skill manifest (`skills/orchestrator.md`) declares a confidence threshold of 0.9 and max turns of 3.
+
+### Error mapping (`crates/agent-runtime/src/http.rs`)
+
+- `AgentError::ConfidenceTooLow` returns HTTP 200 (not a server error).
+- `AgentError::Internal` returns HTTP 500.
+- `AgentError::ToolCallFailed` returns HTTP 502.
+- Successful invocations return HTTP 200 with `AgentResponse` JSON body.
+
+### Artifact convention
+
+Prior steps save outputs to `tests/e2e/artifacts/`. This script saves its responses to `tests/e2e/artifacts/step4-response.json` for downstream consumption.
+
+## Requirements
+
+- The script must be a Bash script (`#!/usr/bin/env bash`) with `set -euo pipefail`.
+- Accept the orchestrator base URL via an environment variable `ORCHESTRATOR_URL` with a default of `http://orchestrator:8080` (matching docker-compose service name).
+- Accept an artifacts directory via `ARTIFACTS_DIR` with a default of `tests/e2e/artifacts`.
+
+### Test case 1: Convert 100F to C
+
+1. Construct an `AgentRequest` JSON body with:
+   - `id`: a generated UUID (use `uuidgen` or a hardcoded test UUID).
+   - `input`: `"Convert 100 degrees Fahrenheit to Celsius"`
+   - `context`: `null` (let the orchestrator route semantically).
+   - `caller`: `null`.
+2. Send `POST ${ORCHESTRATOR_URL}/invoke` with `Content-Type: application/json`.
+3. Use a generous timeout (60 seconds) on the curl call to account for LLM latency.
+4. Assert HTTP status code is 200.
+5. Save the full response body to `${ARTIFACTS_DIR}/step4-response-q1.json`.
+6. Parse the JSON response with `jq` and validate:
+   - **Confidence**: `.confidence >= 0.8`. Use `jq` numeric comparison. Print the actual confidence value on failure.
+   - **Numerically reasonable output**: Extract a numeric value from `.output` (which may be a JSON object or string depending on the agent's output format). The expected answer is approximately 37.78 (the exact conversion of 100F). Validate the extracted number is between 37.0 and 39.0 (inclusive) to allow for rounding and formatting differences. If `.output` is a string, use `grep -oE` or `jq` to extract a float with a regex pattern. If `.output` is an object, check common field names (`.output.result`, `.output.value`, `.output.answer`, `.output.temperature`, `.output.celsius`) for the numeric value.
+   - **Non-empty tool_calls**: `.tool_calls | length > 0`. This proves the agent used its `convert_temperature` tool rather than answering from LLM knowledge alone.
+
+### Test case 2: Convert 0K to C
+
+1. Construct an `AgentRequest` with `input`: `"Convert 0 Kelvin to Celsius"`.
+2. Send `POST ${ORCHESTRATOR_URL}/invoke`.
+3. Assert HTTP 200.
+4. Save the response to `${ARTIFACTS_DIR}/step4-response-q2.json`.
+5. Validate:
+   - **Confidence**: `.confidence >= 0.8`.
+   - **Numerically reasonable output**: The expected answer is approximately -273.15. Validate the extracted number is between -274.0 and -273.0 (inclusive).
+   - **Non-empty tool_calls**: `.tool_calls | length > 0`.
+
+### Output and exit behavior
+
+- Print a clear pass/fail message per test case and per assertion.
+- On the first validation failure, print the failing assertion name, the expected range or condition, and the actual value, then exit with code 1.
+- On success of all assertions, print a summary line (e.g., `"Step 4: All routing validations passed"`) and exit with code 0.
+- Save a combined summary to `${ARTIFACTS_DIR}/step4-response.json` containing both query responses for downstream consumption.
+
+## Implementation Details
+
+### Files to create
+
+**`tests/e2e/validate_step4_route.sh`**
+
+The script structure:
+
+1. **Header and configuration**:
+   - Shebang: `#!/usr/bin/env bash`
+   - `set -euo pipefail`
+   - `ORCHESTRATOR_URL="${ORCHESTRATOR_URL:-http://orchestrator:8080}"`
+   - `ARTIFACTS_DIR="${ARTIFACTS_DIR:-tests/e2e/artifacts}"`
+   - `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"`
+   - Ensure `${ARTIFACTS_DIR}` directory exists (`mkdir -p`).
+
+2. **Helper function `assert_http_ok`**:
+   - Takes a label and a curl output file path.
+   - Extracts the HTTP status code (use `curl -w '%{http_code}' -o <file>` pattern).
+   - If status is not 200, print error with the label and status code, then `exit 1`.
+
+3. **Helper function `extract_number`**:
+   - Takes a `jq` path and a JSON file.
+   - Attempts to extract a number from the response output field.
+   - Strategy: first try `.output` as a direct number; then try common object fields (`.output.result`, `.output.value`, `.output.answer`, `.output.temperature`, `.output.celsius`); then try parsing `.output` as a string and extracting a float with a regex pattern like `-?[0-9]+\.?[0-9]*`.
+   - Prints the extracted number to stdout. Prints an error and returns non-zero if no number is found.
+
+4. **Helper function `assert_in_range`**:
+   - Takes a label, actual value, min, and max.
+   - Uses `awk` for floating-point comparison (bash cannot compare floats natively).
+   - If out of range, print the label, expected range, and actual value, then `exit 1`.
+
+5. **Helper function `assert_confidence`**:
+   - Takes a label, a JSON file, and a minimum threshold (0.8).
+   - Extracts `.confidence` with `jq`.
+   - Uses `awk` for `>=` comparison.
+   - Fails with a diagnostic message if below threshold.
+
+6. **Helper function `assert_tool_calls_nonempty`**:
+   - Takes a label and a JSON file.
+   - Checks `.tool_calls | length` with `jq`.
+   - Fails if length is 0.
+
+7. **Test case 1 execution**:
+   - Generate a UUID for the request (use `uuidgen` if available, otherwise a hardcoded UUID like `"00000000-0000-4000-a000-000000000001"`).
+   - Build the JSON payload using `jq -n` with `--arg` for the input string and id.
+   - Call `curl -s -w '\n%{http_code}' -X POST "${ORCHESTRATOR_URL}/invoke" -H 'Content-Type: application/json' -d "${PAYLOAD}" --max-time 60`.
+   - Split response body from status code (last line).
+   - Call `assert_http_ok`.
+   - Save body to `${ARTIFACTS_DIR}/step4-response-q1.json`.
+   - Call `assert_confidence "Q1" <file> 0.8`.
+   - Extract number, call `assert_in_range "Q1: 100F->C" <number> 37.0 39.0`.
+   - Call `assert_tool_calls_nonempty "Q1"`.
+   - Print `"PASS: Query 1 (100F -> C)"`.
+
+8. **Test case 2 execution**:
+   - Same structure with input `"Convert 0 Kelvin to Celsius"`.
+   - Save to `${ARTIFACTS_DIR}/step4-response-q2.json`.
+   - Assert confidence >= 0.8.
+   - Assert number in range -274.0 to -273.0.
+   - Assert tool_calls non-empty.
+   - Print `"PASS: Query 2 (0K -> C)"`.
+
+9. **Summary**:
+   - Combine both response files into `${ARTIFACTS_DIR}/step4-response.json` using `jq -n --slurpfile q1 <q1file> --slurpfile q2 <q2file> '{query1: $q1[0], query2: $q2[0]}'`.
+   - Print `"Step 4: All routing validations passed"`.
+   - Exit 0.
+
+### Files to modify
+
+None.
+
+### Integration points
+
+- Consumed by `scripts/e2e-test.sh` (Group 3), which calls this script after steps 1-3 have completed.
+- Reads no artifacts from prior steps (the orchestrator routing is self-contained at this point since the temperature agent is already deployed and registered).
+- Writes `step4-response-q1.json`, `step4-response-q2.json`, and `step4-response.json` to the artifacts directory.
+
+### Tool dependencies
+
+- `bash`, `curl`, `jq`, `awk` — all standard tools expected to be available in the E2E test environment.
+- `uuidgen` — optional; falls back to a hardcoded UUID if not available.
+
+## Dependencies
+
+- Blocked by: "Define the test scenario document" (`tests/e2e/SCENARIO.md`) — provides the canonical test queries and expected outputs.
+- Blocking: "Write the E2E shell script orchestrator" (`scripts/e2e-test.sh`) — calls this validator as step 4 in the pipeline.
+
+## Risks & Edge Cases
+
+- **LLM non-determinism in output format**: The temperature-conversion agent's `.output` field may be a plain number, a string like `"37.78 degrees Celsius"`, or a structured object like `{"celsius": 37.78}`. The `extract_number` helper must handle all three forms. The validation uses a wide numeric range (37.0-39.0 and -274.0 to -273.0) to account for rounding.
+- **Orchestrator routing failure**: If semantic routing is not configured or the temperature agent is not registered, the orchestrator returns `AgentError::Internal("NoRoute { input: ... }")` with HTTP 500. The `assert_http_ok` check will catch this with a clear error message.
+- **Agent health check delay**: The orchestrator calls `try_invoke` which checks agent health before forwarding. If the temperature agent is still starting, the health check may fail. The E2E orchestrator script (`scripts/e2e-test.sh`) is responsible for waiting until all services are healthy before running step 4. This script does not retry on its own.
+- **Confidence threshold mismatch**: The orchestrator skill manifest declares `confidence_threshold: 0.9`, but the routed agent (temperature converter) controls its own response confidence. The validation threshold in this script (0.8) is intentionally lower than the orchestrator's routing threshold to avoid false negatives from minor confidence variations.
+- **`escalate_to` field absence**: The `escalate_to` field uses `skip_serializing_if = "Option::is_none"`, so it may be entirely absent from the JSON response. The script does not check this field — it only validates confidence, output, and tool_calls.
+- **Curl timeout**: A 60-second timeout per request should be sufficient for a single LLM call through the orchestrator, but in degraded environments it could be tight. The timeout is configurable by editing the script but is not exposed as a variable to keep the interface simple.
+- **Floating-point extraction from strings**: The regex `-?[0-9]+\.?[0-9]*` may match unrelated numbers in verbose output (e.g., "100" from the input echoed in the output). The extraction strategy should prefer structured fields first and fall back to regex only as a last resort, prioritizing numbers that match the expected range.
+
+## Verification
+
+- `bash -n tests/e2e/validate_step4_route.sh` confirms no syntax errors.
+- `shellcheck tests/e2e/validate_step4_route.sh` produces no errors (if shellcheck is available).
+- The script is executable (`chmod +x`).
+- Manual review confirms:
+  - Both test cases (100F->C and 0K->C) are exercised.
+  - Confidence threshold is 0.8.
+  - Numeric ranges are 37.0-39.0 and -274.0 to -273.0.
+  - Tool calls non-empty assertion is present for both queries.
+  - Artifacts are saved to the expected paths.
+  - Exit code is 1 on any failure, 0 on full success.
+  - All helper functions are under 50 lines.
+  - No hardcoded URLs (configurable via `ORCHESTRATOR_URL`).

--- a/.claude/specs/issue-22/write-the-e2e-shell-script-orchestrator.md
+++ b/.claude/specs/issue-22/write-the-e2e-shell-script-orchestrator.md
@@ -1,0 +1,266 @@
+# Spec: Write the E2E shell script orchestrator
+
+> From: .claude/tasks/issue-22.md
+
+## Objective
+
+Create `scripts/e2e-test.sh` as the top-level test driver for the end-to-end self-bootstrapping pipeline. The script orchestrates the full lifecycle: starts the docker-compose environment, waits for services to become healthy, runs four step validators sequentially, preserves artifacts for debugging, dumps container logs on failure, tracks elapsed time, and cleans up in a trap. It supports `--no-cleanup` and `--timeout` flags to aid debugging and CI integration.
+
+## Current State
+
+### Dockerfile (`Dockerfile`)
+
+The project builds a statically-linked `agent-runtime` binary using a multi-stage Docker build:
+- Builder stage: `rust:latest`, targets `x86_64-unknown-linux-musl`, produces a static binary at `target/x86_64-unknown-linux-musl/release/agent-runtime`.
+- Runtime stage: `FROM scratch`, copies the binary to `/agent-runtime`, copies `skills/` to `/skills/`.
+- Accepts `SKILL_NAME` build-arg (default `echo`), sets `SKILL_DIR=/skills`, exposes port 8080, runs as user 1000.
+- Entrypoint is `/agent-runtime`.
+
+### Health endpoint (`crates/agent-runtime/src/http.rs`)
+
+- `GET /health` returns a JSON `HealthResponse` with fields `name` (String), `version` (String), `status` (HealthStatus).
+- `HealthStatus` is an enum: `Healthy`, `Degraded(String)`, `Unhealthy(String)`.
+- A healthy response looks like: `{"name":"...","version":"...","status":"Healthy"}`.
+- The runtime listens on port 8080 (configured via `RuntimeConfig::bind_addr`, default `0.0.0.0:8080`).
+
+### Docker-compose file (not yet created)
+
+`docker-compose.e2e.yml` will define services: `skill-writer`, `tool-coder`, `deploy-agent`, and `orchestrator`, each built from the project `Dockerfile` with different `SKILL_NAME` build-args. Each service exposes port 8080 internally with unique host-mapped ports. Services share a Docker network for inter-agent HTTP.
+
+### Step validator scripts (not yet created)
+
+Four shell scripts under `tests/e2e/`:
+- `validate_step1_skill.sh` -- invokes skill-writer, validates skill YAML structure, saves to artifacts.
+- `validate_step2_tools.sh` -- invokes tool-coder, validates compilation result, saves to artifacts.
+- `validate_step3_deploy.sh` -- invokes deploy-agent, validates image and endpoint, saves to artifacts.
+- `validate_step4_route.sh` -- invokes orchestrator, validates routing and numeric answers, saves to artifacts.
+
+Each exits non-zero on failure with diagnostic output. Each expects service URLs to be reachable.
+
+## Requirements
+
+- The script must be a Bash script (`#!/usr/bin/env bash`) with `set -euo pipefail`.
+- Parse CLI flags: `--no-cleanup` (skip teardown on exit), `--timeout <seconds>` (default 600, i.e. 10 minutes).
+- Start the docker-compose environment: `docker compose -f docker-compose.e2e.yml up -d --build`.
+- Wait for all four services to become healthy by polling `GET /health` with exponential backoff.
+- Create `tests/e2e/artifacts/` directory for intermediate outputs.
+- Run step validators 1 through 4 sequentially; stop on first failure.
+- On failure: dump container logs, print which step failed and the error, exit non-zero.
+- On success: print a summary of all steps passed with per-step and total elapsed times.
+- Always run cleanup in a trap (unless `--no-cleanup` is set): `docker compose -f docker-compose.e2e.yml down -v --remove-orphans`.
+- Enforce the overall timeout: if elapsed time exceeds the limit, kill remaining work and exit non-zero.
+- Preserve all intermediate artifacts in `tests/e2e/artifacts/` regardless of outcome.
+- Dump container logs to `tests/e2e/artifacts/container-logs.txt` on failure.
+- The script must be executable (`chmod +x`).
+- All functions must be under 50 lines per project rules.
+
+## Implementation Details
+
+### File to create
+
+**`scripts/e2e-test.sh`**
+
+The script is organized into the following sections and functions:
+
+### 1. Shebang and strict mode
+
+```
+#!/usr/bin/env bash
+set -euo pipefail
+```
+
+### 2. Constants and defaults
+
+- `COMPOSE_FILE="docker-compose.e2e.yml"` -- path to the compose file (relative to project root).
+- `ARTIFACTS_DIR="tests/e2e/artifacts"` -- directory for intermediate outputs.
+- `DEFAULT_TIMEOUT=600` -- default overall timeout in seconds (10 minutes).
+- `HEALTH_MAX_WAIT=60` -- maximum seconds to wait for health checks.
+- `HEALTH_INITIAL_INTERVAL=1` -- initial polling interval in seconds.
+- `SERVICES=("skill-writer" "tool-coder" "deploy-agent" "orchestrator")` -- list of service names matching docker-compose service definitions.
+- `HOST_PORTS` associative array mapping service names to their host-mapped ports (must match `docker-compose.e2e.yml`). Example: `skill-writer=8081`, `tool-coder=8082`, `deploy-agent=8083`, `orchestrator=8084`.
+- `STEPS=("tests/e2e/validate_step1_skill.sh" "tests/e2e/validate_step2_tools.sh" "tests/e2e/validate_step3_deploy.sh" "tests/e2e/validate_step4_route.sh")` -- ordered list of validator scripts.
+- `STEP_NAMES=("skill-writer invocation" "tool-coder invocation" "deploy-agent invocation" "orchestrator routing")` -- human-readable step names for output.
+
+### 3. Global state variables
+
+- `NO_CLEANUP=false` -- toggled by `--no-cleanup` flag.
+- `TIMEOUT=$DEFAULT_TIMEOUT` -- overridden by `--timeout` flag.
+- `START_TIME` -- captured via `date +%s` at script start for elapsed time tracking.
+- `STEP_TIMES=()` -- array accumulating per-step elapsed seconds.
+
+### 4. Function: `usage`
+
+Print usage information and exit. Describes `--no-cleanup`, `--timeout`, and `--help` flags.
+
+### 5. Function: `parse_args`
+
+Loop over `"$@"`, handling:
+- `--no-cleanup` -- set `NO_CLEANUP=true`.
+- `--timeout` -- consume the next argument as `TIMEOUT`; validate it is a positive integer.
+- `--help` / `-h` -- call `usage`.
+- Any unknown flag -- print error and call `usage`.
+
+### 6. Function: `log_info`
+
+Print a timestamped info message to stdout. Format: `[YYYY-MM-DDTHH:MM:SS] INFO: <message>`.
+
+### 7. Function: `log_error`
+
+Print a timestamped error message to stderr. Format: `[YYYY-MM-DDTHH:MM:SS] ERROR: <message>`.
+
+### 8. Function: `elapsed_since`
+
+Accept a start timestamp as argument. Compute and print `$(( $(date +%s) - $1 ))`.
+
+### 9. Function: `check_timeout`
+
+Compare `elapsed_since "$START_TIME"` against `$TIMEOUT`. If exceeded, call `log_error` with a timeout message and `exit 1`. The trap will handle cleanup.
+
+### 10. Function: `cleanup`
+
+Called by the EXIT trap. If `NO_CLEANUP` is true, print a message that cleanup is skipped and the environment is still running, then return. Otherwise, run `docker compose -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true`. Print total elapsed time.
+
+### 11. Function: `dump_container_logs`
+
+Run `docker compose -f "$COMPOSE_FILE" logs --no-color` and write output to `$ARTIFACTS_DIR/container-logs.txt`. Also print a message indicating where logs were saved. This is called on step failure before exiting.
+
+### 12. Function: `wait_for_health`
+
+Accept a service name and host port as arguments. Implements exponential backoff health polling:
+- Initialize `interval=$HEALTH_INITIAL_INTERVAL` and `elapsed=0`.
+- Loop while `elapsed < HEALTH_MAX_WAIT`:
+  - `check_timeout` (enforce overall timeout).
+  - Attempt `curl -sf "http://localhost:${port}/health"` and capture the response.
+  - Parse the response with `jq -r '.status'`.
+  - If status is `"Healthy"`, return 0.
+  - If status is `"Degraded"`, log a warning but continue waiting.
+  - Sleep `$interval` seconds.
+  - Update `elapsed` and double `interval` (cap at 16 seconds).
+- If the loop exits without a healthy response, return 1.
+
+### 13. Function: `wait_for_all_services`
+
+Iterate over `SERVICES` array. For each service, call `wait_for_health "$service" "${HOST_PORTS[$service]}"`. If any service fails to become healthy within the timeout, call `log_error`, `dump_container_logs`, and `exit 1`. Log each service as it becomes healthy.
+
+### 14. Function: `run_step`
+
+Accept a step index (0-based) as argument. Extract the script path from `STEPS[$index]` and the human-readable name from `STEP_NAMES[$index]`.
+- `check_timeout`.
+- Log that the step is starting.
+- Record `step_start=$(date +%s)`.
+- Run `bash "${STEPS[$index]}"` capturing exit code.
+- Record `step_elapsed=$(elapsed_since "$step_start")` and append to `STEP_TIMES`.
+- If exit code is non-zero: log the failure with step name and elapsed time, call `dump_container_logs`, and `exit 1`.
+- If exit code is zero: log success with step name and elapsed time.
+
+### 15. Function: `print_summary`
+
+Print a formatted summary table showing each step name, its pass/fail status, and elapsed time. Print total elapsed time. Example output:
+
+```
+========================================
+  E2E Pipeline Results
+========================================
+  Step 1: skill-writer invocation   PASS  (12s)
+  Step 2: tool-coder invocation     PASS  (45s)
+  Step 3: deploy-agent invocation   PASS  (180s)
+  Step 4: orchestrator routing      PASS  (8s)
+----------------------------------------
+  Total elapsed: 245s
+  Status: ALL STEPS PASSED
+========================================
+```
+
+### 16. Function: `check_prerequisites`
+
+Verify that required tools are installed before doing any work:
+- `curl` -- for health check polling.
+- `jq` -- for JSON parsing (used by health check and step validators).
+- `docker` -- for container management.
+- `docker compose` -- for multi-container orchestration (verify via `docker compose version`).
+
+For each missing tool, print a clear error message and exit non-zero.
+
+### 17. Main execution flow
+
+```
+parse_args "$@"
+START_TIME=$(date +%s)
+trap cleanup EXIT
+
+log_info "Starting E2E pipeline test (timeout=${TIMEOUT}s)"
+
+# Ensure we are in the project root (where docker-compose.e2e.yml lives)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+check_prerequisites
+
+# Create artifacts directory
+mkdir -p "$ARTIFACTS_DIR"
+
+# Start docker-compose environment
+log_info "Building and starting services..."
+docker compose -f "$COMPOSE_FILE" up -d --build 2>&1 | tee "$ARTIFACTS_DIR/compose-up.log"
+
+# Wait for all services to become healthy
+log_info "Waiting for services to become healthy..."
+wait_for_all_services
+
+# Run step validators sequentially
+for i in "${!STEPS[@]}"; do
+    run_step "$i"
+done
+
+# All steps passed
+print_summary
+log_info "E2E pipeline test PASSED"
+```
+
+### Error handling and edge cases
+
+- **Trap ordering**: The `cleanup` function is registered as an EXIT trap before any docker-compose commands. This ensures cleanup runs even if the script is interrupted with SIGINT/SIGTERM (since EXIT traps fire on those signals in Bash).
+- **Timeout enforcement**: `check_timeout` is called at the start of each health poll iteration and before each step. This provides granular timeout checks without a background watchdog process.
+- **Partial artifacts**: If step 2 fails, artifacts from step 1 are already saved in `tests/e2e/artifacts/` and remain available. The `dump_container_logs` call on failure adds container logs to the same directory.
+- **Docker compose version**: Use `docker compose` (v2 plugin syntax), not `docker-compose` (v1 standalone). The v2 syntax is the modern standard.
+- **Port availability**: If host-mapped ports are already in use, `docker compose up` will fail. The error will propagate through `set -e` and trigger the cleanup trap. No special handling needed beyond the compose error message.
+- **Non-TTY output**: Use `--no-color` for docker compose logs to ensure clean output in CI environments. Do not use ANSI escape codes in `log_info`/`log_error` -- keep output plain text for portability.
+- **`set -e` and step exit codes**: The `run_step` function must capture the exit code of the validator script without letting `set -e` terminate the script prematurely. Use `bash "${STEPS[$index]}" || step_exit=$?` pattern or temporarily disable errexit.
+
+### Files to modify
+
+None. This is a new file.
+
+### Integration points
+
+- Reads `docker-compose.e2e.yml` from the project root (created by the "Create docker-compose.e2e.yml" task).
+- Invokes `tests/e2e/validate_step{1-4}_*.sh` (created by the four step validator tasks).
+- Writes artifacts to `tests/e2e/artifacts/` which are read by the Rust integration test wrapper for post-mortem debugging.
+- The Rust integration test wrapper (`tests/e2e_bootstrap_test.rs`) calls this script via `Command::new("bash").arg("scripts/e2e-test.sh")` and asserts exit code 0.
+
+## Dependencies
+
+- Blocked by: "Create `docker-compose.e2e.yml`", "Write step 1 validator: skill-writer invocation", "Write step 2 validator: tool-coder invocation", "Write step 3 validator: deploy-agent invocation", "Write step 4 validator: orchestrator routing"
+- Blocking: "Add Rust integration test wrapper"
+
+## Risks & Edge Cases
+
+- **Docker socket availability**: The script assumes Docker is running and the current user has permission to use it. In CI, this may require Docker-in-Docker or a privileged runner. The preflight check will catch a missing `docker` binary but not permission issues -- those will surface as compose errors.
+- **Port conflicts**: Host-mapped ports (8081-8084) may conflict with other services. The compose file should use unique ports, but the script cannot detect pre-existing conflicts before `docker compose up` fails.
+- **Build time**: `docker compose up --build` may take several minutes for the Rust compilation. This counts against the overall timeout. The default 600s (10 minutes) should be sufficient, but slow CI runners may need `--timeout 900` or higher.
+- **Health check false positives**: A service might return `{"status":"Healthy"}` briefly before crashing. The step validators will catch this when their HTTP calls fail, but the error message may be confusing. Container logs in artifacts will clarify.
+- **LLM API key availability**: The step validators invoke LLM-backed agents. If API keys are not set in the environment or docker-compose file, the agents will fail. This is outside the script's scope but should be documented in the README section.
+- **Disk space**: Docker image builds and container logs can consume significant disk space. The script does not manage disk space -- this is an operational concern for the CI environment.
+- **Signal handling**: If the user sends SIGTERM or SIGINT, the EXIT trap fires and runs `cleanup`. However, if `docker compose down` itself hangs, the script may not terminate cleanly. Adding a timeout to the cleanup `docker compose down` command (e.g., `timeout 30 docker compose ...`) would mitigate this.
+
+## Verification
+
+- `bash -n scripts/e2e-test.sh` passes (syntax check, no execution).
+- `shellcheck scripts/e2e-test.sh` produces no errors (if shellcheck is available).
+- `ls -la scripts/e2e-test.sh` shows the executable bit is set.
+- `./scripts/e2e-test.sh --help` prints usage and exits 0.
+- `./scripts/e2e-test.sh --timeout abc` exits non-zero with a clear error about invalid timeout value.
+- `docker compose -f docker-compose.e2e.yml config` validates the compose file syntax (dry run, does not start services).
+- `cargo check` and `cargo test` pass (no Rust changes in this task).
+- Full E2E run is NOT verified in this task (requires LLM API keys and Docker) -- only syntax and flag parsing are verified.

--- a/.claude/specs/issue-44/add-tools-read-file-to-workspace-members.md
+++ b/.claude/specs/issue-44/add-tools-read-file-to-workspace-members.md
@@ -1,0 +1,61 @@
+# Spec: Add `tools/read-file` to workspace members
+
+> From: .claude/tasks/issue-44.md
+
+## Objective
+Register the `tools/read-file` crate in the Cargo workspace so that standard workspace commands (`cargo build -p read-file`, `cargo test -p read-file`, `cargo clippy -p read-file`) discover and operate on it. This is a prerequisite for all subsequent read-file implementation and testing tasks.
+
+## Current State
+The root `Cargo.toml` defines a workspace with `resolver = "2"` and six members:
+
+```toml
+members = [
+    "crates/agent-sdk",
+    "crates/skill-loader",
+    "crates/tool-registry",
+    "crates/agent-runtime",
+    "crates/orchestrator",
+    "tools/echo-tool",
+]
+```
+
+The `tools/` directory already contains `echo-tool`. No `tools/read-file` path is referenced anywhere in the workspace yet.
+
+## Requirements
+- The string `"tools/read-file"` must appear in the `members` array of `[workspace]` in the root `Cargo.toml`.
+- The entry must be placed immediately after `"tools/echo-tool"` to maintain logical grouping of tool crates.
+- The entry must be syntactically valid TOML and maintain the existing formatting style (one entry per line, trailing comma, 4-space indentation).
+- After the change, `cargo metadata` must list `tools/read-file` as a workspace member path (this will only fully resolve once the companion task "Create tools/read-file/Cargo.toml" is also complete).
+
+## Implementation Details
+- **File to modify:** `/workspaces/spore/Cargo.toml`
+- **Change:** Append `"tools/read-file",` as a new line inside the `members` array, after the existing `"tools/echo-tool"` entry.
+- No new files are created by this task.
+- No new functions, types, or interfaces are involved.
+
+The resulting `members` array should look like:
+
+```toml
+members = [
+    "crates/agent-sdk",
+    "crates/skill-loader",
+    "crates/tool-registry",
+    "crates/agent-runtime",
+    "crates/orchestrator",
+    "tools/echo-tool",
+    "tools/read-file",
+]
+```
+
+## Dependencies
+- Blocked by: "Create tools/read-file/Cargo.toml"
+- Blocking: "Implement ReadFileTool struct and handler", "Create main.rs entrypoint"
+
+## Risks & Edge Cases
+- **Missing crate directory:** If `tools/read-file/Cargo.toml` does not yet exist, `cargo check` at the workspace level will fail with a "can't find" error. This is expected and resolved once the companion scaffolding task ("Create tools/read-file/Cargo.toml") is completed. Both tasks should land together before running workspace-wide commands.
+- **Path ordering:** Placing the new entry after `tools/echo-tool` keeps the logical grouping clean. All `tools/` entries follow the `crates/` entries. If additional tools are added later, they should follow the same `tools/` prefix pattern.
+
+## Verification
+- Open `/workspaces/spore/Cargo.toml` and confirm `"tools/read-file"` is present in the `members` array, positioned after `"tools/echo-tool"`.
+- After the companion scaffolding task is also complete, run `cargo metadata --no-deps --format-version 1 | grep read-file` and confirm the crate appears in the workspace member list.
+- Run `cargo check -p read-file` (requires the companion `Cargo.toml` to exist) and confirm it resolves the package without "not a member" errors.

--- a/.claude/specs/issue-44/create-main-rs-entrypoint.md
+++ b/.claude/specs/issue-44/create-main-rs-entrypoint.md
@@ -1,0 +1,86 @@
+# Spec: Create `main.rs` entrypoint for read-file tool
+
+> From: .claude/tasks/issue-44.md
+
+## Objective
+Create the `main.rs` entrypoint for the `read-file` MCP tool server. This file follows the established echo-tool pattern: declare the tool module, import the tool struct, configure tracing to stderr, and serve the tool over stdio transport.
+
+## Current State
+- `tools/echo-tool/src/main.rs` exists and serves as the canonical template for all tool entrypoints.
+- The `read-file` crate does not yet exist. The workspace members update and `Cargo.toml` scaffolding must land first.
+- The tool implementation (`ReadFileTool`) will live in a sibling module `read_file.rs`, created by a separate task.
+
+## Requirements
+- Create `tools/read-file/src/main.rs` following the exact echo-tool entrypoint pattern.
+- Declare `mod read_file;` and import `ReadFileTool` from that module.
+- Configure `tracing_subscriber` to write to stderr with ANSI disabled and an `EnvFilter` defaulting to `DEBUG`.
+- Log `"Starting read-file MCP server"` at `info` level on startup.
+- Serve `ReadFileTool::new()` over `rmcp::transport::stdio()`.
+- Wait for transport close via `.waiting().await`.
+- No CLI argument parsing. No `clap` dependency.
+- File must stay under 50 lines.
+
+## Implementation Details
+
+### File: `tools/read-file/src/main.rs`
+
+```rust
+use rmcp::ServiceExt;
+use tracing_subscriber::{self, EnvFilter};
+
+mod read_file;
+use read_file::ReadFileTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::DEBUG.into()))
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    tracing::info!("Starting read-file MCP server");
+
+    let service = ReadFileTool::new()
+        .serve(rmcp::transport::stdio())
+        .await
+        .inspect_err(|e| tracing::error!("serving error: {:?}", e))?;
+
+    service.waiting().await?;
+    Ok(())
+}
+```
+
+### Key decisions
+- **`flavor = "current_thread"`**: Matches echo-tool. A single-threaded tokio runtime is sufficient for a stdio-based MCP server.
+- **`Box<dyn std::error::Error>`**: Used instead of `anyhow::Result` to avoid an extra dependency, consistent with echo-tool.
+- **Module name `read_file`**: Rust module names use underscores. The file will be `tools/read-file/src/read_file.rs`.
+
+### Line budget
+- Imports: 4 lines
+- Module declaration + use: 2 lines
+- `main` function: ~16 lines
+- Blank lines: ~3 lines
+- **Total: ~25 lines** (well under the 50-line limit)
+
+## Dependencies
+- Blocked by: workspace members update (adding `tools/read-file` to workspace `Cargo.toml`), `Cargo.toml` scaffolding for the read-file crate
+- Blocking: read-file tool implementation (`read_file.rs`), integration tests
+
+## Risks & Edge Cases
+
+1. **`ReadFileTool::new()` not yet available:** This file will not compile until the `read_file.rs` module is created with a `ReadFileTool` struct that has a `new()` constructor. This is expected -- the entrypoint is scaffolded first, and the tool implementation follows.
+
+2. **Stdout contamination:** All logging must go to stderr. The `tracing_subscriber` is explicitly configured with `.with_writer(std::io::stderr)`. No `println!` calls are permitted anywhere in the crate, as stdout is reserved for the MCP stdio transport.
+
+3. **Module naming collision:** The module is named `read_file` (underscore), matching Rust conventions. The crate is named `read-file` (hyphen). These do not conflict.
+
+## Verification
+
+1. **File exists:** `tools/read-file/src/main.rs` is present and matches the implementation above.
+2. **Line count:** `wc -l tools/read-file/src/main.rs` is under 50 lines.
+3. **Pattern match:** The file structurally mirrors `tools/echo-tool/src/main.rs` with only the module name, struct name, and log message changed.
+4. **Compilation:** `cargo check -p read-file` succeeds once the `read_file.rs` module and `Cargo.toml` are in place (not expected to pass in isolation from this task alone).
+5. **Lint:** `cargo clippy -p read-file` produces no warnings (once dependencies are in place).
+6. **Server starts:** `cargo run -p read-file` logs "Starting read-file MCP server" to stderr and waits for MCP client input (once the full tool is implemented).
+7. **Workspace tests:** `cargo test` across the full workspace still passes.

--- a/.claude/specs/issue-44/write-readme.md
+++ b/.claude/specs/issue-44/write-readme.md
@@ -1,0 +1,94 @@
+# Spec: Write README
+
+> From: .claude/tasks/issue-44.md
+
+## Objective
+
+Create a README for the `tools/read-file/` crate that documents the tool's purpose, how to build, run, and test it, and the stdio transport model. Follow the established pattern from `tools/echo-tool/README.md`. This is a documentation-only task with no code changes.
+
+## Current State
+
+- The `tools/read-file/` crate will be implemented by earlier tasks in this issue (scaffold, core implementation, unit tests).
+- The `tools/echo-tool/README.md` exists and serves as the reference template for all tool READMEs.
+- The tool uses `rmcp` with stdio transport, `tokio` for async, and `std::fs` for file operations.
+- The tool reads file contents from disk and returns them as a string, with descriptive error handling and a 10 MB size guard.
+
+## Requirements
+
+- The README must contain the following sections:
+  1. **Purpose** -- describe the read-file tool as an MCP tool server that reads file contents from disk and returns them as text, with validation and descriptive error handling.
+  2. **Build** -- `cargo build -p read-file`.
+  3. **Run** -- `cargo run -p read-file` with a note about stdio transport.
+  4. **Test** -- `cargo test -p read-file`.
+  5. **Test with MCP Inspector** -- `npx @modelcontextprotocol/inspector cargo run -p read-file`.
+  6. **Stdio transport note** -- explain that the server reads MCP messages from stdin and writes responses to stdout, with all logging directed to stderr.
+- The README must not include a "Creating a New Tool" section (that belongs only in the echo-tool reference README).
+- The README must not contain speculative information about APIs or features not yet implemented.
+- The document must use standard markdown formatting consistent with the project style (heading hierarchy, fenced code blocks for commands).
+
+## Implementation Details
+
+### File to create
+
+- **`tools/read-file/README.md`**
+
+### Document structure
+
+```
+# read-file
+
+<One-paragraph description: MCP tool server that reads file contents from disk
+and returns them as text. Includes path validation, existence checks, and a
+size guard (10 MB) to prevent reading excessively large files.>
+
+## Build
+
+<cargo build command in a fenced code block>
+
+## Run
+
+<cargo run command in a fenced code block, followed by a paragraph explaining
+stdio transport: stdin/stdout for MCP messages, stderr for logging>
+
+## Test
+
+<cargo test command in a fenced code block>
+
+## Test with MCP Inspector
+
+<npx inspector command in a fenced code block, with a brief explanation of
+what the inspector does and how to use it to verify tool behavior>
+```
+
+### Key content details
+
+- The purpose paragraph should mention that the tool accepts a file path, validates it, checks existence and size, reads the contents via `std::fs::read_to_string`, and returns the text or a descriptive error.
+- The "Run" section must note that the tool communicates over stdin/stdout using the MCP protocol, and that all logging goes to stderr to avoid corrupting the transport channel.
+- The "Test with MCP Inspector" section should briefly explain that the MCP Inspector provides a web UI for sending tool calls and inspecting responses interactively.
+- The build command must be exactly `cargo build -p read-file`.
+- The run command must be exactly `cargo run -p read-file`.
+- The test command must be exactly `cargo test -p read-file`.
+- The inspector command must be exactly `npx @modelcontextprotocol/inspector cargo run -p read-file`.
+
+## Dependencies
+
+- Blocked by: "Write unit tests" -- the README documents the implemented tool's behavior and test commands; writing it before tests exist risks documenting behavior that changes during test-driven fixes.
+- Blocking: "Run verification suite" -- the verification suite confirms all artifacts including documentation are in place.
+
+## Risks & Edge Cases
+
+1. **API drift:** If the read-file tool implementation changes after the README is written (e.g., method names, error messages, size limit), the README will become inaccurate. Mitigate by keeping descriptions at the behavioral level rather than pinning to exact internal names.
+2. **MCP Inspector availability:** The `npx @modelcontextprotocol/inspector` command depends on the inspector package being published to npm. This is an external dependency outside project control.
+3. **No "Creating a New Tool" section:** Unlike the echo-tool README, this README should not include a template guide. The echo-tool README is the canonical source for that guidance.
+
+## Verification
+
+1. The file `tools/read-file/README.md` exists and is valid markdown.
+2. All required sections are present: purpose, build, run, test, and MCP Inspector.
+3. The build command is exactly `cargo build -p read-file`.
+4. The run command is exactly `cargo run -p read-file`.
+5. The test command is exactly `cargo test -p read-file`.
+6. The inspector command is exactly `npx @modelcontextprotocol/inspector cargo run -p read-file`.
+7. The stdio transport note is present in the "Run" section.
+8. No speculative or incorrect API documentation is present.
+9. `cargo test` and `cargo clippy` pass (no code changes, but confirm nothing is broken).

--- a/.claude/specs/issue-44/write-unit-tests.md
+++ b/.claude/specs/issue-44/write-unit-tests.md
@@ -1,0 +1,178 @@
+# Spec: Write unit tests for read_file tool logic
+
+> From: .claude/tasks/issue-44.md
+
+## Objective
+
+Add inline unit tests for the read_file tool's core handler method to verify that it correctly reads file contents from disk, handles missing and empty paths, preserves unicode, and handles empty files. Tests exercise the tool logic directly (without starting an MCP server), using temporary files for filesystem interactions.
+
+## Current State
+
+- **ReadFileTool does not exist yet.** The `tools/read-file/` crate has not been created. Per the task breakdown (`.claude/tasks/issue-44.md`), `read_file.rs` will define a `ReadFileTool` struct with a `#[tool_router]` impl containing a `read_file` method that accepts a `ReadFileRequest { path: String }` and returns a `String` (file contents on success, descriptive error string on failure).
+
+- **Expected ReadFileTool API (from task breakdown):**
+  - `ReadFileRequest` struct with a single field `path: String`, deriving `Deserialize` and `JsonSchema`.
+  - `ReadFileTool` struct holding a `ToolRouter<Self>`, with a `new()` constructor (same pattern as `EchoTool`).
+  - `read_file(&self, Parameters(request): Parameters<ReadFileRequest>) -> String` method under `#[tool_router]`.
+  - Validates path is non-empty, returning a descriptive error string if empty.
+  - Returns a descriptive error if the file does not exist.
+  - Returns a descriptive error if the file exceeds 10 MB.
+  - Returns the file contents as a `String` on success.
+
+- **Reference pattern:** `tools/echo-tool/src/echo.rs` defines `EchoTool` with a helper function `call_echo` in its test module that constructs a `Parameters(EchoRequest { ... })` and calls the tool method directly. The read_file tests follow this same pattern.
+
+- **Workspace test conventions:**
+  - Inline tests use `#[cfg(test)] mod tests { use super::*; ... }`.
+  - Async tests use `#[tokio::test]` with `tokio` as a dev-dependency.
+  - Tests construct structs directly and assert on return values. No mocking frameworks.
+  - Assertions use `assert_eq!`, `assert!`, and `.contains()` for error message substring checks.
+
+## Requirements
+
+1. **File location:** The `#[cfg(test)] mod tests` block must be appended to `tools/read-file/src/read_file.rs`, the file that defines `ReadFileTool`.
+
+2. **Direct construction:** Tests must construct `ReadFileTool::new()` directly. No MCP server startup, no transport layer, no client connection.
+
+3. **Direct method call via helper:** Define a helper function `call_read_file(tool: &ReadFileTool, path: &str) -> String` that wraps the `Parameters(ReadFileRequest { ... })` construction, mirroring the `call_echo` helper in echo-tool.
+
+4. **Temp files:** Tests that need real files on disk must use `std::env::temp_dir()` combined with unique file names (e.g., using the test function name as a suffix) to create temporary files. Each test must clean up its temp file after assertions. Alternatively, tests may use a unique subdirectory per test.
+
+5. **Five test cases**, each as a separate `#[tokio::test] async fn`:
+
+   | # | Test name | Setup | Input | Assertion |
+   |---|-----------|-------|-------|-----------|
+   | 1 | `read_file_returns_contents` | Create a temp file containing `"hello from read_file test"` | Path to the temp file | Result string equals `"hello from read_file test"` |
+   | 2 | `read_file_nonexistent_path` | None | `"/tmp/nonexistent_file_spore_test_12345.txt"` (a path that does not exist) | Result string contains a substring indicating the file was not found (e.g., `.contains("not found")` or `.contains("does not exist")` or `.contains("No such file")`, case-insensitive check preferred) |
+   | 3 | `read_file_empty_path` | None | `""` (empty string) | Result string contains a substring indicating the path is empty or invalid (e.g., `.contains("empty")` or `.contains("path")`) |
+   | 4 | `read_file_preserves_unicode` | Create a temp file containing `"\u{1F600} hello \u{00E9}\u{00E8}\u{00EA} \u{4E16}\u{754C}"` | Path to the temp file | Result string equals the exact unicode input |
+   | 5 | `read_file_empty_file` | Create a temp file with empty contents (`""`) | Path to the temp file | Result string equals `""` (empty string, not an error) |
+
+6. **No server, no transport:** Tests must not start an MCP server, spawn a process, or use any transport. They test the pure function logic only.
+
+7. **Imports:** The test module imports from `super::*` (to access `ReadFileTool`, `ReadFileRequest`) and `rmcp::handler::server::wrapper::Parameters`. It also uses `std::fs` and `std::io::Write` for temp file management.
+
+## Implementation Details
+
+### File to modify: `tools/read-file/src/read_file.rs`
+
+Append a `#[cfg(test)]` module at the bottom of the file:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    fn temp_file_path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("spore_read_file_test_{}", name))
+    }
+
+    fn call_read_file(tool: &ReadFileTool, path: &str) -> String {
+        tool.read_file(Parameters(ReadFileRequest {
+            path: path.to_string(),
+        }))
+    }
+
+    #[tokio::test]
+    async fn read_file_returns_contents() {
+        let path = temp_file_path("returns_contents.txt");
+        let content = "hello from read_file test";
+        fs::write(&path, content).expect("failed to write temp file");
+
+        let tool = ReadFileTool::new();
+        let result = call_read_file(&tool, path.to_str().unwrap());
+        assert_eq!(result, content);
+
+        fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn read_file_nonexistent_path() {
+        let tool = ReadFileTool::new();
+        let result = call_read_file(&tool, "/tmp/nonexistent_file_spore_test_12345.txt");
+        let lower = result.to_lowercase();
+        assert!(
+            lower.contains("not found") || lower.contains("does not exist") || lower.contains("no such file"),
+            "expected error about missing file, got: {}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn read_file_empty_path() {
+        let tool = ReadFileTool::new();
+        let result = call_read_file(&tool, "");
+        let lower = result.to_lowercase();
+        assert!(
+            lower.contains("empty") || lower.contains("path"),
+            "expected error about empty path, got: {}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn read_file_preserves_unicode() {
+        let path = temp_file_path("preserves_unicode.txt");
+        let content = "\u{1F600} hello \u{00E9}\u{00E8}\u{00EA} \u{4E16}\u{754C}";
+        fs::write(&path, content).expect("failed to write temp file");
+
+        let tool = ReadFileTool::new();
+        let result = call_read_file(&tool, path.to_str().unwrap());
+        assert_eq!(result, content);
+
+        fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn read_file_empty_file() {
+        let path = temp_file_path("empty_file.txt");
+        fs::write(&path, "").expect("failed to write temp file");
+
+        let tool = ReadFileTool::new();
+        let result = call_read_file(&tool, path.to_str().unwrap());
+        assert_eq!(result, "");
+
+        fs::remove_file(&path).ok();
+    }
+}
+```
+
+**Note on `call_read_file` return type:** The echo-tool's `echo` method returns `String` directly (not `Result`). Per the task breakdown, the `read_file` method also returns `String` (returning descriptive error strings rather than `Result`). If the implementer uses a different return type, the helper and assertions must be adapted accordingly.
+
+**Note on temp file cleanup:** Tests use `fs::remove_file(&path).ok()` to silently ignore cleanup failures. This is acceptable for test code since temp files are ephemeral.
+
+### No other files created or modified
+
+This task only adds the `#[cfg(test)] mod tests` block. It does not modify `Cargo.toml` (dev-dependencies are handled by the scaffolding task), `main.rs`, or any other files.
+
+## Dependencies
+
+- **Blocked by:**
+  - "Implement `ReadFileTool` struct and handler" (Group 2, issue #44) -- the `ReadFileTool` struct and its `read_file` method must exist before tests can be written against them.
+- **Blocking:**
+  - "Write README" (Group 4, issue #44) -- the README task depends on tests existing and passing.
+
+## Risks & Edge Cases
+
+1. **Return type variance:** If the implementer wraps the return in `Result<String, ...>` instead of returning a plain `String`, the helper function and all assertions must unwrap or match on the `Result`. The echo-tool pattern returns `String` directly, so this spec assumes the same.
+
+2. **Error message wording:** Tests use `.contains()` with lowercase comparisons to be resilient against exact wording changes in error messages. The implementer should ensure error messages include at least one of the checked substrings.
+
+3. **Temp file race conditions:** Each test uses a unique file name derived from the test function name, so parallel test execution will not cause collisions.
+
+4. **File path encoding:** `temp_file_path` uses `to_str().unwrap()` which will panic if the temp directory contains non-UTF-8 characters. This is acceptable for test environments on all major platforms.
+
+5. **Nonexistent path test:** The path `/tmp/nonexistent_file_spore_test_12345.txt` is chosen to be extremely unlikely to exist. If it somehow does exist, the test will fail with a clear message.
+
+6. **Empty file vs error:** The spec explicitly requires that reading an empty file returns an empty string, not an error. This verifies that the tool does not treat zero-length files as an error condition.
+
+## Verification
+
+1. `cargo test -p read-file` compiles and all 5 test functions pass.
+2. `cargo clippy -p read-file --tests` reports no warnings on the test module.
+3. Test `read_file_returns_contents` confirms basic file reading works.
+4. Test `read_file_nonexistent_path` confirms a descriptive error is returned for missing files.
+5. Test `read_file_empty_path` confirms a descriptive error is returned for empty paths.
+6. Test `read_file_preserves_unicode` confirms unicode content survives the read round-trip.
+7. Test `read_file_empty_file` confirms empty files are handled gracefully (empty string, not error).

--- a/.claude/specs/issue-47/add-cargo-build-to-workspace.md
+++ b/.claude/specs/issue-47/add-cargo-build-to-workspace.md
@@ -1,0 +1,39 @@
+# Spec: Add `"tools/cargo-build"` to workspace Cargo.toml
+
+> From: .claude/tasks/issue-47.md
+
+## Objective
+Register the new `tools/cargo-build` crate as a workspace member so that it participates in `cargo build`, `cargo test`, and `cargo clippy` runs across the workspace.
+
+## Current State
+The root `Cargo.toml` contains a `[workspace]` section with `members` listing seven crates and four tools:
+```
+"tools/echo-tool",
+"tools/read-file",
+"tools/write-file",
+"tools/validate-skill",
+```
+`tools/cargo-build` is not yet listed.
+
+## Requirements
+1. Add `"tools/cargo-build"` to the `members` array in the root `Cargo.toml`.
+2. Place it after `"tools/validate-skill"` to maintain the current append-to-end ordering pattern used by the existing tool entries.
+3. No other changes to `Cargo.toml`.
+
+## Implementation Details
+- Insert `"tools/cargo-build",` as a new line after the `"tools/validate-skill",` entry (line 23) and before the closing `]` (line 24).
+- Preserve the existing 4-space indentation and trailing comma style.
+
+## Dependencies
+- Blocked by: None (the `tools/cargo-build` crate directory and its own `Cargo.toml` must exist before this change will compile, but that is handled by a sibling task)
+- Blocking: "Run verification suite"
+
+## Risks & Edge Cases
+- If the `tools/cargo-build` directory or its `Cargo.toml` does not yet exist when this change is applied, `cargo` commands will fail with a missing-member error. Ensure the crate scaffolding task runs first or concurrently.
+- A typo in the member path (e.g., `tools/cargo_build` vs `tools/cargo-build`) will cause the same failure; use the hyphenated form matching Cargo convention.
+
+## Verification
+1. `cargo check` — workspace resolves without errors.
+2. `cargo build` — all members, including `tools/cargo-build`, compile.
+3. `cargo test` — all workspace tests pass.
+4. Confirm `cargo metadata --no-deps` includes `cargo-build` in its package list.

--- a/.claude/specs/issue-47/create-cargo-build-cargo-toml.md
+++ b/.claude/specs/issue-47/create-cargo-build-cargo-toml.md
@@ -1,0 +1,62 @@
+# Spec: Create `tools/cargo-build/Cargo.toml`
+
+> From: .claude/tasks/issue-47.md
+
+## Objective
+Create the Cargo manifest for the `cargo-build` MCP tool crate, establishing it as a new tool package within the workspace. This is the foundational file that enables all subsequent implementation work for the cargo-build tool.
+
+## Current State
+The `tools/echo-tool/Cargo.toml` serves as the canonical template for all tool crates. It declares:
+- Package metadata: name, version `0.1.0`, edition `2024`
+- Runtime dependencies: `mcp-tool-harness` (path dep), `rmcp` (with `transport-io`, `server`, `macros`), `tokio` (with `macros`, `rt`, `io-std`), `serde` (with `derive`), `serde_json`
+- Dev dependencies: `mcp-test-utils` (path dep), `tokio` (with `macros`, `rt`, `rt-multi-thread`), `rmcp` (with `client`, `transport-child-process`), `serde_json`
+
+No `tools/cargo-build/` directory exists yet.
+
+## Requirements
+- The file must be a valid Cargo.toml that `cargo check -p cargo-build` accepts
+- Package name must be `cargo-build`
+- Version must be `0.1.0` and edition must be `2024`
+- Dependencies must exactly match the echo-tool pattern (same crates, same features, same version constraints)
+- Path dependencies must use `../../crates/` relative paths for `mcp-tool-harness` and `mcp-test-utils`
+- No additional dependencies beyond what echo-tool declares
+
+## Implementation Details
+- **File to create:** `tools/cargo-build/Cargo.toml`
+- Copy `tools/echo-tool/Cargo.toml` verbatim and change only `name = "echo-tool"` to `name = "cargo-build"`
+- All dependency versions, features, and paths remain identical
+
+### Expected file content
+
+```toml
+[package]
+name = "cargo-build"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }
+rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
+tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+rmcp = { version = "1", features = ["client", "transport-child-process"] }
+serde_json = "1"
+```
+
+## Dependencies
+- Blocked by: none (this is the first task for the cargo-build tool)
+- Blocking: "Implement `CargoBuildTool` struct and handler", "Write `main.rs`", "Write integration test"
+
+## Risks & Edge Cases
+- The workspace root `Cargo.toml` may need to include `tools/cargo-build` in its `[workspace] members` list for the crate to be recognized. Verify whether this is manual or auto-discovered via glob.
+- The crate will not compile until `src/main.rs` (or `src/lib.rs`) exists, so `cargo check -p cargo-build` will fail until the next task is complete. Validation should confirm the manifest parses correctly rather than requiring a full build.
+
+## Verification
+- Run `cargo verify-project --manifest-path tools/cargo-build/Cargo.toml` to confirm the manifest is syntactically valid (this does not require source files to exist)
+- Confirm the file is byte-identical to `tools/echo-tool/Cargo.toml` except for the package name
+- Confirm the workspace root includes the new crate (check `[workspace] members` in the root `Cargo.toml`)

--- a/.claude/specs/issue-47/implement-cargo-build-tool.md
+++ b/.claude/specs/issue-47/implement-cargo-build-tool.md
@@ -1,0 +1,102 @@
+# Spec: Implement CargoBuildTool struct and handler
+
+> From: .claude/tasks/issue-47.md
+
+## Objective
+
+Create `tools/cargo-build/src/cargo_build.rs` containing the `CargoBuildTool` struct and its MCP handler. The tool accepts a package name and an optional release flag, validates the package name to prevent command injection, shells out to `cargo build`, and returns structured JSON with the build result.
+
+## Current State
+
+No `tools/cargo-build/` directory exists yet. The project has established patterns in `echo-tool`, `read-file`, and `write-file` that this implementation must follow: request struct with derive macros, tool struct wrapping a `ToolRouter<Self>`, `#[tool_router]` impl block, `#[tool_handler]` ServerHandler impl, and `#[cfg(test)]` unit tests.
+
+## Requirements
+
+1. **Request type** -- `CargoBuildRequest` with two fields:
+   - `package: String` with doc comment `/// Package name to build (passed as -p <package>)`
+   - `release: Option<bool>` with doc comment `/// Whether to build in release mode`
+   - Derive `Debug, serde::Deserialize, schemars::JsonSchema`
+
+2. **Tool struct** -- `CargoBuildTool` with field `tool_router: ToolRouter<Self>`, derive `Debug, Clone`, and a `new()` constructor calling `Self::tool_router()`.
+
+3. **Package name validation** -- Before invoking `cargo build`, validate `request.package` using a character-by-character check (no regex crate). Every character must be ASCII alphanumeric, hyphen (`-`), or underscore (`_`). The string must also be non-empty. If validation fails, return immediately with a JSON error string: `serde_json::json!({ "success": false, "stderr": "Invalid package name: <name>" }).to_string()`.
+
+4. **Build execution** -- Use `std::process::Command::new("cargo")` with args `["build", "-p", &request.package]`. If `request.release == Some(true)`, append `"--release"` to the args. Capture output via `.output()`.
+
+5. **Result formatting** -- On successful spawn, return `serde_json::json!({ "success": <bool>, "stdout": <String>, "stderr": <String>, "exit_code": <i32> }).to_string()` where:
+   - `success` = `status.success()`
+   - `stdout` = `String::from_utf8_lossy(&output.stdout)`
+   - `stderr` = `String::from_utf8_lossy(&output.stderr)`
+   - `exit_code` = `status.code().unwrap_or(-1)`
+
+6. **Spawn failure** -- If `.output()` returns `Err(e)`, return `serde_json::json!({ "success": false, "stderr": format!("Failed to execute cargo: {e}") }).to_string()`.
+
+7. **Tool annotation** -- The method is annotated `#[tool(description = "Run cargo build on a specified package and return the result")]` and named `cargo_build`.
+
+8. **ServerHandler** -- `#[tool_handler] impl ServerHandler for CargoBuildTool` with `get_info` returning `ServerInfo::new(ServerCapabilities::builder().enable_tools().build())`.
+
+9. **Unit tests** -- `#[cfg(test)] mod tests` with three tests:
+   - `rejects_invalid_package_name` -- calls with `"foo; rm -rf /"`, parses result as JSON, asserts `success` is `false` and `stderr` contains `"Invalid package name"`.
+   - `rejects_package_with_path_separator` -- calls with `"../evil"`, parses result as JSON, asserts `success` is `false` and `stderr` contains `"Invalid package name"`.
+   - `validates_clean_package_name` -- calls with `"echo-tool"`, parses result as JSON, asserts the result contains the keys `success`, `stdout`, `stderr`, and `exit_code` (does not assert build success since the package may not exist in the test environment).
+
+## Implementation Details
+
+### Imports
+
+```rust
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+```
+
+### Validation helper
+
+Extract a private function `validate_package_name(name: &str) -> bool` that returns `true` only if the string is non-empty and every character satisfies `ch.is_ascii_alphanumeric() || ch == '-' || ch == '_'`. This keeps the tool method itself under 50 lines and follows single-responsibility.
+
+### Method body sketch
+
+The `cargo_build` method should:
+1. Call `validate_package_name` -- if false, return JSON error immediately.
+2. Build a `Command`, conditionally add `--release`.
+3. Match on `.output()` -- `Ok(output)` produces the success JSON, `Err(e)` produces the failure JSON.
+
+### Test helper
+
+Define a `call_cargo_build` helper (like `call_write_file` in write-file) to reduce boilerplate in tests:
+
+```rust
+fn call_cargo_build(tool: &CargoBuildTool, package: &str, release: Option<bool>) -> String {
+    tool.cargo_build(Parameters(CargoBuildRequest {
+        package: package.to_string(),
+        release,
+    }))
+}
+```
+
+Tests parse the returned string with `serde_json::from_str::<serde_json::Value>(&result).unwrap()` to assert on individual fields.
+
+## Dependencies
+
+- **Crate dependencies**: `rmcp`, `serde`, `schemars`, `serde_json` (all already used by sibling tools).
+- **No new external crates** -- validation is done with stdlib character checks.
+- **Blocked by**: `tools/cargo-build/Cargo.toml` must exist first so this file can compile.
+- **Blocks**: `main.rs` (needs to import and instantiate `CargoBuildTool`) and the integration test.
+
+## Risks & Edge Cases
+
+- **Command injection** -- Mitigated by the character validation. `std::process::Command` also passes args as a list (not through a shell), providing a second layer of defense.
+- **Empty package name** -- Covered by the non-empty check in `validate_package_name`.
+- **Path separators in package name** -- Characters like `.`, `/`, `\` are rejected by the allowlist, blocking path traversal attempts like `"../evil"`.
+- **Cargo not installed** -- The spawn-failure branch handles this gracefully, returning a JSON error rather than panicking.
+- **Signal-killed process** -- `status.code()` returns `None` when the process is killed by a signal; `unwrap_or(-1)` handles this.
+- **Large build output** -- `Command::output()` captures all stdout/stderr into memory. For very large builds this could use significant memory, but this is acceptable for an MCP tool where the caller expects a complete response.
+
+## Verification
+
+1. `cargo check -p cargo-build` -- confirms the file compiles.
+2. `cargo test -p cargo-build` -- runs all three unit tests.
+3. `cargo clippy -p cargo-build` -- no warnings.
+4. Manual review that the validation function rejects injection attempts, path traversal strings, and empty strings, while accepting valid names like `"echo-tool"`, `"my_package"`, `"foo123"`.

--- a/.claude/specs/issue-47/run-verification-suite.md
+++ b/.claude/specs/issue-47/run-verification-suite.md
@@ -1,0 +1,78 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-47.md
+
+## Objective
+Run the full verification suite for the `cargo-build` tool crate and the workspace as a whole to confirm that the implementation is correct, complete, and introduces no regressions. This is the final gate task for issue-47 -- it validates that the crate scaffolding, core implementation, integration tests, and workspace membership all integrate correctly.
+
+## Current State
+By the time this task runs, the preceding issue-47 tasks will have:
+1. Created `tools/cargo-build/Cargo.toml` with dependencies mirroring `echo-tool` (rmcp, tokio, serde, serde_json, mcp-tool-harness, mcp-test-utils)
+2. Added `"tools/cargo-build"` to the workspace `members` array in the root `Cargo.toml`
+3. Implemented `CargoBuildTool` in `tools/cargo-build/src/cargo_build.rs` with package name validation, `std::process::Command` invocation, and structured JSON output
+4. Written `tools/cargo-build/src/main.rs` using `mcp_tool_harness::serve_stdio_tool`
+5. Written unit tests for package name validation (rejects injection attempts, accepts valid names)
+6. Written integration tests in `tools/cargo-build/tests/cargo_build_server_test.rs` (MCP round-trip: tools/list, successful build, failed build, invalid package name rejection)
+
+## Requirements
+- `cargo build -p cargo-build` succeeds with zero errors
+- `cargo test -p cargo-build` succeeds with all tests passing, including:
+  - Unit tests: `rejects_invalid_package_name`, `rejects_package_with_path_separator`, `validates_clean_package_name`
+  - Integration tests: `tools_list_returns_cargo_build_tool`, `tools_call_builds_echo_tool_successfully`, `tools_call_returns_error_for_nonexistent_package`, `tools_call_rejects_invalid_package_name`
+- `cargo clippy -p cargo-build` succeeds with zero warnings
+- `cargo check` (workspace-wide) succeeds with zero errors, confirming no regressions in any other crate
+- The tool is named `cargo_build` in the MCP `tools/list` response (verified by the integration test)
+- A successful build returns structured JSON with `success: true`, `stdout`, `stderr`, and `exit_code: 0`
+- A failed build (nonexistent package) returns structured JSON with `success: false` and non-empty `stderr`
+- No commented-out code or debug statements remain in `cargo-build` source files
+- No unused imports, dead code, or Clippy lint violations in the `cargo-build` crate
+
+## Implementation Details
+This task does not create or modify source files. It is a verification-only task. The steps are:
+
+1. **Run `cargo build -p cargo-build`** from the workspace root. This compiles the `cargo-build` binary. If it fails, diagnose the root cause -- likely candidates include:
+   - Missing or incorrect dependency features in `tools/cargo-build/Cargo.toml`
+   - Import errors in source files (wrong `rmcp` module paths, missing `mcp_tool_harness` import)
+   - Type mismatches in the `ServerHandler` or `#[tool_router]` implementations
+   - The `tools/cargo-build` path not present in the root `Cargo.toml` `members` array
+
+2. **Run `cargo test -p cargo-build`** from the workspace root. This compiles and executes all unit and integration tests for the crate. Verify:
+   - All unit tests pass (package name validation: injection attempts rejected, valid names accepted)
+   - All integration tests pass (MCP client connects, tools/list returns `cargo_build`, build succeeds for `echo-tool`, build fails for nonexistent package, invalid package name is rejected before command execution)
+
+3. **Run `cargo clippy -p cargo-build`** from the workspace root with `-- -D warnings` to treat warnings as errors. Pay attention to:
+   - Unused imports or variables
+   - Clippy suggestions for `Command` API usage
+   - Warnings in test modules
+   - Any lint issues with the `#[tool_router]` macro-generated code
+
+4. **Run `cargo check`** (workspace-wide, no `-p` filter) to confirm that adding the `cargo-build` crate has not broken any other workspace member.
+
+5. If any step fails, **diagnose before fixing** (per project rules). Explain the root cause, then apply the minimal fix to the relevant file(s) introduced by the preceding tasks. Do not modify files outside the `cargo-build` crate unless a workspace-level issue is discovered.
+
+### Files potentially touched (fixes only, if needed)
+- `tools/cargo-build/Cargo.toml` -- dependency version or feature adjustments
+- `tools/cargo-build/src/cargo_build.rs` -- tool handler or validation fixes
+- `tools/cargo-build/src/main.rs` -- import or wiring fixes
+- `tools/cargo-build/tests/cargo_build_server_test.rs` -- test assertion corrections
+- `Cargo.toml` -- workspace member path fix (unlikely)
+
+## Dependencies
+- Blocked by: All preceding issue-47 tasks (Groups 1-3: crate scaffold, core implementation, integration tests)
+- Blocking: None (this is the final task for issue-47)
+
+## Risks & Edge Cases
+- **Integration test duration**: The integration test `tools_call_builds_echo_tool_successfully` invokes a real `cargo build -p echo-tool`. This is inherently slow (compiling a real crate). If the test runner has a short timeout, this test may fail. Mitigation: the test uses `#[tokio::test(flavor = "multi_thread")]` which has no default timeout; the CI environment should allow sufficient build time.
+- **Workspace-wide `cargo check` regressions**: A failing check in an unrelated crate (e.g., `agent-sdk`, `skill-loader`) would block this task. Mitigation: if a pre-existing issue is found, confirm it also fails on the `main` branch before attributing it to `cargo-build` changes.
+- **Command injection test false positive**: The unit test `validates_clean_package_name` actually invokes `cargo build -p echo-tool`. If `echo-tool` is not yet compiled or has issues, this test will fail for reasons unrelated to `cargo-build`. Mitigation: ensure `echo-tool` builds cleanly first (it should, as a workspace member).
+- **Binary name vs tool name mismatch**: The binary is `cargo-build` (hyphenated, from `[package] name`), but the MCP tool name must be `cargo_build` (snake_case, from the `#[tool_router]` method name). The integration test `tools_list_returns_cargo_build_tool` explicitly verifies this mapping.
+- **Stdio transport interference**: Since `cargo-build` uses stdin/stdout as the MCP transport, any accidental stdout writes (e.g., from `println!`) will corrupt the protocol. The integration tests will catch this if it happens.
+- **Edition 2024 lint behavior**: The workspace uses `edition = "2024"`, which may trigger lints not present in older editions. Address each lint individually rather than blanket-suppressing with `#[allow]`.
+
+## Verification
+- `cargo build -p cargo-build` exits with code 0
+- `cargo test -p cargo-build` exits with code 0, all test cases report `ok`, and the summary line shows 0 failures
+- `cargo clippy -p cargo-build -- -D warnings` exits with code 0 and produces no warning output
+- `cargo check` (workspace-wide) exits with code 0, confirming no regressions
+- The integration test output confirms the tool is listed as `cargo_build` in MCP tools/list
+- The integration test output confirms structured JSON with `success: true` for a valid build and `success: false` with non-empty `stderr` for a failed build

--- a/.claude/specs/issue-47/write-integration-tests.md
+++ b/.claude/specs/issue-47/write-integration-tests.md
@@ -1,0 +1,82 @@
+# Spec: Write integration tests
+
+> From: .claude/tasks/issue-47.md
+
+## Objective
+
+Create integration tests for the `cargo-build` MCP tool in `tools/cargo-build/tests/cargo_build_server_test.rs`. The tests verify the tool's listing metadata, successful builds, error handling for nonexistent packages, and input validation for malicious package names.
+
+## Current State
+
+No `tools/cargo-build/` directory exists yet. The tool and its `main.rs` are prerequisites (blocked by "Write `main.rs`"). The test file will be created once the binary crate is in place.
+
+## Requirements
+
+1. **File location:** `tools/cargo-build/tests/cargo_build_server_test.rs`
+2. **Binary reference:** Use `env!("CARGO_BIN_EXE_cargo-build")` to locate the compiled server binary.
+3. **Test runtime:** Every test function must use `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`.
+4. **Four test cases** (details in Implementation Details below).
+
+## Implementation Details
+
+Follow the pattern established in `tools/echo-tool/tests/echo_server_test.rs`:
+- Spawn the MCP client via `mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_cargo-build"))`.
+- Use `rmcp::model::CallToolRequestParams` for tool invocations.
+- Cancel the client at the end of each test with `client.cancel().await.expect("failed to cancel client")`.
+
+### Test 1: `tools_list_returns_cargo_build_tool`
+
+- Call `mcp_test_utils::assert_single_tool` with:
+  - `expected_name`: `"cargo_build"`
+  - `description_contains`: `"cargo build"` (case-sensitive substring match)
+  - `expected_params`: `&["package", "release"]`
+- No tool invocation needed; listing validation only.
+
+### Test 2: `tools_call_builds_echo_tool_successfully`
+
+- Create `CallToolRequestParams::new("cargo_build")` with arguments `{"package": "echo-tool"}`.
+- Call the tool via `client.peer().call_tool(params).await`.
+- Extract the first content element as text.
+- Parse the text as JSON (`serde_json::from_str`).
+- Assert `json["success"]` is `true`.
+- Assert `json["exit_code"]` is `0`.
+
+### Test 3: `tools_call_returns_error_for_nonexistent_package`
+
+- Create `CallToolRequestParams::new("cargo_build")` with arguments `{"package": "nonexistent-package-xyz"}`.
+- Call the tool and extract text from the first content element.
+- Parse the text as JSON.
+- Assert `json["success"]` is `false`.
+- Assert `json["stderr"]` is a non-empty string (use `.as_str().map(|s| !s.is_empty())`).
+
+### Test 4: `tools_call_rejects_invalid_package_name`
+
+- Create `CallToolRequestParams::new("cargo_build")` with arguments `{"package": "foo;bar"}`.
+- Call the tool and inspect the response.
+- Assert the response indicates an error. This could manifest as:
+  - `result.is_error` being `Some(true)`, or
+  - The text content containing an error message about invalid package name.
+- The key invariant: the tool must reject `foo;bar` **before** spawning any `cargo` subprocess (shell-injection prevention).
+
+## Dependencies
+
+- **Crate dependencies** (in `tools/cargo-build/Cargo.toml` under `[dev-dependencies]`):
+  - `tokio` (with `macros`, `rt-multi-thread` features)
+  - `rmcp`
+  - `serde_json`
+  - `mcp-test-utils` (path = `../../crates/mcp-test-utils`)
+- **Blocked by:** The `cargo-build` binary (`main.rs`) must exist and compile before these tests can run.
+
+## Risks & Edge Cases
+
+- **Test 2 build time:** Building `echo-tool` from within a test may be slow; no timeout override is specified, so the default `tokio::test` timeout applies. If CI is slow, this test may need a longer timeout or `#[ignore]` annotation. Start without either and adjust if needed.
+- **Workspace root assumption:** The `cargo build -p echo-tool` command in Test 2 assumes the working directory or `--manifest-path` resolves to the workspace root. The tool implementation must handle this; the test just validates the contract.
+- **Error format in Test 4:** The exact error shape depends on whether validation happens at the MCP schema level (rmcp rejects it) or at the tool handler level (tool returns an error response). The test should accept either `is_error == true` on the result or an error message in the text content.
+
+## Verification
+
+1. `cargo test -p cargo-build` passes all four tests.
+2. Each test spawns and cleanly shuts down the MCP server process (no zombie processes).
+3. Test 2 produces a successful build of `echo-tool`.
+4. Test 3 confirms failure output with non-empty stderr.
+5. Test 4 confirms `foo;bar` is rejected without shell execution.

--- a/.claude/specs/issue-47/write-main-rs.md
+++ b/.claude/specs/issue-47/write-main-rs.md
@@ -1,0 +1,52 @@
+# Spec: Write `src/main.rs`
+
+> From: .claude/tasks/issue-47.md
+
+## Objective
+
+Create the entry-point file `tools/cargo-build/src/main.rs` that boots the `cargo-build` MCP tool via `mcp_tool_harness::serve_stdio_tool`. The file must mirror the structure of `tools/echo-tool/src/main.rs` exactly and remain under 10 lines.
+
+## Current State
+
+The file `tools/cargo-build/src/main.rs` does not yet exist. The established pattern is visible in `tools/echo-tool/src/main.rs` (7 lines): declare the module, import the tool struct, define an async `main`, and delegate to `serve_stdio_tool`.
+
+## Requirements
+
+1. Declare `mod cargo_build;` to pull in the sibling module.
+2. Import `CargoBuildTool` from that module (`use cargo_build::CargoBuildTool;`).
+3. Annotate `main` with `#[tokio::main(flavor = "current_thread")]`.
+4. Return `Result<(), Box<dyn std::error::Error>>`.
+5. Body: a single expression `mcp_tool_harness::serve_stdio_tool(CargoBuildTool::new(), "cargo-build").await`.
+6. Total file length must be under 10 lines (target: 7 lines, matching echo-tool).
+
+## Implementation Details
+
+The file should be exactly:
+
+```rust
+mod cargo_build;
+use cargo_build::CargoBuildTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(CargoBuildTool::new(), "cargo-build").await
+}
+```
+
+No additional imports, logic, or error handling beyond what `serve_stdio_tool` already provides.
+
+## Dependencies
+
+- **Blocked by**: `src/cargo_build.rs` must exist and export `CargoBuildTool` with a `new()` constructor; otherwise this file will not compile.
+- **Crate dependencies**: `tokio` (with `rt` and `macros` features) and `mcp_tool_harness` must be listed in `tools/cargo-build/Cargo.toml`.
+
+## Risks & Edge Cases
+
+- If the module file is named incorrectly (e.g., `cargo-build.rs` with a hyphen instead of `cargo_build.rs` with an underscore), `mod cargo_build;` will fail to resolve. Rust module names use underscores.
+- If `CargoBuildTool::new()` is not publicly exported, compilation will fail.
+
+## Verification
+
+1. `cargo check -p cargo-build` compiles without errors (requires the sibling module and Cargo.toml to be in place).
+2. `wc -l tools/cargo-build/src/main.rs` reports fewer than 10 lines.
+3. `diff <(sed 's/echo/cargo_build/g; s/EchoTool/CargoBuildTool/g; s/echo-tool/cargo-build/g' tools/echo-tool/src/main.rs) tools/cargo-build/src/main.rs` produces no output, confirming structural parity with echo-tool.

--- a/.claude/specs/issue-48/add-workspace-member.md
+++ b/.claude/specs/issue-48/add-workspace-member.md
@@ -1,0 +1,49 @@
+# Spec: Add `"tools/docker-build"` to workspace `Cargo.toml`
+
+> From: .claude/tasks/issue-48.md
+
+## Objective
+Register the new `tools/docker-build` crate as a workspace member so that `cargo build`, `cargo test`, and other workspace-wide commands include it. This is a prerequisite for the verification suite to pass once the crate exists.
+
+## Current State
+The root `Cargo.toml` defines a workspace with 11 members. The last entry in the `members` list is `"tools/cargo-build"` (line 24). The `tools/docker-build` directory is not yet referenced.
+
+```toml
+members = [
+    "crates/agent-sdk",
+    "crates/skill-loader",
+    "crates/tool-registry",
+    "crates/agent-runtime",
+    "crates/mcp-tool-harness",
+    "crates/orchestrator",
+    "crates/mcp-test-utils",
+    "tools/echo-tool",
+    "tools/read-file",
+    "tools/write-file",
+    "tools/validate-skill",
+    "tools/cargo-build",
+]
+```
+
+## Requirements
+- The string `"tools/docker-build"` must appear in the `members` array of the `[workspace]` section.
+- It must be placed immediately after `"tools/cargo-build"` to maintain alphabetical/logical ordering of tool entries.
+- The trailing comma style must be preserved (each entry on its own line, trailing comma after the last entry).
+- No other lines in `Cargo.toml` should be modified.
+
+## Implementation Details
+- **File to modify:** `Cargo.toml` (root workspace manifest)
+- **Change:** Add the line `    "tools/docker-build",` after the `    "tools/cargo-build",` line inside the `members` list.
+
+## Dependencies
+- Blocked by: None
+- Blocking: "Run verification suite"
+
+## Risks & Edge Cases
+- If the `tools/docker-build` directory or its own `Cargo.toml` does not exist yet when this change is applied, `cargo` commands will fail with a missing-manifest error. Ensure the crate scaffold is created before (or in the same PR as) this workspace registration.
+- Duplicate entry: confirm `"tools/docker-build"` does not already appear in the list before adding.
+
+## Verification
+- `grep '"tools/docker-build"' Cargo.toml` returns exactly one match.
+- The `members` list is syntactically valid TOML (no missing commas, no duplicate entries).
+- Once the `tools/docker-build` crate exists on disk, `cargo metadata --no-deps` includes `docker-build` in its package list.

--- a/.claude/specs/issue-48/create-cargo-toml.md
+++ b/.claude/specs/issue-48/create-cargo-toml.md
@@ -1,0 +1,50 @@
+# Spec: Create `tools/docker-build/Cargo.toml`
+
+> From: .claude/tasks/issue-48.md
+
+## Objective
+Create the Cargo manifest for the `docker-build` MCP tool crate. This is the foundational file that defines the crate metadata, dependencies, and dev-dependencies needed before any Rust source files can be written. Without it, the crate cannot compile or be included in the workspace.
+
+## Current State
+- `tools/cargo-build/Cargo.toml` exists and serves as the template. It declares `mcp-tool-harness` (path), `rmcp`, `tokio`, `serde`, and `serde_json` as dependencies, plus `mcp-test-utils` and test-oriented features in dev-dependencies.
+- The workspace `Cargo.toml` at the repo root lists tool crates under `[workspace] members`. Currently `tools/cargo-build` is listed but `tools/docker-build` is not.
+- The directory `tools/docker-build/` does not yet exist.
+
+## Requirements
+- The file `tools/docker-build/Cargo.toml` must be a valid Cargo manifest with `name = "docker-build"`.
+- `edition` must be `"2024"`, matching the existing tool crates.
+- `version` must be `"0.1.0"`.
+- `[dependencies]` must include exactly:
+  - `mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }`
+  - `rmcp = { version = "1", features = ["transport-io", "server", "macros"] }`
+  - `tokio = { version = "1", features = ["macros", "rt", "io-std"] }`
+  - `serde = { version = "1", features = ["derive"] }`
+  - `serde_json = "1"`
+- `[dev-dependencies]` must include exactly:
+  - `mcp-test-utils = { path = "../../crates/mcp-test-utils" }`
+  - `tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }`
+  - `rmcp = { version = "1", features = ["client", "transport-child-process"] }`
+  - `serde_json = "1"`
+- The workspace root `Cargo.toml` must add `"tools/docker-build"` to the `members` list so Cargo discovers the crate.
+- No new external dependencies beyond what `cargo-build` already uses.
+
+## Implementation Details
+- **Files to create:**
+  - `tools/docker-build/Cargo.toml` -- copy of `tools/cargo-build/Cargo.toml` with `name` changed to `"docker-build"`. All other fields remain identical.
+- **Files to modify:**
+  - `Cargo.toml` (workspace root) -- add `"tools/docker-build"` to the `[workspace] members` array, placed alphabetically near `"tools/cargo-build"`.
+- No Rust source files are created in this task. The crate will not compile until `src/main.rs` is added by the blocking task.
+
+## Dependencies
+- Blocked by: None
+- Blocking: "Implement `DockerBuildTool` struct and handler", "Write `main.rs`", "Write integration tests"
+
+## Risks & Edge Cases
+- **Workspace resolution failure**: If the workspace root `Cargo.toml` is not updated, `cargo build` will not find the new crate. Mitigation: always update the members list as part of this task.
+- **Path dependency correctness**: The relative path `../../crates/mcp-tool-harness` assumes the crate lives at `tools/docker-build/`. If the directory is placed elsewhere, the path will break. Mitigation: verify the directory structure matches `tools/cargo-build/`.
+- **Incomplete task**: Because no `src/main.rs` exists yet, `cargo check -p docker-build` will fail after this task alone. This is expected and resolved by the blocking tasks.
+
+## Verification
+- `cat tools/docker-build/Cargo.toml` shows the correct manifest with `name = "docker-build"` and all required dependencies.
+- `grep "tools/docker-build" Cargo.toml` confirms the workspace root includes the new member.
+- `cargo metadata --no-deps` lists `docker-build` as a workspace member (will only fully succeed once `src/main.rs` exists from the blocking task).

--- a/.claude/specs/issue-48/implement-docker-build-tool.md
+++ b/.claude/specs/issue-48/implement-docker-build-tool.md
@@ -1,0 +1,159 @@
+# Spec: Implement `DockerBuildTool` struct and handler
+
+> From: .claude/tasks/issue-48.md
+
+## Objective
+
+Create `tools/docker-build/src/docker_build.rs` containing the `DockerBuildTool` struct and its MCP handler. The tool accepts a build context path, an image tag, optional build arguments, and an optional Dockerfile path. It performs security-critical input validation on all fields, shells out to `docker build`, parses the image ID from build output, and returns structured JSON with the result.
+
+## Current State
+
+The project has established MCP tool patterns in `cargo-build`, `echo-tool`, `read-file`, and `write-file`. Each tool follows the same structure: a request struct with `#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]`, a tool struct wrapping `ToolRouter<Self>`, a `#[tool_router]` impl block with a `#[tool]`-annotated method, a `#[tool_handler]` ServerHandler impl, and `#[cfg(test)]` unit tests. The `CargoBuildTool` in `tools/cargo-build/src/cargo_build.rs` is the closest reference -- it validates input, constructs a `std::process::Command`, captures output, and returns JSON. The `DockerBuildTool` follows this same pattern but with more complex validation (path traversal checks, shell metacharacter rejection) and output parsing (image ID extraction).
+
+## Requirements
+
+1. **Request type** -- `DockerBuildRequest` with four fields:
+   - `context: String` with doc comment `/// Build context path (required)`
+   - `tag: String` with doc comment `/// Image tag (required)`
+   - `build_args: Option<std::collections::HashMap<String, String>>` with doc comment `/// Optional build arguments`
+   - `dockerfile: Option<String>` with doc comment `/// Optional Dockerfile path`
+   - Derive `Debug, serde::Deserialize, schemars::JsonSchema`
+
+2. **Tool struct** -- `DockerBuildTool` with field `tool_router: ToolRouter<Self>`, derive `Debug, Clone`, and a `new()` constructor calling `Self::tool_router()`.
+
+3. **Context path validation (security-critical)**:
+   - Reject if `context` contains `..` path segments before any canonicalization (check for `..` as a standalone path component, not just as a substring).
+   - Canonicalize the path with `std::fs::canonicalize`. If canonicalization fails (path does not exist), return a validation error.
+   - Verify the canonicalized path starts with `std::env::current_dir()` (or a configured project root). Reject if the resolved path escapes the working directory.
+   - Return JSON error: `{ "success": false, "build_log": "Invalid context path: <reason>" }`.
+
+4. **Tag validation**:
+   - Only allow characters matching `[a-zA-Z0-9._:/-]`. Reject if any character falls outside this set.
+   - The tag must be non-empty.
+   - Return JSON error: `{ "success": false, "build_log": "Invalid tag: <tag>" }`.
+
+5. **Dockerfile path validation** (if provided):
+   - Apply the same path traversal checks as `context` (reject `..` segments, canonicalize, verify within working directory).
+   - Return JSON error: `{ "success": false, "build_log": "Invalid dockerfile path: <reason>" }`.
+
+6. **Build args validation** (if provided):
+   - Reject any key or value containing shell metacharacters: `;`, `&`, `|`, `$`, backtick, `\n`, `\r`, `(`, `)`, `{`, `}`, `<`, `>`, `'`, `"`, `\\`.
+   - Keys must also be non-empty.
+   - Return JSON error: `{ "success": false, "build_log": "Invalid build argument: <reason>" }`.
+
+7. **Build execution**:
+   - Use `std::process::Command::new("docker")` with base args `["build", "-t", &tag]`.
+   - If `dockerfile` is provided, append `["-f", &dockerfile]` before the context argument.
+   - For each entry in `build_args`, append `["--build-arg", &format!("{key}={value}")]`.
+   - Append `&context` as the final argument.
+   - Capture output with `.output()`.
+
+8. **Output parsing**:
+   - On successful spawn, combine stdout and stderr into a single `build_log` string.
+   - Extract image ID by searching for a line matching either:
+     - `Successfully built <id>` (legacy builder) -- capture `<id>`
+     - `writing image sha256:<id>` (BuildKit) -- capture the sha256 prefix (first 12+ chars)
+   - Return JSON: `{ "success": <bool>, "image_id": "<extracted or empty>", "tag": "<tag>", "build_log": "<combined output>" }`.
+   - On spawn failure (`Err(e)`), return: `{ "success": false, "image_id": "", "tag": "<tag>", "build_log": "Failed to execute docker: <error>" }`.
+
+9. **Tool annotation** -- The method is annotated `#[tool(description = "Run docker build and return the result with image ID")]` and named `docker_build`.
+
+10. **ServerHandler** -- `#[tool_handler] impl ServerHandler for DockerBuildTool` with `get_info` returning `ServerInfo::new(ServerCapabilities::builder().enable_tools().build())`.
+
+11. **Unit tests** -- `#[cfg(test)] mod tests` with four tests (details in Verification section).
+
+## Implementation Details
+
+### Imports
+
+```rust
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+use std::collections::HashMap;
+```
+
+### Validation helpers
+
+Extract private functions to keep the tool method under 50 lines and maintain single responsibility:
+
+- `validate_path(path: &str, label: &str) -> Result<std::path::PathBuf, String>` -- Checks for `..` segments by splitting on path separators (`/` and `\`) and checking if any component equals `..`. Then calls `std::fs::canonicalize`. Then verifies the result starts with `std::env::current_dir().unwrap()`. Returns `Ok(canonicalized)` or `Err(reason)`.
+
+- `validate_tag(tag: &str) -> bool` -- Returns `true` only if non-empty and every character satisfies `ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | ':' | '/' | '-')`.
+
+- `validate_build_args(args: &HashMap<String, String>) -> Result<(), String>` -- Iterates all keys and values, checking for shell metacharacters and newlines. Returns `Ok(())` or `Err(description)`.
+
+- `has_shell_metacharacters(s: &str) -> bool` -- Returns `true` if `s` contains any of: `;`, `&`, `|`, `$`, backtick, `\n`, `\r`, `(`, `)`, `{`, `}`, `<`, `>`, `'`, `"`, `\\`.
+
+- `extract_image_id(output: &str) -> String` -- Scans lines for `Successfully built ` or `writing image sha256:`. Returns the extracted ID or an empty string.
+
+### Method body sketch
+
+The `docker_build` method should:
+1. Call `validate_path(&request.context, "context")` -- if Err, return JSON error.
+2. Call `validate_tag(&request.tag)` -- if false, return JSON error.
+3. If `request.dockerfile` is `Some`, call `validate_path` on it -- if Err, return JSON error.
+4. If `request.build_args` is `Some`, call `validate_build_args` -- if Err, return JSON error.
+5. Build `Command::new("docker")` with args `["build", "-t", &request.tag]`.
+6. Conditionally add `["-f", &dockerfile]`.
+7. Loop over build_args appending `["--build-arg", "{k}={v}"]`.
+8. Append context as the last positional arg.
+9. Match on `.output()` -- on `Ok`, extract image ID, build JSON response; on `Err`, return failure JSON.
+
+### Test helper
+
+```rust
+fn call_docker_build(
+    tool: &DockerBuildTool,
+    context: &str,
+    tag: &str,
+    build_args: Option<HashMap<String, String>>,
+    dockerfile: Option<&str>,
+) -> String {
+    tool.docker_build(Parameters(DockerBuildRequest {
+        context: context.to_string(),
+        tag: tag.to_string(),
+        build_args,
+        dockerfile: dockerfile.map(|s| s.to_string()),
+    }))
+}
+```
+
+Tests parse the returned string with `serde_json::from_str::<serde_json::Value>(&result).unwrap()` to assert on individual fields.
+
+### JSON output field names
+
+All responses use exactly these field names: `success` (bool), `image_id` (string), `tag` (string), `build_log` (string). This is distinct from the `cargo_build` tool which uses `stdout`/`stderr`/`exit_code` -- the docker tool merges output into a single `build_log` and adds the parsed `image_id`.
+
+## Dependencies
+
+- **Crate dependencies**: `rmcp`, `serde`, `schemars`, `serde_json` (all already used by sibling tools).
+- **No new external crates** -- validation uses stdlib character checks and path operations. Image ID extraction uses simple string searching (no regex needed).
+- **Blocked by**: "Create `tools/docker-build/Cargo.toml`" must exist first so this file can compile.
+- **Blocking**: "Write `main.rs`" (needs to import and instantiate `DockerBuildTool`) and "Write integration tests".
+
+## Risks & Edge Cases
+
+- **Path traversal attacks** -- Mitigated by rejecting `..` segments before canonicalization and verifying canonicalized paths are within the working directory. Symlinks that escape the working directory are caught by checking the canonicalized result.
+- **Command injection via tag** -- Mitigated by the strict character allowlist. `std::process::Command` also passes args as a list (not through a shell), providing a second layer of defense.
+- **Command injection via build args** -- Mitigated by rejecting shell metacharacters in both keys and values. Even though `Command` does not use a shell, this prevents misuse if the args are ever logged or processed by other tools.
+- **Docker not installed** -- The spawn-failure branch handles this gracefully, returning structured JSON with `success: false` rather than panicking.
+- **BuildKit vs legacy builder output** -- The image ID extraction handles both formats (`Successfully built` and `writing image sha256:`). If neither pattern is found (e.g., future Docker output format changes), `image_id` is returned as an empty string -- the caller can still use the `tag` field.
+- **Non-existent context path** -- `std::fs::canonicalize` will fail, caught by the validation step with a clear error message.
+- **Large build output** -- `Command::output()` captures all stdout/stderr into memory. Acceptable for an MCP tool where the caller expects a complete response.
+- **Race conditions on paths** -- A validated path could be modified between validation and Docker invocation (TOCTOU). This is an inherent limitation; Docker itself will fail with a clear error if the path disappears.
+- **Signal-killed process** -- Not directly relevant since we do not report `exit_code`; we rely on `status.success()` for the `success` field.
+- **Empty build_args HashMap** -- An empty `Some(HashMap::new())` should be treated the same as `None` (no `--build-arg` flags added). The iteration loop handles this naturally.
+
+## Verification
+
+1. `cargo check -p docker-build` -- confirms the file compiles.
+2. `cargo test -p docker-build` -- runs all four unit tests:
+   - `rejects_context_with_path_traversal` -- calls with `context: "../../etc"`, `tag: "test:latest"`, no build_args, no dockerfile. Parses JSON, asserts `success` is `false` and `build_log` contains a path validation error message.
+   - `rejects_tag_with_shell_metacharacters` -- calls with `context: "."`, `tag: "foo;echo injected"`, no build_args, no dockerfile. Parses JSON, asserts `success` is `false` and `build_log` contains `"Invalid tag"`.
+   - `rejects_invalid_build_arg_keys` -- calls with `context: "."`, `tag: "test:latest"`, `build_args: Some(HashMap::from([("key;bad".into(), "val".into())]))`, no dockerfile. Parses JSON, asserts `success` is `false` and `build_log` contains `"Invalid build argument"`.
+   - `validates_clean_inputs` -- calls with `context: "."`, `tag: "test:latest"`, no build_args, no dockerfile. Parses JSON, asserts the result contains keys `success`, `image_id`, `tag`, and `build_log`. Does not assert `success: true` since Docker may not be installed in the test environment.
+3. `cargo clippy -p docker-build` -- no warnings.
+4. Manual review that validation functions correctly reject path traversal, shell injection, and metacharacter attacks while accepting legitimate inputs.

--- a/.claude/specs/issue-48/run-verification-suite.md
+++ b/.claude/specs/issue-48/run-verification-suite.md
@@ -1,0 +1,68 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-48.md
+
+## Objective
+Validate that the fully implemented `docker-build` crate compiles, passes all tests, satisfies linting rules, and meets every acceptance criterion defined in the task breakdown. This is the final gate before the feature branch is considered complete.
+
+## Current State
+N/A — this is a verification-only task. All implementation tasks (crate scaffold, core handler, main entry point, integration tests, workspace registration) must be complete before this task runs.
+
+## Requirements
+- `cargo build -p docker-build` exits with code 0 (no compilation errors or warnings treated as errors).
+- `cargo test -p docker-build` exits with code 0 and all tests pass, including:
+  - Unit tests for input validation (path traversal rejection, tag sanitization, build-arg key validation, clean input acceptance).
+  - Integration tests (tools/list returns `docker_build`, path traversal rejected via MCP call, invalid tag rejected via MCP call, graceful error when Docker is unavailable).
+- `cargo clippy -p docker-build` exits with code 0 (no lint warnings).
+- `cargo check` (workspace-wide, no `-p` flag) exits with code 0, confirming the new crate does not break any other workspace member.
+- The MCP tools/list response contains exactly one tool named `docker_build` with a description containing "Docker image" and parameters including `context`, `tag`, `build_args`, and `dockerfile`.
+- On valid inputs where Docker is unavailable, the tool returns structured JSON with `success: false` and a human-readable error in `build_log` (not a crash or unstructured text).
+- On invalid inputs (path traversal, shell metacharacters in tag, bad build-arg keys), the tool returns structured JSON with `success: false` and a validation error message — the invalid input must never reach a `docker` subprocess.
+
+## Implementation Details
+Run the following commands in order. Each must succeed before proceeding to the next.
+
+1. **Build the crate:**
+   ```
+   cargo build -p docker-build
+   ```
+   Expected: exit code 0, binary produced at `target/debug/docker-build`.
+
+2. **Run tests:**
+   ```
+   cargo test -p docker-build
+   ```
+   Expected: exit code 0, all unit and integration tests pass. Review test output to confirm each named test case executed.
+
+3. **Run linter:**
+   ```
+   cargo clippy -p docker-build
+   ```
+   Expected: exit code 0, no warnings.
+
+4. **Workspace-wide check:**
+   ```
+   cargo check
+   ```
+   Expected: exit code 0 for every workspace member.
+
+5. **Spot-check acceptance criteria** (already covered by integration tests, but confirm in test output):
+   - `tools_list_returns_docker_build_tool` — tool name is `docker_build`.
+   - `tools_call_rejects_path_traversal` — validation error returned as JSON.
+   - `tools_call_rejects_invalid_tag` — validation error returned as JSON.
+   - `tools_call_returns_error_when_docker_unavailable` — structured JSON with `success: false`.
+
+## Dependencies
+- Blocked by: All previous tasks (Create `Cargo.toml`, Add workspace member, Implement `DockerBuildTool`, Write `main.rs`, Write integration tests, Write `README.md`)
+- Blocking: None
+
+## Risks & Edge Cases
+- **Docker availability:** CI environments may not have Docker installed. The integration test `tools_call_returns_error_when_docker_unavailable` is designed to handle this gracefully, but if Docker happens to be available, the test should still pass (it checks for valid JSON structure regardless of success/failure).
+- **Flaky tests from process spawning:** The `spawn_mcp_client!` macro starts a child process. If the binary path is wrong or the build step was skipped, integration tests will fail with an opaque error. Always run `cargo build` before `cargo test`.
+- **Clippy version differences:** Different Rust toolchain versions may surface different clippy lints. If a new lint appears, fix the code rather than suppressing it.
+- **Workspace breakage:** Adding a new member could surface dependency conflicts or feature-flag incompatibilities. The `cargo check` step catches this at the workspace level.
+
+## Verification
+- All four commands (`cargo build -p docker-build`, `cargo test -p docker-build`, `cargo clippy -p docker-build`, `cargo check`) exit with code 0.
+- Test output shows every expected test name (unit and integration) with status `ok`.
+- No warnings or errors in any command output.

--- a/.claude/specs/issue-48/write-integration-tests.md
+++ b/.claude/specs/issue-48/write-integration-tests.md
@@ -1,0 +1,156 @@
+# Spec: Write integration tests
+
+> From: .claude/tasks/issue-48.md
+
+## Objective
+
+Create integration tests for the `docker-build` MCP tool binary that verify tool discovery, input validation (path traversal and tag injection), and graceful degradation when Docker is unavailable. These tests exercise the full MCP server process over stdio transport, matching the project's established integration test pattern.
+
+## Current State
+
+The project has a well-established integration test pattern used across all tool crates:
+
+- **`crates/mcp-test-utils/src/lib.rs`** provides:
+  - `spawn_mcp_client!($bin_path)` macro: spawns the MCP server binary as a child process via `TokioChildProcess`, connects an `rmcp` client, and returns a `RunningService<RoleClient, ()>`.
+  - `assert_single_tool(client, name, description_contains, expected_params)`: asserts the server exposes exactly one tool with matching name, description substring, and parameter names.
+  - `unique_temp_dir(test_name)`: creates isolated temp directories for tests (not needed here).
+
+- **Existing test files follow an identical structure** (see `tools/cargo-build/tests/cargo_build_server_test.rs`, `tools/echo-tool/tests/echo_server_test.rs`):
+  - Single `use rmcp::model::CallToolRequestParams;` import at top.
+  - Each test is `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`.
+  - Client is spawned via `mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_<crate-name>")).await`.
+  - Tool calls use `CallToolRequestParams::new("<tool_name>").with_arguments(serde_json::json!({...}).as_object().unwrap().clone())`.
+  - Response text is extracted via `result.content.first().expect(...).as_text().expect(...)`.
+  - JSON is parsed via `serde_json::from_str::<serde_json::Value>(&text.text)`.
+  - Assertions check `json["success"]`, `json["stderr"]`, etc.
+  - Each test ends with `client.cancel().await.expect("failed to cancel client");`.
+
+- The `docker-build` crate does not yet exist. This spec depends on the `main.rs` and `docker_build.rs` implementation being complete first.
+
+## Requirements
+
+1. **File location**: `tools/docker-build/tests/docker_build_server_test.rs`.
+
+2. **Test: `tools_list_returns_docker_build_tool`**
+   - Spawn the `docker-build` binary via `spawn_mcp_client!(env!("CARGO_BIN_EXE_docker-build"))`.
+   - Call `mcp_test_utils::assert_single_tool` with:
+     - `expected_name`: `"docker_build"`
+     - `description_contains`: `"Docker image"`
+     - `expected_params`: `["context", "tag", "build_args", "dockerfile"]`
+   - Cancel the client.
+
+3. **Test: `tools_call_rejects_path_traversal`**
+   - Spawn the client.
+   - Call `docker_build` with arguments `{"context": "../../etc", "tag": "test:latest"}`.
+   - Parse response content as JSON.
+   - Assert `json["success"] == false`.
+   - Assert the response text contains a validation-related error message (e.g., check that `json["build_log"]` or `json["stderr"]` contains a substring like `"validation"`, `"path traversal"`, `"invalid"`, or similar -- the exact field and message depends on the `docker_build.rs` implementation, so the assertion should be flexible enough to match any reasonable validation error wording).
+   - Cancel the client.
+
+4. **Test: `tools_call_rejects_invalid_tag`**
+   - Spawn the client.
+   - Call `docker_build` with arguments `{"context": ".", "tag": "test;evil"}`.
+   - Parse response content as JSON.
+   - Assert `json["success"] == false`.
+   - Cancel the client.
+
+5. **Test: `tools_call_returns_error_when_docker_unavailable`**
+   - Spawn the client.
+   - Call `docker_build` with valid arguments `{"context": ".", "tag": "test:latest"}`.
+   - Parse response content as JSON.
+   - Assert `json["success"] == false` (Docker is not expected to be available in CI).
+   - Assert the response contains a meaningful error message (non-empty `build_log` or error field).
+   - This test validates graceful degradation: the tool must return well-formed JSON even when Docker is missing, rather than crashing or returning unparseable output.
+   - Cancel the client.
+
+6. **All tests must use** `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`.
+
+7. **Imports**: Only `use rmcp::model::CallToolRequestParams;` at the top, consistent with existing tests. The `mcp_test_utils` and `serde_json` crates are accessed via their fully qualified paths.
+
+## Implementation Details
+
+### File to create
+
+**`tools/docker-build/tests/docker_build_server_test.rs`**
+
+Structure (pseudocode outline):
+
+```
+use rmcp::model::CallToolRequestParams;
+
+// Test 1: tools_list_returns_docker_build_tool
+//   - spawn client
+//   - assert_single_tool("docker_build", "Docker image", &["context", "tag", "build_args", "dockerfile"])
+//   - cancel client
+
+// Test 2: tools_call_rejects_path_traversal
+//   - spawn client
+//   - call docker_build with {"context": "../../etc", "tag": "test:latest"}
+//   - parse JSON from response text
+//   - assert success == false
+//   - assert error message is present and indicates validation failure
+//   - cancel client
+
+// Test 3: tools_call_rejects_invalid_tag
+//   - spawn client
+//   - call docker_build with {"context": ".", "tag": "test;evil"}
+//   - parse JSON from response text
+//   - assert success == false
+//   - cancel client
+
+// Test 4: tools_call_returns_error_when_docker_unavailable
+//   - spawn client
+//   - call docker_build with {"context": ".", "tag": "test:latest"}
+//   - parse JSON from response text
+//   - assert success == false
+//   - assert error/build_log field is non-empty
+//   - cancel client
+```
+
+### Helper pattern for call + parse (repeated in tests 2-4)
+
+Each tool-call test follows this exact sequence from `cargo_build_server_test.rs`:
+
+```rust
+let params = CallToolRequestParams::new("docker_build").with_arguments(
+    serde_json::json!({ "context": "...", "tag": "..." })
+        .as_object()
+        .unwrap()
+        .clone(),
+);
+let result = client.peer().call_tool(params).await.expect("call_tool");
+let text = result.content.first().expect("should have content")
+    .as_text().expect("first content should be text");
+let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
+```
+
+### JSON response field assumptions
+
+The `docker_build.rs` implementation (per the task breakdown) returns JSON with at minimum:
+- `success`: bool
+- `build_log`: string (contains error details on failure)
+
+Tests should assert on `json["success"]` directly. For error message content, assert that `build_log` (or whichever error field exists) is non-empty or contains a relevant substring. If the field name differs from what is expected, the test will fail clearly, making it easy to align.
+
+## Dependencies
+
+- **Blocked by**: "Write `main.rs`" (the binary must exist for `env!("CARGO_BIN_EXE_docker-build")` to resolve) and "Implement `DockerBuildTool` struct and handler" (the tool logic must be implemented for tests to exercise it).
+- **Blocking**: None.
+- **Crate dev-dependencies** (must be in `Cargo.toml`, handled by the "Create Cargo.toml" task): `mcp-test-utils`, `tokio` with `rt-multi-thread`, `rmcp` with `client`/`transport-child-process`, `serde_json`.
+
+## Risks & Edge Cases
+
+1. **JSON field naming mismatch**: The tests assume the response JSON uses `success` and `build_log` fields. If `docker_build.rs` uses different field names (e.g., `error`, `stderr`, `message`), assertions will need adjustment. Mitigation: the task breakdown specifies `success`, `build_log`, `image_id`, and `tag` as output fields.
+
+2. **Validation error message wording**: The path traversal test should not assert an exact error string, since the wording may change. Use a loose check (e.g., non-empty error field, or `contains` with a broad term like `"path"` or `"invalid"` or `"traversal"`).
+
+3. **Docker actually being available**: Test 4 assumes Docker is NOT installed in the CI environment. If Docker IS available, the test would pass with `success: true` instead of `false`. Mitigation: the test should accept either outcome -- if `success` is `true`, that is also valid (Docker happened to be present). Alternatively, the test can simply verify the response is well-formed JSON regardless of `success` value, and only check `success: false` behavior as a secondary assertion. The simplest approach is: assert the response parses as JSON and has a `success` field. If `success` is `false`, also assert `build_log` is non-empty.
+
+4. **Binary name resolution**: The `env!("CARGO_BIN_EXE_docker-build")` macro requires the crate to produce a binary named `docker-build`. This is determined by the `[[bin]]` section or crate name in `Cargo.toml`.
+
+## Verification
+
+1. `cargo test -p docker-build --test docker_build_server_test` -- all four tests pass.
+2. `cargo clippy -p docker-build` -- no warnings in the test file.
+3. Each test independently spawns and tears down its own MCP client (no shared state).
+4. Tests run in under 30 seconds each (no long-running Docker builds; validation failures and missing-Docker errors are fast).

--- a/.claude/specs/issue-48/write-main-rs.md
+++ b/.claude/specs/issue-48/write-main-rs.md
@@ -1,0 +1,38 @@
+# Spec: Write `src/main.rs`
+
+> From: .claude/tasks/issue-48.md
+
+## Objective
+Create the binary entrypoint for the `docker-build` MCP tool. This file wires together the `DockerBuildTool` struct and the shared `mcp_tool_harness` runtime so the tool can be launched as a standalone stdio-based MCP server.
+
+## Current State
+`tools/cargo-build/src/main.rs` provides the established pattern: declare the module, import the tool struct, and call `mcp_tool_harness::serve_stdio_tool` inside a single-threaded Tokio main function. The `docker-build` crate directory does not yet contain a `src/main.rs`.
+
+## Requirements
+- File must be located at `tools/docker-build/src/main.rs`.
+- Declare `mod docker_build;` to pull in the sibling module.
+- Import `DockerBuildTool` from that module.
+- Use `#[tokio::main(flavor = "current_thread")]` on an async `main` function.
+- Call `mcp_tool_harness::serve_stdio_tool(DockerBuildTool::new(), "docker-build").await` and return its result.
+- Return type must be `Result<(), Box<dyn std::error::Error>>`.
+- File must be under 10 lines total (matching the cargo-build pattern exactly).
+- No additional logic, imports, or feature flags beyond what is listed above.
+
+## Implementation Details
+- **Create** `tools/docker-build/src/main.rs`
+  - Line 1: `mod docker_build;`
+  - Line 2: `use docker_build::DockerBuildTool;`
+  - Lines 4-7: Tokio main function calling `serve_stdio_tool`
+
+## Dependencies
+- Blocked by: "Implement `DockerBuildTool` struct and handler" (the `docker_build` module must exist and export `DockerBuildTool` with a `new()` constructor)
+- Blocking: "Write integration tests" (tests need a compilable binary to run against)
+
+## Risks & Edge Cases
+- If `DockerBuildTool::new()` signature changes (e.g., requires arguments), this file must be updated to match.
+- The module file must be named `docker_build.rs` (not `docker-build.rs`) due to Rust module naming rules; ensure the sibling module uses underscores.
+
+## Verification
+- `cargo check -p docker-build` compiles without errors (requires the `DockerBuildTool` struct to exist).
+- `cargo build -p docker-build` produces a binary at `target/debug/docker-build`.
+- The file is 7 lines (or fewer than 10), matching the cargo-build pattern.

--- a/.claude/specs/issue-48/write-readme.md
+++ b/.claude/specs/issue-48/write-readme.md
@@ -1,0 +1,60 @@
+# Spec: Write `README.md`
+
+> From: .claude/tasks/issue-48.md
+
+## Objective
+Create a README for the `docker-build` tool crate that documents its purpose, usage, parameters, output format, and security model. This gives developers and users a self-contained reference for the tool, following the established pattern used by `echo-tool` and `validate-skill`.
+
+## Current State
+- `tools/echo-tool/README.md` and `tools/validate-skill/README.md` exist as reference patterns.
+- `tools/cargo-build/` has no README yet, so `validate-skill` is the best feature-tool reference (it includes Parameters and Output tables).
+- The task breakdown in `.claude/tasks/issue-48.md` defines the tool's four input parameters (`context`, `tag`, `build_args`, `dockerfile`), output JSON structure (`success`, `image_id`, `tag`, `build_log`), and security validation rules.
+
+## Requirements
+- Follow the section structure from existing tool READMEs: description paragraph, Build, Run, Test with MCP Inspector, Test, Parameters table, Output table with success/failure examples, and a Notes/Security section.
+- **Description**: Explain that `docker-build` is an MCP tool server that builds Docker images from a Dockerfile and context directory, returning structured JSON results.
+- **Build/Run/Test commands**: Use `-p docker-build` consistently (`cargo build -p docker-build`, `cargo run -p docker-build`, `cargo test -p docker-build`, and `npx @modelcontextprotocol/inspector cargo run -p docker-build`).
+- **Parameters table**: Document all four parameters with types and descriptions:
+  - `context` (string, required) — build context directory path
+  - `tag` (string, required) — image tag to assign
+  - `build_args` (object, optional) — key-value map of Docker build arguments
+  - `dockerfile` (string, optional) — path to Dockerfile (defaults to `context/Dockerfile`)
+- **Output table**: Document the four output fields: `success` (boolean), `image_id` (string), `tag` (string), `build_log` (string). Include a success JSON example and a failure JSON example.
+- **Security Considerations section**: Cover these points:
+  - Path validation: `context` and `dockerfile` are canonicalized and checked to be within the project root; `..` segments are rejected before canonicalization.
+  - Tag validation: only `[a-zA-Z0-9._:/-]` characters are allowed.
+  - Build-arg sanitization: keys and values are rejected if they contain shell metacharacters or newlines.
+  - No shell execution: commands run via `std::process::Command`, not through a shell, preventing shell injection.
+- **Docker-in-Docker caveat**: Note that when running inside a container (e.g., CI or devcontainers), the Docker socket must be mounted or Docker-in-Docker must be configured for the tool to function. If Docker is unavailable, the tool returns a graceful JSON error with `success: false`.
+
+## Implementation Details
+- File to create: `tools/docker-build/README.md`
+- Use markdown tables for Parameters and Output (matching `tools/validate-skill/README.md` style).
+- Use fenced code blocks with `json` language tag for output examples and `sh` for commands.
+- Keep the document concise; no "Creating a New Tool" section (that belongs only in `echo-tool`).
+- Sections in order:
+  1. Title and description paragraph
+  2. Build (`cargo build -p docker-build`)
+  3. Run (`cargo run -p docker-build`) with stdio transport note
+  4. Test with MCP Inspector (`npx @modelcontextprotocol/inspector cargo run -p docker-build`)
+  5. Test (`cargo test -p docker-build`)
+  6. Parameters (markdown table: Name, Type, Required, Description)
+  7. Output (markdown table: Field, Type, Description; then success and failure JSON examples)
+  8. Security Considerations (bullet list covering path validation, tag validation, build-arg sanitization, no shell execution)
+  9. Notes (Docker-in-Docker caveat, `image_id` may be `"unknown"` when ID cannot be parsed)
+
+## Dependencies
+- Blocked by: None (documentation can be written before or after implementation)
+- Blocking: None (non-blocking task per the task breakdown)
+
+## Risks & Edge Cases
+- The output JSON structure may evolve during implementation (e.g., additional fields). The README should be updated if the final implementation diverges from the spec.
+- The image ID extraction logic handles both legacy Docker builder and BuildKit output formats; the README should mention that `image_id` may be `"unknown"` if neither format is detected, without overexplaining the parsing internals.
+
+## Verification
+- The README file exists at `tools/docker-build/README.md`.
+- It contains all required sections: description, Build, Run, Test with MCP Inspector, Test, Parameters, Output (with success and failure examples), Security Considerations, and a Docker-in-Docker note.
+- Parameter names and types match the `DockerBuildRequest` struct defined in the task breakdown (`context`, `tag`, `build_args`, `dockerfile`).
+- Output fields match the specified JSON response shape (`success`, `image_id`, `tag`, `build_log`).
+- Commands use `-p docker-build` consistently.
+- No broken markdown formatting (tables render correctly, code blocks are properly fenced).

--- a/.claude/specs/issue-50/add-register-agent-to-workspace-members.md
+++ b/.claude/specs/issue-50/add-register-agent-to-workspace-members.md
@@ -1,0 +1,38 @@
+# Spec: Add register-agent to workspace members
+
+> From: .claude/tasks/issue-50.md
+
+## Objective
+Add `"tools/register-agent"` to the `[workspace] members` array in the root `Cargo.toml` so that Cargo recognizes the new tool crate as part of the workspace. This is a prerequisite for all subsequent register-agent implementation tasks.
+
+## Current State
+The root `Cargo.toml` defines a workspace with 13 members across `crates/` and `tools/` directories. The current members list ends with `"tools/docker-build"`. The `tools/register-agent` directory does not yet exist but will be created by the sibling scaffolding task ("Create register-agent Cargo.toml").
+
+## Requirements
+- The string `"tools/register-agent"` must appear in the `[workspace] members` array in `/workspaces/spore/Cargo.toml`
+- The entry must be added after the last existing `tools/` entry (`"tools/docker-build"`) to maintain alphabetical/logical grouping
+- No other lines in `Cargo.toml` should be modified
+- The trailing comma convention used by existing entries must be preserved
+
+## Implementation Details
+- **File to modify:** `Cargo.toml` (root)
+- **Change:** Add `"tools/register-agent",` as a new line after `"tools/docker-build",` inside the `members` array
+- The resulting members array should end with:
+  ```toml
+      "tools/docker-build",
+      "tools/register-agent",
+  ]
+  ```
+
+## Dependencies
+- Blocked by: none (Group 1)
+- Blocking: "Implement register_agent tool logic", "Create main.rs entry point", "Write integration tests"
+
+## Risks & Edge Cases
+- If this change lands before the `tools/register-agent/Cargo.toml` exists, `cargo` commands will fail with a missing-manifest error. Ensure the sibling task ("Create register-agent Cargo.toml") is merged together with or before this change.
+- Merge conflicts are possible if other PRs add new workspace members concurrently. Resolution is straightforward: include all entries.
+
+## Verification
+- `grep -q '"tools/register-agent"' Cargo.toml` exits 0
+- Once the sibling `Cargo.toml` scaffolding task is also complete, `cargo metadata --no-deps` lists `register-agent` as a workspace member
+- `cargo check` passes (requires both scaffolding tasks to be complete)

--- a/.claude/specs/issue-50/create-main-rs-entry-point.md
+++ b/.claude/specs/issue-50/create-main-rs-entry-point.md
@@ -1,0 +1,58 @@
+# Spec: Create main.rs entry point
+
+> From: .claude/tasks/issue-50.md
+
+## Objective
+Create the `main.rs` entry point for the `register-agent` MCP tool binary, following the established pattern used by other tools (e.g., `docker-push`). This wires the `RegisterAgentTool` implementation into the MCP stdio harness so the tool can be invoked as a standalone process.
+
+## Current State
+All other MCP tool binaries in `tools/*/src/main.rs` follow an identical pattern:
+1. Declare a module for the tool implementation.
+2. Import the tool struct.
+3. Define an async `main` that calls `mcp_tool_harness::serve_stdio_tool`.
+
+Reference (`tools/docker-push/src/main.rs`):
+```rust
+mod docker_push;
+use docker_push::DockerPushTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(DockerPushTool::new(), "docker-push").await
+}
+```
+
+The file `tools/register-agent/src/main.rs` does not yet exist.
+
+## Requirements
+- Create `tools/register-agent/src/main.rs` with the standard entry point pattern.
+- The module declaration must be `mod register_agent;`.
+- The use statement must import `register_agent::RegisterAgentTool`.
+- The `main` function must use `#[tokio::main(flavor = "current_thread")]`.
+- The `main` function must return `Result<(), Box<dyn std::error::Error>>`.
+- The body must call `mcp_tool_harness::serve_stdio_tool(RegisterAgentTool::new(), "register-agent").await`.
+- The file must be exactly 7 lines (matching the docker-push convention), with no extraneous code.
+
+## Implementation Details
+- **Create** `tools/register-agent/src/main.rs`:
+  - Line 1: `mod register_agent;`
+  - Line 2: `use register_agent::RegisterAgentTool;`
+  - Line 3: blank
+  - Line 4: `#[tokio::main(flavor = "current_thread")]`
+  - Line 5: `async fn main() -> Result<(), Box<dyn std::error::Error>> {`
+  - Line 6: `    mcp_tool_harness::serve_stdio_tool(RegisterAgentTool::new(), "register-agent").await`
+  - Line 7: `}`
+
+## Dependencies
+- Blocked by: "Implement register_agent tool logic" (the `RegisterAgentTool` struct and its `new()` constructor must exist in `tools/register-agent/src/register_agent.rs` before this file compiles)
+- Blocking: "Write integration tests" (tests need a compilable binary to run against)
+
+## Risks & Edge Cases
+- If the `register_agent` module file does not exist or does not export `RegisterAgentTool`, compilation will fail. This is expected since this task is blocked by the tool logic implementation.
+- The tool name string `"register-agent"` must match what the MCP harness and any upstream configuration expect. Verify consistency with `Cargo.toml` binary name.
+
+## Verification
+- `cargo check -p register-agent` succeeds (once the blocking task is complete).
+- `cargo build -p register-agent` produces a binary.
+- The file content matches the docker-push pattern exactly (substituting module and type names).
+- `cargo clippy -p register-agent` reports no warnings.

--- a/.claude/specs/issue-50/create-register-agent-cargo-toml.md
+++ b/.claude/specs/issue-50/create-register-agent-cargo-toml.md
@@ -1,0 +1,59 @@
+# Spec: Create register-agent Cargo.toml
+
+> From: .claude/tasks/issue-50.md
+
+## Objective
+Create the Cargo manifest for the `register-agent` MCP tool crate and add it to the workspace. This tool will make HTTP POST requests to the orchestrator to register agents, so it needs `reqwest` as an additional runtime dependency and a lightweight HTTP server for testing. This is the foundational file that must exist before any Rust source files can be written.
+
+## Current State
+- `tools/docker-push/Cargo.toml` is the closest existing template. It declares `mcp-tool-harness` (path), `rmcp`, `tokio`, `serde`, and `serde_json` as dependencies, plus `mcp-test-utils` and test-oriented features in dev-dependencies.
+- The workspace root `Cargo.toml` lists tool crates under `[workspace] members`. Currently `tools/docker-push` and `tools/docker-build` are the most recently added members. `tools/register-agent` is not yet listed.
+- The directory `tools/register-agent/` does not yet exist.
+- No existing tool crate uses `reqwest` or `axum`, so these will be new workspace-level dependencies.
+
+## Requirements
+- The file `tools/register-agent/Cargo.toml` must be a valid Cargo manifest with `name = "register-agent"`.
+- `edition` must be `"2024"`, matching all existing tool crates.
+- `version` must be `"0.1.0"`.
+- `[dependencies]` must include exactly:
+  - `mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }`
+  - `rmcp = { version = "1", features = ["transport-io", "server", "macros"] }`
+  - `tokio = { version = "1", features = ["macros", "rt", "io-std"] }`
+  - `serde = { version = "1", features = ["derive"] }`
+  - `serde_json = "1"`
+  - `reqwest = { version = "0.12", features = ["json"] }` -- needed for HTTP POST to the orchestrator
+- `[dev-dependencies]` must include exactly:
+  - `mcp-test-utils = { path = "../../crates/mcp-test-utils" }`
+  - `tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }`
+  - `rmcp = { version = "1", features = ["client", "transport-child-process"] }`
+  - `serde_json = "1"`
+  - `axum = "0.8"` -- lightweight mock HTTP server for integration tests (preferred over adding `mockito` or `wiremock` per task instructions)
+- The workspace root `Cargo.toml` must add `"tools/register-agent"` to the `[workspace] members` array.
+- No other external dependencies beyond those listed above.
+
+## Implementation Details
+- **Files to create:**
+  - `tools/register-agent/Cargo.toml` -- based on the `tools/docker-push/Cargo.toml` pattern with the following differences:
+    - `name` changed to `"register-agent"`
+    - `reqwest = { version = "0.12", features = ["json"] }` added to `[dependencies]`
+    - `axum = "0.8"` added to `[dev-dependencies]`
+- **Files to modify:**
+  - `Cargo.toml` (workspace root) -- add `"tools/register-agent"` to the `[workspace] members` array, placed alphabetically after `"tools/read-file"`.
+- No Rust source files are created in this task. The crate will not compile until `src/main.rs` is added by a blocking task.
+
+## Dependencies
+- Blocked by: none (Group 1)
+- Blocking: "Implement register_agent tool logic", "Create main.rs entry point", "Write integration tests"
+
+## Risks & Edge Cases
+- **New external dependencies**: `reqwest` and `axum` are new to the workspace. `reqwest` pulls in a significant dependency tree (hyper, http, tower, rustls/native-tls). Ensure the `reqwest` version chosen is compatible with the existing `rmcp` and `tokio` versions already in the lockfile. Using `0.12` aligns with the current tokio 1.x ecosystem.
+- **`axum` version alignment**: `axum` 0.8 depends on tokio 1.x and hyper 1.x, which should be compatible with `reqwest` 0.12. If version conflicts arise, pinning to a specific patch version may be needed.
+- **Workspace resolution failure**: If the workspace root `Cargo.toml` is not updated, `cargo build` will not find the new crate. Mitigation: always update the members list as part of this task.
+- **Path dependency correctness**: The relative path `../../crates/mcp-tool-harness` assumes the crate lives at `tools/register-agent/`. If the directory is placed elsewhere, the path will break. Mitigation: verify the directory structure matches `tools/docker-push/`.
+- **Incomplete task**: Because no `src/main.rs` exists yet, `cargo check -p register-agent` will fail after this task alone. This is expected and resolved by the blocking tasks.
+
+## Verification
+- `cat tools/register-agent/Cargo.toml` shows the correct manifest with `name = "register-agent"`, edition 2024, and all required dependencies including `reqwest` and `axum`.
+- `grep "tools/register-agent" Cargo.toml` confirms the workspace root includes the new member.
+- `cargo metadata --no-deps` lists `register-agent` as a workspace member (will only fully succeed once `src/main.rs` exists from the blocking task).
+- Verify `reqwest` features include `json` and `axum` appears only in `[dev-dependencies]`.

--- a/.claude/specs/issue-50/implement-register-agent-tool-logic.md
+++ b/.claude/specs/issue-50/implement-register-agent-tool-logic.md
@@ -1,0 +1,117 @@
+# Spec: Implement register_agent tool logic
+
+> From: .claude/tasks/issue-50.md
+
+## Objective
+Create the core `RegisterAgentTool` implementation in `tools/register-agent/src/register_agent.rs`. This tool accepts an agent's name, URL, and description, validates the inputs, then POSTs a registration payload to the orchestrator's `/register` endpoint via `reqwest`. It follows the established MCP tool pattern (docker-push/docker-build) but differs in that the tool method must be async to perform HTTP calls.
+
+## Current State
+- `tools/docker-push/src/docker_push.rs` defines the primary pattern: a `*Request` struct with `serde::Deserialize` + `schemars::JsonSchema`, a `*Tool` struct holding a `ToolRouter<Self>`, validation helpers, a `#[tool_router]` impl block with a `#[tool]`-annotated method, and a `#[tool_handler] impl ServerHandler`.
+- `tools/docker-build/src/docker_build.rs` follows the same pattern with additional validation helpers.
+- Both existing tools use synchronous `std::process::Command`. This tool must use async `reqwest::Client` instead.
+- The rmcp `#[tool]` macro (v1.2.0) explicitly supports async fn: it detects `sig.asyncness`, strips it, and wraps the body in `Box::pin(async move { ... })`. This is confirmed in `rmcp-macros-1.2.0/src/tool.rs` lines 333-361.
+- `crates/orchestrator/src/agent_endpoint.rs` defines `AgentEndpoint` with fields `name: String`, `description: String`, `url: String`, and a `client: reqwest::Client`. The POST payload sent by this tool should include `name`, `url`, and `description` to align with `AgentEndpoint::new()`.
+- `crates/orchestrator/src/orchestrator.rs` has `pub fn register(&mut self, endpoint: AgentEndpoint)` which stores the endpoint. The HTTP route that accepts the POST is assumed to exist or will be wired separately (outside this issue's scope).
+
+## Requirements
+- Define `RegisterAgentRequest` with three required `String` fields: `name`, `url`, `description`. All derive `serde::Deserialize` and `schemars::JsonSchema`.
+- Define `RegisterAgentTool` struct with field `tool_router: ToolRouter<Self>` and a `new()` constructor following the docker-push pattern.
+- Input validation must reject:
+  - Empty `name` (return error JSON)
+  - Empty `url` (return error JSON)
+  - Empty `description` (return error JSON)
+  - `name` containing unsafe characters (only allow alphanumeric, `-`, `_`, `.`; reject shell metacharacters, spaces, etc.)
+  - `url` that does not start with `http://` or `https://` (basic URL format check)
+- Read `ORCHESTRATOR_URL` from environment variable, defaulting to `http://orchestrator:8080` if unset.
+- Use `reqwest::Client` to POST JSON `{"name": ..., "url": ..., "description": ...}` to `{orchestrator_url}/register`.
+- The tool method must be `async fn` (confirmed supported by rmcp `#[tool]` macro).
+- On success (HTTP 2xx), return: `{"success": true, "agent_name": "<name>", "registered_url": "<url>"}`.
+- On failure (HTTP error, network error, or validation error), return: `{"success": false, "agent_name": "<name>", "registered_url": "", "error": "<reason>"}`.
+- Use `#[tool_router]` on the impl block and `#[tool_handler]` on `impl ServerHandler`.
+- The `#[tool]` annotation must include a description, e.g. `"Register an agent with the orchestrator"`.
+- All validation helpers must be standalone functions (not methods), each under 50 lines, following the single-responsibility pattern from docker-push.
+- No commented-out code or debug statements in the final file.
+
+## Implementation Details
+
+### File to create
+`tools/register-agent/src/register_agent.rs`
+
+### Imports
+```rust
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+```
+
+### Types
+
+**`RegisterAgentRequest`** -- input struct for the tool:
+- `name: String` -- agent name, doc comment: `/// Agent name (alphanumeric, hyphens, underscores, dots only)`
+- `url: String` -- doc comment: `/// Agent URL (must start with http:// or https://)`
+- `description: String` -- doc comment: `/// Human-readable description of the agent`
+
+**`RegisterAgentTool`** -- the MCP tool handler:
+- `tool_router: ToolRouter<Self>` -- populated via `Self::tool_router()` in `new()`
+
+### Validation functions
+
+1. `fn validate_name(name: &str) -> Result<(), String>` -- rejects empty names and names containing characters outside `[a-zA-Z0-9._-]`.
+2. `fn validate_url(url: &str) -> Result<(), String>` -- rejects empty URLs and URLs not starting with `http://` or `https://`.
+3. `fn validate_description(description: &str) -> Result<(), String>` -- rejects empty descriptions.
+
+### Helper functions
+
+4. `fn build_error_json(name: &str, reason: &str) -> String` -- returns `{"success": false, "agent_name": name, "registered_url": "", "error": reason}`.
+5. `fn resolve_orchestrator_url() -> String` -- reads `ORCHESTRATOR_URL` env var, defaults to `"http://orchestrator:8080"`, trims trailing slashes.
+
+### Tool method (in `#[tool_router] impl RegisterAgentTool`)
+
+```rust
+#[tool(description = "Register an agent with the orchestrator")]
+async fn register_agent(&self, Parameters(request): Parameters<RegisterAgentRequest>) -> String
+```
+
+Flow:
+1. Validate `name`, `url`, `description` -- return `build_error_json` on any failure.
+2. Call `resolve_orchestrator_url()` to get base URL.
+3. Construct `reqwest::Client::new()` and POST JSON payload to `{base_url}/register`.
+4. On success: return success JSON.
+5. On HTTP error or network error: return error JSON with the error message.
+
+### ServerHandler implementation
+
+```rust
+#[tool_handler]
+impl ServerHandler for RegisterAgentTool {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+}
+```
+
+### Integration points
+- `tools/register-agent/src/main.rs` (created by a separate task) will `mod register_agent;` and use `RegisterAgentTool::new()`.
+- The orchestrator's `/register` HTTP endpoint is the target of the POST. The payload shape (`name`, `url`, `description`) aligns with the `AgentEndpoint::new()` constructor parameters.
+
+## Dependencies
+- Blocked by: "Create register-agent Cargo.toml", "Add register-agent to workspace members"
+- Blocking: "Create main.rs entry point", "Write unit tests", "Write integration tests"
+
+## Risks & Edge Cases
+- **Orchestrator endpoint does not exist yet**: The orchestrator has `register()` on its struct but may not have an HTTP route wired for `/register`. The tool should still be implemented to POST to this path; wiring the route is outside this issue's scope. Tests should use a mock HTTP server.
+- **reqwest::Client lifetime**: Creating a new `reqwest::Client` per call is acceptable for an MCP tool (low call frequency). If performance becomes a concern, the client could be stored on the struct, but that adds complexity (not Clone-friendly with ToolRouter). Keep it simple for now.
+- **Async in rmcp #[tool]**: Confirmed supported in rmcp-macros 1.2.0. The macro detects `asyncness`, removes it from the signature, and wraps the body in `Box::pin(async move { ... })`. No special handling needed by the implementer.
+- **URL validation depth**: Only checking for `http://` or `https://` prefix is intentionally minimal. Full URL parsing (e.g., via the `url` crate) would add a dependency. The basic check prevents obvious misuse while keeping dependencies minimal.
+- **Name character set**: Allowing `[a-zA-Z0-9._-]` matches common DNS/container naming conventions and prevents shell injection. This is more restrictive than docker-push's `is_valid_ref_char` (which also allows `/` and `:`) because agent names should be simple identifiers.
+- **Network timeouts**: `reqwest::Client::new()` uses default timeouts. For a first implementation this is acceptable. If orchestrator calls hang in production, a timeout can be added later via `reqwest::ClientBuilder::timeout()`.
+
+## Verification
+- `cargo check -p register-agent` compiles without errors (requires Cargo.toml and main.rs tasks to be complete first).
+- `cargo clippy -p register-agent` produces no warnings.
+- `cargo test -p register-agent` passes all unit tests (validation tests do not require a running orchestrator).
+- The file contains no `todo!()`, `unimplemented!()`, commented-out code, or debug print statements.
+- The `#[tool]` method is declared `async fn` and the file compiles, confirming rmcp macro support.
+- Manual review confirms: all three input fields are validated, error JSON includes `"success": false` with an `"error"` field, success JSON includes `"success": true` with `"agent_name"` and `"registered_url"`.

--- a/.claude/specs/issue-50/write-integration-tests.md
+++ b/.claude/specs/issue-50/write-integration-tests.md
@@ -1,0 +1,110 @@
+# Spec: Write integration tests (MCP server tests)
+
+> From: .claude/tasks/issue-50.md
+
+## Objective
+
+Create MCP server-level integration tests for the `register-agent` tool binary. These tests verify that the tool is correctly registered via the MCP protocol, validates inputs, and returns well-structured JSON responses. This ensures the full stdio MCP transport path works end-to-end, complementing the unit tests in the tool module.
+
+## Current State
+
+The project has an established integration test pattern used by `docker-push` and `docker-build`:
+
+- Each tool binary has a `tests/<tool_name>_server_test.rs` file.
+- Tests use `mcp_test_utils::spawn_mcp_client!` macro to spawn the binary as a child process and connect an MCP client over stdio transport.
+- Tests use `mcp_test_utils::assert_single_tool` to verify tool name, description substring, and parameter names.
+- Tests call `client.peer().call_tool(params)` and parse the text content as JSON to assert on fields.
+- Every test ends with `client.cancel().await.expect("failed to cancel client")`.
+- All tests use `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`.
+- Parameters are constructed via `CallToolRequestParams::new("tool_name").with_arguments(serde_json::json!({...}).as_object().unwrap().clone())`.
+
+## Requirements
+
+- Create file `tools/register-agent/tests/register_agent_server_test.rs`.
+- Import `rmcp::model::CallToolRequestParams` (the only direct rmcp import needed; `mcp_test_utils` re-exports the rest).
+- Implement exactly three test functions:
+
+1. **`tools_list_returns_register_agent_tool`** -- Spawns an MCP client connected to the `register-agent` binary. Calls `assert_single_tool` with name `"register_agent"`, a description substring related to registration (e.g., `"register"` or `"Register"`), and expected params `["name", "url", "description"]`.
+
+2. **`tools_call_with_empty_name_returns_error`** -- Calls the tool with `name` set to `""`, `url` set to a valid placeholder (e.g., `"http://example.com"`), and `description` set to a non-empty string. Asserts the response parses as JSON with `success: false`.
+
+3. **`tools_call_with_valid_inputs_returns_structured_json`** -- Calls the tool with valid inputs: a non-empty `name`, a valid `url`, and a non-empty `description`. Since the orchestrator is unreachable in CI, does NOT assert `success: true`. Instead asserts the response JSON has the expected shape: `success` field is present, `agent_name` field is present, and `registered_url` field is present.
+
+## Implementation Details
+
+### File structure
+
+```rust
+use rmcp::model::CallToolRequestParams;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_returns_register_agent_tool() { ... }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_with_empty_name_returns_error() { ... }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_with_valid_inputs_returns_structured_json() { ... }
+```
+
+### Test 1: `tools_list_returns_register_agent_tool`
+
+- Spawn client: `mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_register-agent")).await`
+- Call `mcp_test_utils::assert_single_tool(&client, "register_agent", <description_substring>, &["name", "url", "description"]).await`
+- The description substring should be a word like `"egister"` or `"Register"` that will appear in the tool description. Check the actual description set in `register_agent.rs` when implementing.
+- Cancel client.
+
+### Test 2: `tools_call_with_empty_name_returns_error`
+
+- Spawn client.
+- Build params: `CallToolRequestParams::new("register_agent").with_arguments(serde_json::json!({"name": "", "url": "http://example.com", "description": "A test agent"}).as_object().unwrap().clone())`
+- Call `client.peer().call_tool(params).await.expect("call_tool")`
+- Extract first content item as text, parse as `serde_json::Value`.
+- Assert `json["success"] == false`.
+- Cancel client.
+
+### Test 3: `tools_call_with_valid_inputs_returns_structured_json`
+
+- Spawn client.
+- Build params with valid values: `{"name": "test-agent", "url": "http://localhost:9999", "description": "A test agent"}`
+- Call tool, extract JSON.
+- Assert `json.get("success").is_some()` -- field present.
+- Assert `json.get("agent_name").is_some()` -- field present.
+- Assert `json.get("registered_url").is_some()` -- field present.
+- Do NOT assert the value of `success` since the orchestrator will be unreachable. The response will likely be `success: false` with an error message, but we only care about the JSON shape.
+- Cancel client.
+
+### Using mcp-test-utils
+
+The `Cargo.toml` dev-dependencies should already include `mcp-test-utils` (set up by the scaffolding task). The macro `spawn_mcp_client!` and function `assert_single_tool` are the two main utilities. No other helpers are needed for these tests.
+
+### JSON extraction pattern (reused across tests 2 and 3)
+
+```rust
+let text = result
+    .content
+    .first()
+    .expect("should have content")
+    .as_text()
+    .expect("first content should be text");
+let json: serde_json::Value = serde_json::from_str(&text.text).expect("should parse as JSON");
+```
+
+## Dependencies
+
+- **Blocked by:** "Create main.rs entry point" -- the binary must exist for `env!("CARGO_BIN_EXE_register-agent")` to resolve.
+- **Blocking:** None
+
+## Risks & Edge Cases
+
+- **Description substring mismatch:** The `assert_single_tool` call requires a substring that appears in the tool's description. The implementer must check what description string is set in `register_agent.rs` and use a matching substring. Using a short, common word like `"egister"` reduces fragility.
+- **Orchestrator unreachable in CI:** Test 3 deliberately avoids asserting `success: true` because the orchestrator endpoint will not be running in CI. It only checks JSON shape. If the tool implementation hangs waiting for a connection (e.g., no timeout on the HTTP request), the test will time out. The tool implementation should use a reasonable timeout on the reqwest client (covered by the tool logic spec, not this spec).
+- **Binary name:** The Cargo binary name is derived from the package name `register-agent`, so the env var is `CARGO_BIN_EXE_register-agent`. If the `Cargo.toml` uses a different `[[bin]]` name, this must be adjusted.
+- **Flaky cancel:** All existing tests call `client.cancel().await` at the end. If a test panics before cancel, the child process may linger. This is consistent with existing patterns and acceptable.
+
+## Verification
+
+- `cargo test -p register-agent` passes with all three tests green.
+- `cargo test -p register-agent tools_list_returns_register_agent_tool` confirms the tool is discoverable with correct name and params.
+- `cargo test -p register-agent tools_call_with_empty_name_returns_error` confirms validation rejects empty name.
+- `cargo test -p register-agent tools_call_with_valid_inputs_returns_structured_json` confirms response JSON structure is correct even when orchestrator is unreachable.

--- a/.claude/specs/issue-50/write-readme.md
+++ b/.claude/specs/issue-50/write-readme.md
@@ -1,0 +1,105 @@
+# Spec: Write README.md
+
+> From: .claude/tasks/issue-50.md
+
+## Objective
+Create `tools/register-agent/README.md` that documents the register-agent MCP tool server, following the established documentation pattern used by docker-build and docker-push READMEs. This gives users and contributors a consistent reference for building, running, testing, and understanding the tool.
+
+## Current State
+- `tools/docker-build/README.md` and `tools/docker-push/README.md` establish the documentation pattern: purpose line, Build/Run/Test sections with cargo commands, MCP Inspector section, Parameters table, Output table with examples, Environment Variables, and Security Considerations.
+- The register-agent tool does not yet exist (blocked by core implementation tasks), but the task breakdown in `issue-50.md` fully specifies the interface: parameters (`name`, `url`, `description`), output fields (`success`, `agent_name`, `registered_url`, `error`), and environment variable (`ORCHESTRATOR_URL` with default `http://orchestrator:8080`).
+
+## Requirements
+- Follow the same section ordering and formatting as `tools/docker-build/README.md`
+- Include all sections specified in the task: purpose, build/run/test commands, MCP Inspector command, parameters table, output JSON table, success/failure examples, environment variables, security considerations
+- Package name in all cargo commands must be `register-agent`
+- Parameters table must document three required parameters: `name` (string), `url` (string), `description` (string)
+- Output table must document four fields: `success` (boolean), `agent_name` (string), `registered_url` (string), `error` (string)
+- Environment variables section must document `ORCHESTRATOR_URL` with default value `http://orchestrator:8080` and explain resolution order
+- Success example must show a JSON object with `success: true`, `agent_name`, and `registered_url` populated
+- Failure example must show a JSON object with `success: false`, an `error` message, and empty `registered_url`
+- Security considerations must cover: input validation (name/url/description), no shell execution, and URL format validation
+
+## Implementation Details
+
+### Sections to include (in order)
+
+1. **Title and purpose line**: `# register-agent` followed by a one-sentence description: "An MCP tool server that registers an agent with the orchestrator by POSTing its name, URL, and description, returning structured JSON with registration status."
+
+2. **Build section**: `cargo build -p register-agent`
+
+3. **Run section**: `cargo run -p register-agent` with the standard stdio transport explanation paragraph (copied from docker-build/docker-push pattern).
+
+4. **Test with MCP Inspector section**: `npx @modelcontextprotocol/inspector cargo run -p register-agent` with the standard explanatory paragraph.
+
+5. **Test section**: `cargo test -p register-agent`
+
+6. **Parameters table** (Input Parameters):
+
+   | Name          | Type   | Required | Description                                      |
+   |---------------|--------|----------|--------------------------------------------------|
+   | `name`        | string | yes      | Agent name (alphanumeric, hyphens, underscores)  |
+   | `url`         | string | yes      | Agent endpoint URL (must be valid URL format)    |
+   | `description` | string | yes      | Human-readable description of the agent          |
+
+7. **Output section** with table:
+
+   | Field            | Type    | Description                                              |
+   |------------------|---------|----------------------------------------------------------|
+   | `success`        | boolean | Whether the registration completed successfully          |
+   | `agent_name`     | string  | The name of the registered agent                         |
+   | `registered_url` | string  | The URL at which the agent was registered (empty on failure) |
+   | `error`          | string  | Error message (empty on success, present on failure)     |
+
+8. **Success example**:
+   ```json
+   {
+     "success": true,
+     "agent_name": "my-agent",
+     "registered_url": "http://my-agent:8080",
+     "error": ""
+   }
+   ```
+
+9. **Failure example**:
+   ```json
+   {
+     "success": false,
+     "agent_name": "my-agent",
+     "registered_url": "",
+     "error": "Failed to register agent: orchestrator returned 503"
+   }
+   ```
+
+10. **Environment Variables table**:
+
+    | Variable          | Description                                                              |
+    |-------------------|--------------------------------------------------------------------------|
+    | `ORCHESTRATOR_URL` | Base URL of the orchestrator service (default: `http://orchestrator:8080`) |
+
+    Include a paragraph explaining: the `ORCHESTRATOR_URL` environment variable sets the base URL for the orchestrator. If not set, it defaults to `http://orchestrator:8080`. The registration payload is POSTed to `{ORCHESTRATOR_URL}/register`.
+
+11. **Security Considerations** (bulleted with bold labels, matching docker-build style):
+    - **Name validation** -- Agent names are restricted to alphanumeric characters, hyphens, and underscores. Shell metacharacters are rejected.
+    - **URL validation** -- The `url` parameter is validated for proper URL format. Malformed URLs are rejected before any HTTP request is made.
+    - **Description validation** -- Empty descriptions are rejected.
+    - **No shell execution** -- The tool uses `reqwest` to make HTTP requests directly, without spawning a shell process.
+
+## Dependencies
+- Blocked by: "Implement register_agent tool logic" (the README documents the implemented interface; it should be written after or alongside implementation to ensure accuracy)
+- Blocking: None
+
+## Risks & Edge Cases
+- The actual implementation may diverge slightly from the task breakdown spec (e.g., field names, error message format). The README should be reviewed against the final implementation and updated if needed.
+- The `error` field behavior (empty string vs. absent) should match whatever serde serialization the implementation uses. The spec assumes it is always present as a string.
+
+## Verification
+- The README file exists at `tools/register-agent/README.md`
+- All sections listed above are present and in the specified order
+- Cargo commands use `-p register-agent` consistently
+- The parameters table lists exactly three required parameters: `name`, `url`, `description`
+- The output table lists exactly four fields: `success`, `agent_name`, `registered_url`, `error`
+- Success and failure JSON examples are valid JSON and consistent with the output table
+- The `ORCHESTRATOR_URL` environment variable is documented with its default value
+- Security considerations cover input validation for all three parameters, URL format validation, and no-shell-execution
+- Formatting is consistent with `tools/docker-build/README.md` (heading levels, table alignment, code fence language tags)

--- a/.claude/specs/issue-50/write-unit-tests.md
+++ b/.claude/specs/issue-50/write-unit-tests.md
@@ -1,0 +1,123 @@
+# Spec: Write unit tests
+
+> From: .claude/tasks/issue-50.md
+
+## Objective
+
+Add a comprehensive `#[cfg(test)] mod tests` block inside `tools/register-agent/src/register_agent.rs` that covers input validation, error JSON structure, and HTTP POST logic against a lightweight mock server. This ensures the register_agent tool behaves correctly before integration tests run against the full MCP server.
+
+## Current State
+
+The codebase has two established unit-test patterns in sibling tools:
+
+- **`tools/docker-push/src/docker_push.rs`** -- inline `#[cfg(test)] mod tests` with a `call_docker_push` helper that directly invokes the tool method via `Parameters(...)`. Tests cover: empty input rejected, shell metacharacters rejected, valid input produces correct JSON shape, helper function edge cases (digest extraction, registry URL resolution). All tests are synchronous `#[test]`.
+
+- **`tools/docker-build/src/docker_build.rs`** -- same pattern with a `call_docker_build` helper. Tests cover: path traversal rejected, shell metacharacters in tag rejected, invalid build arg keys rejected, valid inputs produce correct JSON shape, helper function edge cases (image ID extraction, tag validation, metacharacter detection). All tests are synchronous `#[test]`.
+
+Key differences for `register_agent`:
+- The tool method will be **async** (it uses `reqwest` for HTTP POST), so tests must use `#[tokio::test]`.
+- Tests need a **mock HTTP server** to verify POST behavior without a real orchestrator.
+- The task file specifies `axum` or `tokio::net::TcpListener` for mocking (no `mockito`/`wiremock`).
+
+## Requirements
+
+- All tests live in `#[cfg(test)] mod tests` inside `register_agent.rs`.
+- A `call_register_agent` async helper wraps `tool.register_agent(Parameters(...))` for convenience.
+- Input validation tests (synchronous logic, but tool is async so use `#[tokio::test]`):
+  - Empty `name` is rejected with `success: false` and error message containing "name".
+  - Empty `url` is rejected with `success: false` and error message containing "url".
+  - Empty `description` is rejected with `success: false` and error message containing "description".
+  - `name` containing shell metacharacters (`;`, `|`, `$`, backtick) is rejected with `success: false`.
+- Error JSON structure test:
+  - On any validation failure, response parses as JSON with fields: `success` (false), `agent_name` (String), `registered_url` (empty string), `error` (non-empty string).
+- Mock HTTP server tests:
+  - Successful registration: mock returns 200 with a JSON body; tool returns `success: true`, correct `agent_name`, correct `registered_url`.
+  - Orchestrator returns 4xx (e.g., 400 or 409): tool returns `success: false` with meaningful `error` string.
+  - Orchestrator returns 5xx (e.g., 500): tool returns `success: false` with meaningful `error` string.
+  - Orchestrator unreachable (connect to a port with nothing listening): tool returns `success: false` with an `error` string that indicates connection failure.
+
+## Implementation Details
+
+### Test helper
+
+```rust
+async fn call_register_agent(
+    tool: &RegisterAgentTool,
+    name: &str,
+    url: &str,
+    description: &str,
+) -> String {
+    tool.register_agent(Parameters(RegisterAgentRequest {
+        name: name.to_string(),
+        url: url.to_string(),
+        description: description.to_string(),
+    }))
+    .await
+}
+```
+
+### Mock server approach
+
+Use `tokio::net::TcpListener` bound to `127.0.0.1:0` (OS-assigned port) to avoid port conflicts. For each test that needs a server:
+
+1. Bind a `TcpListener` on port 0, extract the assigned port.
+2. Spawn a `tokio::spawn` task that accepts one connection and writes a canned HTTP response.
+3. Set the tool's orchestrator URL (or `ORCHESTRATOR_URL` env var) to `http://127.0.0.1:{port}`.
+4. Call the tool and assert the response.
+5. The spawned task completes after serving the single request.
+
+Alternatively, if `axum` is already a dev-dependency (check Cargo.toml), use a minimal `axum::Router` with a single POST `/register` handler. This gives cleaner request parsing. Bind with `axum::Server::bind` on port 0.
+
+For the "unreachable" test, find a free port, do NOT start a listener, and use that port as the orchestrator URL.
+
+### Test cases
+
+| Test name | Type | What it asserts |
+|---|---|---|
+| `rejects_empty_name` | Validation | `success: false`, error mentions "name" |
+| `rejects_empty_url` | Validation | `success: false`, error mentions "url" |
+| `rejects_empty_description` | Validation | `success: false`, error mentions "description" |
+| `rejects_name_with_shell_metachar` | Validation | `success: false` for names like `"foo;bar"`, `"foo|bar"`, `"$(cmd)"` |
+| `error_json_has_expected_structure` | Structure | Response has `success`, `agent_name`, `registered_url`, `error` fields |
+| `successful_registration_returns_correct_json` | HTTP mock | Mock returns 200; assert `success: true`, `agent_name` matches, `registered_url` matches |
+| `orchestrator_4xx_produces_error_json` | HTTP mock | Mock returns 400; assert `success: false`, `error` non-empty |
+| `orchestrator_5xx_produces_error_json` | HTTP mock | Mock returns 500; assert `success: false`, `error` non-empty |
+| `orchestrator_unreachable_produces_error_json` | HTTP mock | No listener; assert `success: false`, `error` mentions connection failure |
+
+### Key assertions pattern
+
+Follow the existing pattern from docker-push/docker-build:
+```rust
+let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+assert_eq!(json["success"], false);
+assert!(json["error"].as_str().unwrap().contains("expected substring"));
+```
+
+### Environment variable handling
+
+The tool reads `ORCHESTRATOR_URL` to know where to POST. Tests that use mock servers must set this env var or pass the URL through the request/tool constructor. Since env vars are global state and tests run in parallel, prefer one of:
+- A constructor parameter on `RegisterAgentTool` that accepts an optional override URL.
+- Or use `std::sync::Mutex` / serial test execution for env var manipulation.
+
+The cleaner approach (constructor parameter) should be coordinated with the "Implement register_agent tool logic" task -- the tool should accept an optional `orchestrator_url` override in its constructor (e.g., `RegisterAgentTool::with_orchestrator_url(url)`) that takes precedence over the env var. This makes tests deterministic and parallel-safe.
+
+## Dependencies
+
+- Blocked by: "Implement register_agent tool logic" -- the `RegisterAgentTool`, `RegisterAgentRequest`, validation functions, and tool method must exist before tests can be written.
+- Blocking: None
+
+## Risks & Edge Cases
+
+- **Async test runtime**: All tests must use `#[tokio::test]` since the tool method is async. Use `#[tokio::test(flavor = "current_thread")]` to keep tests lightweight.
+- **Port conflicts**: Using port 0 for mock servers avoids conflicts. Each test gets its own listener.
+- **Env var race conditions**: If the tool reads `ORCHESTRATOR_URL` from the environment, parallel tests that set different values will conflict. Mitigate by passing the URL via a constructor/method parameter rather than env vars in tests.
+- **Mock server cleanup**: Spawned tasks must not leak. Either `.await` the join handle or ensure the task exits after one request.
+- **No new dependencies**: `tokio::net::TcpListener` is already available via the `tokio` dependency. If using `axum`, confirm it is listed in dev-dependencies in the Cargo.toml (the scaffolding task should add it). If not, prefer raw `TcpListener` with hand-crafted HTTP responses to avoid adding a dependency.
+
+## Verification
+
+- `cargo test -p register-agent` passes with all tests green.
+- `cargo test -p register-agent -- --list` shows all 9 test names listed above.
+- `cargo clippy -p register-agent` produces no warnings.
+- Each validation test confirms `success: false` and a meaningful error message.
+- Each mock server test confirms the tool correctly interprets 200, 4xx, 5xx, and unreachable scenarios.

--- a/.claude/specs/issue-56/add-assert-single-tool-helper-to-mcp-test-utils.md
+++ b/.claude/specs/issue-56/add-assert-single-tool-helper-to-mcp-test-utils.md
@@ -1,0 +1,145 @@
+# Spec: Add `assert_single_tool` helper to `mcp-test-utils`
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+
+Add a public async helper function `assert_single_tool` to the `crates/mcp-test-utils` crate that consolidates the three repeated `tools_list_*` integration tests (name check, description check, parameter check) into a single reusable call. Every MCP tool in the workspace currently has three near-identical tests that list tools and assert name, description, and input schema properties. This function replaces all of them with one call per tool.
+
+## Current State
+
+- The `crates/mcp-test-utils` crate exists (created by the prerequisite task "Create `crates/mcp-test-utils` crate") and contains the `spawn_mcp_client!` macro.
+- Each of the tool crates (`echo-tool`, `write-file`, `validate-skill`, and `read-file`) has three duplicated test functions following this pattern:
+  1. **Name test**: calls `client.peer().list_tools(None).await`, asserts `tools.len() == 1`, asserts `tools[0].name == expected_name`.
+  2. **Description test**: calls `list_tools`, reads `tools[0].description`, asserts it contains a substring.
+  3. **Parameters test**: calls `list_tools`, reads `tools[0].input_schema["properties"]`, asserts each expected parameter key exists.
+- All three tests spawn a separate client, make the same `list_tools` call, and differ only in what they assert. The pattern is identical across all four tool crates.
+
+## Requirements
+
+- Add a public async function with this signature to `crates/mcp-test-utils/src/lib.rs`:
+  ```rust
+  pub async fn assert_single_tool(
+      client: &RunningService<RoleClient, ()>,
+      expected_name: &str,
+      description_contains: &str,
+      expected_params: &[&str],
+  )
+  ```
+- The function must perform these assertions in order:
+  1. Call `client.peer().list_tools(None).await` and unwrap with a clear message.
+  2. Assert that `tools_result.tools.len() == 1` with the message `"expected exactly 1 tool"`.
+  3. Assert that `tools_result.tools[0].name == expected_name`.
+  4. Assert that the tool has a description (`tools[0].description` is `Some`) and that the description contains the `description_contains` substring. Use a descriptive panic message that includes the actual description on failure.
+  5. Assert that `tools[0].input_schema` has a `"properties"` key.
+  6. For each entry in `expected_params`, assert that the `"properties"` object contains that key. Use a descriptive panic message that includes the missing parameter name on failure.
+- The function must NOT call `client.cancel()` -- that remains the caller's responsibility.
+- The function must NOT spawn or manage the MCP client -- it receives a reference.
+- No new external dependencies are required. The function uses types already depended on by `mcp-test-utils`: `rmcp::service::RunningService`, `rmcp::RoleClient`.
+
+## Implementation Details
+
+### File to modify
+
+**`crates/mcp-test-utils/src/lib.rs`** -- append the function after the existing `spawn_mcp_client!` macro.
+
+### Function body
+
+The function should follow the exact assertion pattern from the existing tests. Specifically:
+
+1. `list_tools` call:
+   ```rust
+   let tools_result = client.peer().list_tools(None).await.expect("list_tools failed");
+   ```
+
+2. Tool count and name:
+   ```rust
+   assert_eq!(tools_result.tools.len(), 1, "expected exactly 1 tool");
+   assert_eq!(tools_result.tools[0].name, expected_name);
+   ```
+
+3. Description check:
+   ```rust
+   let description = tools_result.tools[0]
+       .description
+       .as_deref()
+       .expect("tool should have a description");
+   assert!(
+       description.contains(description_contains),
+       "expected description to contain '{}', got: {}",
+       description_contains,
+       description
+   );
+   ```
+
+4. Parameter checks:
+   ```rust
+   let properties = tools_result.tools[0]
+       .input_schema
+       .get("properties")
+       .expect("input_schema should have properties");
+   for param in expected_params {
+       assert!(
+           properties.get(*param).is_some(),
+           "input_schema properties should contain '{}'",
+           param
+       );
+   }
+   ```
+
+### Required imports
+
+The function needs these types in scope (some may already be imported for the macro):
+- `rmcp::service::RunningService`
+- `rmcp::RoleClient`
+
+### How callers will use it
+
+After migration, each tool's integration test file will replace its three `tools_list_*` tests with a single test like:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_validates_echo_tool() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_echo-tool"));
+    mcp_test_utils::assert_single_tool(
+        &client,
+        "echo",
+        "Returns the input message unchanged",
+        &["message"],
+    ).await;
+    client.cancel().await.expect("failed to cancel client");
+}
+```
+
+### Key design decisions
+
+- **Async function, not macro**: Unlike `spawn_mcp_client!` which must be a macro (because `env!` resolves at compile time in the calling crate), `assert_single_tool` is a plain async function. It receives a reference to an already-constructed client, so no macro is needed.
+- **Borrows client**: Takes `&RunningService` rather than consuming it, so callers can continue using the client for tool-call tests after the assertion and call `cancel()` when done.
+- **Slice of param names**: Uses `&[&str]` for `expected_params` to handle tools with varying numbers of parameters (e.g., `echo-tool` has 1 param, `write-file` has 2).
+- **No return value**: The function returns `()`. All checks use `assert!`/`assert_eq!` and panic on failure, matching the existing test convention.
+
+### Files NOT modified by this task
+
+- Tool test files (`tools/*/tests/*_server_test.rs`) -- those are modified by the Group 4 migration tasks.
+- `crates/mcp-test-utils/Cargo.toml` -- no new dependencies needed; `rmcp` with `client` feature is already present from the macro task.
+- `Cargo.toml` (workspace root) -- already updated by the prerequisite task.
+
+## Dependencies
+
+- Blocked by: "Create `crates/mcp-test-utils` crate with `spawn_mcp_client!` macro"
+- Blocking: "Migrate echo-tool integration tests", "Migrate read-file integration tests", "Migrate write-file integration tests", "Migrate validate-skill integration tests"
+
+## Risks & Edge Cases
+
+- **`list_tools` return type changes**: The function accesses `tools_result.tools[0].input_schema` as a map-like type via `.get("properties")`. If `rmcp` changes the `input_schema` type in a future version, this will need updating. The current code matches the pattern used across all four existing test files.
+- **Tools with zero or multiple parameters**: The `expected_params` slice handles this naturally -- an empty slice `&[]` would skip parameter checks, and a multi-element slice checks each one. All current tools have at least one parameter.
+- **Description substring sensitivity**: The `description_contains` check is case-sensitive, matching the existing test behavior. Callers must pass a substring that matches the tool's actual description casing.
+
+## Verification
+
+- `cargo check -p mcp-test-utils` succeeds with no errors.
+- `cargo clippy -p mcp-test-utils` produces no warnings.
+- `cargo test -p mcp-test-utils` succeeds (the function itself has no unit tests -- it is exercised by the integration tests in the Group 4 migration tasks).
+- The function signature matches the one specified in this spec exactly.
+- The function is `pub` and accessible from external crates.
+- No new dependencies are added to `crates/mcp-test-utils/Cargo.toml`.

--- a/.claude/specs/issue-56/add-shared-skill-fixture-constants-to-mcp-test-utils.md
+++ b/.claude/specs/issue-56/add-shared-skill-fixture-constants-to-mcp-test-utils.md
@@ -1,0 +1,110 @@
+# Spec: Add shared skill fixture constants to `mcp-test-utils`
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+
+Add a public function `valid_skill_content() -> String` to the `mcp-test-utils` crate that returns the canonical valid skill YAML frontmatter fixture. This eliminates three near-identical copies of the same fixture scattered across the codebase.
+
+## Current State
+
+Three files each define their own private helper returning nearly identical skill YAML frontmatter:
+
+1. **`crates/skill-loader/src/lib.rs`** -- `fn valid_frontmatter() -> String` (line 96). Uses `output.format: markdown`.
+2. **`tools/validate-skill/src/validate_skill.rs`** -- `fn valid_content() -> String` (line 76). Uses `output.format: json`.
+3. **`tools/validate-skill/tests/validate_skill_server_test.rs`** -- `fn valid_skill_content() -> String` (line 20). Uses `output.format: json`.
+
+All three share the same structure: a YAML frontmatter block delimited by `---`, containing fields `name`, `version`, `description`, `model` (with `provider`, `name`, `temperature`), `tools`, `constraints` (with `confidence_threshold`, `max_turns`, `allowed_actions`), `output` (with `format`, `schema`), and a trailing preamble body line. The only difference is the `output.format` value (`markdown` vs `json`).
+
+The `mcp-test-utils` crate is assumed to already exist (created by the "Create `crates/mcp-test-utils` crate" task in Group 1).
+
+## Requirements
+
+- Add a public function `pub fn valid_skill_content() -> String` to `crates/mcp-test-utils/src/lib.rs`.
+- The function must return a `String` containing valid skill YAML frontmatter with the following field values:
+  - `name: test-skill`
+  - `version: "1.0.0"`
+  - `description: A test skill`
+  - `model.provider: openai`
+  - `model.name: gpt-4`
+  - `model.temperature: 0.7`
+  - `tools: [read_file, write_file]`
+  - `constraints.confidence_threshold: 0.8`
+  - `constraints.max_turns: 5`
+  - `constraints.allowed_actions: [read, write]`
+  - `output.format: json` (canonical value -- not `markdown`)
+  - `output.schema.result: string`
+- The returned string must include the `---` frontmatter delimiters and a trailing preamble body line `This is the preamble body.`, matching the existing fixtures.
+- The function must take no arguments and return `String`.
+- No new dependencies are required -- this is a pure function returning a string literal.
+- Do NOT add any other functions, structs, or modules as part of this task.
+- Do NOT modify any consuming crates in this task. Downstream migration of the three existing copies is handled by separate tasks ("Migrate validate-skill tests" and "Migrate skill-loader tests to use shared fixture").
+
+## Implementation Details
+
+### File to modify
+
+**`crates/mcp-test-utils/src/lib.rs`**
+
+- Add the function `pub fn valid_skill_content() -> String` below any existing code in the file.
+- Use a raw string literal (`r#"..."#`) to define the YAML content, matching the style used in the existing fixtures.
+- Call `.to_string()` on the raw string literal to return an owned `String`.
+
+### Canonical fixture content
+
+The returned string must be exactly:
+
+```
+---
+name: test-skill
+version: "1.0.0"
+description: A test skill
+model:
+  provider: openai
+  name: gpt-4
+  temperature: 0.7
+tools:
+  - read_file
+  - write_file
+constraints:
+  confidence_threshold: 0.8
+  max_turns: 5
+  allowed_actions:
+    - read
+    - write
+output:
+  format: json
+  schema:
+    result: string
+---
+This is the preamble body.
+```
+
+### Why `json` and not `markdown`
+
+Two of the three existing copies use `output.format: json`. The `skill-loader` copy uses `markdown`, but the task description specifies `json` as the canonical value. When the skill-loader tests are migrated (a separate task), they will be updated to use `json` and their assertions adjusted accordingly.
+
+### Integration points
+
+- **`tools/validate-skill/src/validate_skill.rs`** tests will replace local `valid_content()` with `mcp_test_utils::valid_skill_content()` (in the "Migrate validate-skill tests" task).
+- **`tools/validate-skill/tests/validate_skill_server_test.rs`** will replace local `valid_skill_content()` with `mcp_test_utils::valid_skill_content()` (in the "Migrate validate-skill tests" task).
+- **`crates/skill-loader/src/lib.rs`** tests will replace local `valid_frontmatter()` with `mcp_test_utils::valid_skill_content()` and update assertions for `format: json` (in the "Migrate skill-loader tests" task).
+
+## Dependencies
+
+- Blocked by: "Create `crates/mcp-test-utils` crate" (Group 1)
+- Blocking: "Migrate validate-skill tests" (Group 4), "Migrate skill-loader tests to use shared fixture" (Group 4)
+
+## Risks & Edge Cases
+
+- **Fixture drift**: If the `SkillManifest` struct gains new required fields in the future, this fixture will need updating. Since all consumers will share the same function, updates happen in one place -- that is the whole point of this consolidation.
+- **`skill-loader` test assertions**: The skill-loader tests currently assert `output.format` equals `"markdown"`. When migrated, those assertions must change to `"json"`. This is expected and documented in the task breakdown (Implementation Note 4). It is NOT part of this task.
+- **Function placement in `lib.rs`**: Other Group 2 tasks may also be adding functions to the same `lib.rs` file (e.g., `assert_single_tool`, `unique_temp_dir`). Since they are independent additions, merge conflicts should be minimal -- each adds a distinct function.
+
+## Verification
+
+- Run `cargo check -p mcp-test-utils` and confirm no compiler errors.
+- Run `cargo test -p mcp-test-utils` and confirm the crate compiles (no tests are required for this function since it returns a static string, but the crate must compile cleanly).
+- Run `cargo clippy -p mcp-test-utils` and confirm no warnings.
+- Verify the function is `pub` and accessible from other crates by confirming `cargo check -p mcp-test-utils` succeeds with the function exported.
+- Verify the returned string parses correctly by visual inspection against the canonical content above.

--- a/.claude/specs/issue-56/add-unique-temp-dir-helper-to-mcp-test-utils.md
+++ b/.claude/specs/issue-56/add-unique-temp-dir-helper-to-mcp-test-utils.md
@@ -1,0 +1,149 @@
+# Spec: Add `unique_temp_dir` helper to `mcp-test-utils`
+
+> Task: Add `unique_temp_dir` helper to `mcp-test-utils` `[S]`
+
+## Objective
+
+Move the `unique_temp_dir(test_name) -> PathBuf` helper from the write-file tool's inline test module into the `mcp-test-utils` crate as a public function. Replace the hard-coded `"write_file_tests"` prefix with `"spore_tests"` so the helper is tool-agnostic and reusable across all tool crates in the workspace.
+
+## Current State
+
+- **Source function:** `tools/write-file/src/write_file.rs` contains a private `unique_temp_dir` function inside its `#[cfg(test)] mod tests` block (lines 77-85). It constructs a unique temporary directory at `<temp_dir>/write_file_tests/<test_name>/<pid>`, removes any prior contents, creates the directory tree, and returns the `PathBuf`.
+
+- **Current implementation:**
+  ```rust
+  fn unique_temp_dir(test_name: &str) -> std::path::PathBuf {
+      let dir = env::temp_dir()
+          .join("write_file_tests")
+          .join(test_name)
+          .join(format!("{}", std::process::id()));
+      let _ = fs::remove_dir_all(&dir);
+      fs::create_dir_all(&dir).expect("failed to create temp dir");
+      dir
+  }
+  ```
+
+- **`mcp-test-utils` crate:** Does not exist yet. This task is blocked by the "Create `crates/mcp-test-utils` crate" task, which will set up the crate scaffolding (`Cargo.toml`, `lib.rs`, workspace member entry).
+
+## Requirements
+
+1. **File location:** Add the `unique_temp_dir` function to `crates/mcp-test-utils/src/lib.rs` (or a submodule re-exported from `lib.rs`).
+
+2. **Public visibility:** The function must be `pub` so that downstream tool crates can call it as `mcp_test_utils::unique_temp_dir("test_name")`.
+
+3. **Signature:** `pub fn unique_temp_dir(test_name: &str) -> std::path::PathBuf`
+
+4. **Prefix change:** The directory prefix must be `"spore_tests"` instead of `"write_file_tests"`. The resulting path is `<temp_dir>/spore_tests/<test_name>/<pid>`.
+
+5. **Behaviour must match the original:**
+   - Construct path as `env::temp_dir().join("spore_tests").join(test_name).join(format!("{}", std::process::id()))`.
+   - Remove any existing directory at that path (silently ignore errors via `let _ = fs::remove_dir_all(&dir)`).
+   - Create the full directory tree via `fs::create_dir_all(&dir).expect("failed to create temp dir")`.
+   - Return the `PathBuf`.
+
+6. **No new dependencies:** The function uses only `std::env`, `std::fs`, and `std::path::PathBuf`. No external crates are needed beyond what the `mcp-test-utils` crate scaffolding already provides.
+
+7. **Unit tests:** Add at least three `#[test]` functions in an inline `#[cfg(test)] mod tests` block within the same file:
+
+   | # | Test name | Assertion |
+   |---|-----------|-----------|
+   | 1 | `unique_temp_dir_creates_directory` | The returned path exists and is a directory (`dir.exists()` and `dir.is_dir()`). Clean up after. |
+   | 2 | `unique_temp_dir_includes_test_name` | The returned path string contains the provided test name substring. |
+   | 3 | `unique_temp_dir_uses_spore_tests_prefix` | The returned path string contains `"spore_tests"` and does **not** contain `"write_file_tests"`. |
+
+## Implementation Details
+
+### File to modify: `crates/mcp-test-utils/src/lib.rs`
+
+Add the following public function and test module (the crate scaffolding will already have `lib.rs` in place from the prerequisite task):
+
+```rust
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+/// Creates a unique temporary directory for a test, scoped by test name and process ID.
+///
+/// Path format: `<temp_dir>/spore_tests/<test_name>/<pid>`
+///
+/// Any pre-existing directory at the path is removed before creation, ensuring
+/// a clean slate for each test run.
+pub fn unique_temp_dir(test_name: &str) -> PathBuf {
+    let dir = env::temp_dir()
+        .join("spore_tests")
+        .join(test_name)
+        .join(format!("{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("failed to create temp dir");
+    dir
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unique_temp_dir_creates_directory() {
+        let dir = unique_temp_dir("creates_directory");
+        assert!(dir.exists(), "directory should exist");
+        assert!(dir.is_dir(), "path should be a directory");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unique_temp_dir_includes_test_name() {
+        let dir = unique_temp_dir("my_specific_test");
+        let path_str = dir.to_string_lossy();
+        assert!(
+            path_str.contains("my_specific_test"),
+            "path should contain test name, got: {}",
+            path_str
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unique_temp_dir_uses_spore_tests_prefix() {
+        let dir = unique_temp_dir("prefix_check");
+        let path_str = dir.to_string_lossy();
+        assert!(
+            path_str.contains("spore_tests"),
+            "path should contain 'spore_tests', got: {}",
+            path_str
+        );
+        assert!(
+            !path_str.contains("write_file_tests"),
+            "path should not contain old prefix 'write_file_tests', got: {}",
+            path_str
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+}
+```
+
+### No other files created or modified
+
+This task only adds the `unique_temp_dir` function and its tests to the `mcp-test-utils` crate. It does not modify write-file or any other tool crate (that is handled by the downstream "Migrate write-file tests" task).
+
+## Dependencies
+
+- **Blocked by:**
+  - "Create `crates/mcp-test-utils` crate" -- the crate scaffolding (`Cargo.toml`, `lib.rs`, workspace member entry) must exist before this function can be added.
+- **Blocking:**
+  - "Migrate write-file tests" -- downstream tool crates will replace their local `unique_temp_dir` with `mcp_test_utils::unique_temp_dir` once this function is available.
+
+## Risks & Edge Cases
+
+1. **Parallel test execution:** The path includes `std::process::id()`, which is unique per process. Since `cargo test` runs all tests within a single process, two tests with the same `test_name` argument would collide. Each call site must use a distinct `test_name` value.
+
+2. **Non-UTF-8 temp directory:** `env::temp_dir()` could theoretically return a non-UTF-8 path on some platforms. Tests use `to_string_lossy()` for assertions, which handles this gracefully. Callers using `to_str().unwrap()` (as the write-file tests do) would panic, but this is acceptable in test environments on all major platforms.
+
+3. **Cleanup responsibility:** The function does not register any automatic cleanup. Callers are responsible for removing the directory after use (typically `let _ = fs::remove_dir_all(&dir)` at the end of each test). The function does clean up stale directories from prior runs of the same test.
+
+4. **`remove_dir_all` on first call:** On the very first run, the directory does not exist, so `remove_dir_all` returns an error which is silently ignored via `let _ = ...`. This is intentional.
+
+## Verification
+
+1. `cargo test -p mcp-test-utils` compiles and all 3 test functions pass.
+2. `cargo clippy -p mcp-test-utils --tests` reports no warnings.
+3. `cargo check --workspace` confirms no breakage in the wider workspace.

--- a/.claude/specs/issue-56/create-crates-mcp-test-utils-crate-with-spawn-mcp-client-macro.md
+++ b/.claude/specs/issue-56/create-crates-mcp-test-utils-crate-with-spawn-mcp-client-macro.md
@@ -1,0 +1,121 @@
+# Spec: Create `crates/mcp-test-utils` crate with `spawn_mcp_client!` macro
+
+> From: Issue #56
+
+## Objective
+
+Create a new workspace member crate `crates/mcp-test-utils` that provides a declarative macro `spawn_mcp_client!` for spawning MCP tool binaries as child processes and connecting an MCP client. This eliminates the boilerplate `spawn_*_client()` helper that is currently duplicated in each tool's integration tests (e.g., `spawn_echo_client()` in `tools/echo-tool/tests/echo_server_test.rs`). The macro must be a `macro_rules!` macro because it wraps `env!("CARGO_BIN_EXE_...")`, which resolves at compile time in the calling crate's context.
+
+## Current State
+
+- Each tool crate defines its own async helper to spawn a child process and connect an MCP client. For example, `tools/echo-tool/tests/echo_server_test.rs` contains:
+  ```rust
+  async fn spawn_echo_client() -> RunningService<RoleClient, ()> {
+      let transport = TokioChildProcess::new(Command::new(env!("CARGO_BIN_EXE_echo-tool")))
+          .expect("failed to spawn echo-tool");
+      ().serve(transport)
+          .await
+          .expect("failed to connect to echo-tool server")
+  }
+  ```
+- This pattern is identical across tool crates except for the binary name string passed to `env!()`.
+- The workspace root `Cargo.toml` currently has these members:
+  ```toml
+  members = [
+      "crates/agent-sdk",
+      "crates/skill-loader",
+      "crates/tool-registry",
+      "crates/agent-runtime",
+      "crates/orchestrator",
+      "tools/echo-tool",
+      "tools/read-file",
+      "tools/write-file",
+      "tools/validate-skill",
+  ]
+  ```
+- No shared test utility crate exists in the workspace.
+- Tool crates each independently declare `rmcp` with `client` and `transport-child-process` features in their `[dev-dependencies]`.
+
+## Requirements
+
+- Create the directory `crates/mcp-test-utils/src/`.
+- Create `crates/mcp-test-utils/Cargo.toml` with the fields specified in Implementation Details.
+- Create `crates/mcp-test-utils/src/lib.rs` containing the `spawn_mcp_client!` macro.
+- Add `"crates/mcp-test-utils"` to the `members` list in the root `Cargo.toml`.
+- The macro `spawn_mcp_client!` must:
+  - Accept a single expression that evaluates to a binary path (intended to be used with `env!("CARGO_BIN_EXE_<name>")`).
+  - Return `RunningService<RoleClient, ()>` (from the `rmcp` crate).
+  - Be an `async` block internally (the caller must `.await` the result).
+  - Panic with a descriptive message if spawning or connecting fails (this is test-only code).
+- The crate must re-export the `rmcp` types needed by callers so they do not need to add `rmcp` to their own dev-dependencies just for the return type: `RunningService`, `RoleClient`.
+- Dependencies must be limited to: `rmcp` (with `client` and `transport-child-process` features) and `tokio` (with `process` feature).
+- No proc-macro crate is needed; a `macro_rules!` declarative macro is sufficient.
+
+## Implementation Details
+
+### Files to create
+
+1. **`crates/mcp-test-utils/Cargo.toml`**
+
+   ```toml
+   [package]
+   name = "mcp-test-utils"
+   version = "0.1.0"
+   edition = "2024"
+
+   [dependencies]
+   rmcp = { version = "1", features = ["client", "transport-child-process"] }
+   tokio = { version = "1", features = ["process"] }
+   ```
+
+2. **`crates/mcp-test-utils/src/lib.rs`**
+
+   The file must:
+   - Re-export `rmcp::service::RunningService` and `rmcp::RoleClient` so downstream test code can reference the return type without adding `rmcp` as a direct dependency.
+   - Re-export `rmcp::ServiceExt` so callers have the `.serve()` method in scope.
+   - Define the `spawn_mcp_client!` macro that expands to an async block equivalent to:
+     ```rust
+     async {
+         let transport = rmcp::transport::TokioChildProcess::new(
+             tokio::process::Command::new($bin_path)
+         ).expect("failed to spawn MCP server");
+         <() as rmcp::ServiceExt>::serve((), transport)
+             .await
+             .expect("failed to connect to MCP server")
+     }
+     ```
+   - The macro must use fully qualified paths (e.g., `$crate::...` or `::rmcp::...`) to avoid import conflicts in the calling crate.
+
+### Files to modify
+
+3. **`Cargo.toml`** (workspace root)
+
+   Add `"crates/mcp-test-utils"` to the `members` array. Place it alphabetically among the `crates/` entries (after `"crates/agent-sdk"` and before `"crates/orchestrator"`, or at the end of the crates group).
+
+### Key design decisions
+
+- **`macro_rules!` not `proc_macro`:** The entire reason this must be a macro is that `env!("CARGO_BIN_EXE_...")` is resolved at compile time in the crate that invokes it. A regular function would resolve `env!()` in the `mcp-test-utils` crate itself, which does not declare any binary targets. A `macro_rules!` macro expands in the caller's context, so `env!()` resolves correctly.
+- **Re-exports:** By re-exporting `RunningService`, `RoleClient`, and `ServiceExt`, consuming crates only need `mcp-test-utils` in their `[dev-dependencies]`, not `rmcp` directly (unless they need additional `rmcp` types for test assertions like `CallToolRequestParams`).
+- **Panic on failure:** Since this is test utility code, panicking with `.expect()` is the correct error handling strategy. Test failures will show the panic message.
+- **Minimal tokio features:** Only `process` is needed for `tokio::process::Command`. The calling test crate will already have `rt` and `macros` for `#[tokio::test]`.
+
+## Dependencies
+
+- Blocked by: Nothing (this is a foundational test utility crate).
+- Blocking: All test utility additions and test migrations that will replace per-crate `spawn_*_client()` helpers with the shared macro.
+
+## Risks & Edge Cases
+
+- **`env!()` expansion context:** The correctness of this approach depends on `macro_rules!` expanding in the caller's crate context. This is standard Rust behavior for declarative macros and is well-documented. The `env!("CARGO_BIN_EXE_...")` environment variable is set by Cargo during `cargo test` for binary targets in the same package; the calling crate must declare the binary as a dependency or be in the same package for this to work.
+- **Feature unification:** Adding `rmcp` with `client` and `transport-child-process` features may pull in additional transitive dependencies. Since this crate is only used in `[dev-dependencies]`, these will not affect production binary sizes.
+- **Edition 2024:** Consistent with all other workspace crates. Requires rustc 1.85+.
+- **Macro hygiene:** The macro must use fully qualified paths to avoid name collisions. Using `::rmcp::` and `::tokio::` prefixes (or `$crate` for re-exports) ensures the macro works regardless of what the caller has imported.
+
+## Verification
+
+- `crates/mcp-test-utils/Cargo.toml` exists with the specified `[package]` and `[dependencies]` sections.
+- `crates/mcp-test-utils/src/lib.rs` exists and defines the `spawn_mcp_client!` macro with re-exports.
+- The root `Cargo.toml` includes `"crates/mcp-test-utils"` in the workspace members list.
+- `cargo check -p mcp-test-utils` succeeds without errors.
+- `cargo clippy -p mcp-test-utils` succeeds without warnings.
+- `cargo test -p mcp-test-utils` succeeds (even if there are no tests yet, it should compile).

--- a/.claude/specs/issue-56/create-crates-mcp-tool-harness-crate-with-serve-stdio-tool-function.md
+++ b/.claude/specs/issue-56/create-crates-mcp-tool-harness-crate-with-serve-stdio-tool-function.md
@@ -1,0 +1,181 @@
+# Spec: Create `crates/mcp-tool-harness` crate with `serve_stdio_tool` function
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+
+Create a new workspace member crate at `crates/mcp-tool-harness` that extracts the common MCP stdio server boilerplate into a reusable library function. Today, every tool binary (echo-tool, read-file, write-file, validate-skill) duplicates the same tracing setup, stdio transport initialization, and service lifecycle management in its `main.rs`. This crate provides a single `serve_stdio_tool` function that encapsulates all of that, so each tool's `main.rs` reduces to a one-liner call.
+
+## Current State
+
+- The workspace root `Cargo.toml` lists these members:
+  ```toml
+  [workspace]
+  resolver = "2"
+  members = [
+      "crates/agent-sdk",
+      "crates/skill-loader",
+      "crates/tool-registry",
+      "crates/agent-runtime",
+      "crates/orchestrator",
+      "tools/echo-tool",
+      "tools/read-file",
+      "tools/write-file",
+      "tools/validate-skill",
+  ]
+  ```
+- No `crates/mcp-tool-harness` directory exists yet.
+- Each tool binary contains duplicated boilerplate in `main.rs` that follows this pattern (taken from `tools/echo-tool/src/main.rs`):
+  ```rust
+  tracing_subscriber::fmt()
+      .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::DEBUG.into()))
+      .with_writer(std::io::stderr)
+      .with_ansi(false)
+      .init();
+
+  tracing::info!("Starting echo-tool MCP server");
+
+  let service = EchoTool::new()
+      .serve(rmcp::transport::stdio())
+      .await
+      .inspect_err(|e| tracing::error!("serving error: {:?}", e))?;
+
+  service.waiting().await?;
+  ```
+- All existing crates use `edition = "2024"` and `version = "0.1.0"`.
+
+## Requirements
+
+- Create the directory `crates/mcp-tool-harness/src/`.
+- Create `crates/mcp-tool-harness/Cargo.toml` with `publish = false` and the dependencies listed below.
+- Create `crates/mcp-tool-harness/src/lib.rs` implementing the `serve_stdio_tool` function.
+- Add `"crates/mcp-tool-harness"` to the workspace `members` list in the root `Cargo.toml`.
+- The public API must be exactly one function:
+  ```rust
+  pub async fn serve_stdio_tool<T: ServerHandler>(tool: T, tool_name: &str) -> Result<(), Box<dyn std::error::Error>>
+  ```
+- The function must:
+  1. Initialize `tracing_subscriber` to write to stderr with ANSI disabled and `EnvFilter` defaulting to DEBUG level.
+  2. Log an info message including the `tool_name` parameter (e.g., `"Starting {tool_name} MCP server"`).
+  3. Call `.serve(rmcp::transport::stdio())` on the tool and log errors with `inspect_err`.
+  4. Call `.waiting().await?` on the resulting service.
+  5. Return `Ok(())`.
+- The `ServerHandler` trait bound comes from `rmcp::handler::server::ServerHandler`. The function must re-export or use the correct import so callers only need `rmcp` as a dependency for their tool struct, not for the handler trait.
+- Dependencies must be exactly: `rmcp`, `tokio`, `tracing`, `tracing-subscriber`. No additional dependencies.
+
+## Implementation Details
+
+### Files to create
+
+1. **`crates/mcp-tool-harness/Cargo.toml`**
+
+   ```toml
+   [package]
+   name = "mcp-tool-harness"
+   version = "0.1.0"
+   edition = "2024"
+   publish = false
+
+   [dependencies]
+   rmcp = { version = "1", features = ["transport-io", "server"] }
+   tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+   tracing = "0.1"
+   tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+   ```
+
+   Key points:
+   - `publish = false` since this is an internal workspace utility, not intended for crates.io.
+   - `rmcp` features mirror what the tool binaries already use: `transport-io` for `rmcp::transport::stdio()` and `server` for `ServerHandler` and `ServiceExt`.
+   - `tokio` needs `io-std` for stdio transport access. `macros` and `rt` for the async runtime used by callers.
+   - No `serde` or `serde_json` -- those are tool-specific concerns, not harness concerns.
+
+2. **`crates/mcp-tool-harness/src/lib.rs`**
+
+   Must contain:
+   - A `pub use rmcp::handler::server::ServerHandler;` re-export so downstream tool crates can reference the trait without importing `rmcp` handler internals directly.
+   - The `serve_stdio_tool` function with the exact signature specified above.
+   - The function body must replicate the existing boilerplate pattern from the tool binaries, parameterized by `tool` and `tool_name`.
+
+   Approximate structure (implementation must match this logic):
+   ```rust
+   use rmcp::ServiceExt;
+   use tracing_subscriber::EnvFilter;
+
+   pub use rmcp::handler::server::ServerHandler;
+
+   pub async fn serve_stdio_tool<T: ServerHandler>(
+       tool: T,
+       tool_name: &str,
+   ) -> Result<(), Box<dyn std::error::Error>> {
+       tracing_subscriber::fmt()
+           .with_env_filter(
+               EnvFilter::from_default_env()
+                   .add_directive(tracing::Level::DEBUG.into()),
+           )
+           .with_writer(std::io::stderr)
+           .with_ansi(false)
+           .init();
+
+       tracing::info!("Starting {tool_name} MCP server");
+
+       let service = tool
+           .serve(rmcp::transport::stdio())
+           .await
+           .inspect_err(|e| tracing::error!("serving error: {:?}", e))?;
+
+       service.waiting().await?;
+       Ok(())
+   }
+   ```
+
+### Files to modify
+
+3. **`Cargo.toml`** (workspace root)
+
+   Add `"crates/mcp-tool-harness"` to the `members` array. Insert it among the `crates/` entries, before the `tools/` entries, to maintain the current grouping convention:
+   ```toml
+   members = [
+       "crates/agent-sdk",
+       "crates/skill-loader",
+       "crates/tool-registry",
+       "crates/agent-runtime",
+       "crates/mcp-tool-harness",
+       "crates/orchestrator",
+       "tools/echo-tool",
+       "tools/read-file",
+       "tools/write-file",
+       "tools/validate-skill",
+   ]
+   ```
+
+### Key design decisions
+
+- **Library crate, not binary:** This is a `lib.rs` crate (no `main.rs`) because it provides a reusable function, not a standalone executable.
+- **`publish = false`:** This is an internal utility for this workspace only. It should never be published to crates.io.
+- **Single function API:** The entire public surface is one function. This keeps the API minimal and easy to evolve. If future tools need different transport options (e.g., HTTP SSE), new functions can be added without breaking existing callers.
+- **Re-export `ServerHandler`:** Downstream tool crates need the `ServerHandler` trait in scope for the generic bound to resolve. Re-exporting it from the harness avoids requiring tools to know about `rmcp::handler::server` internals.
+- **`Box<dyn std::error::Error>` return type:** Matches the existing `main.rs` return type in all tool binaries, making migration straightforward.
+- **No `serde`/`serde_json` dependency:** Those are tool-specific for defining tool schemas. The harness only deals with transport and lifecycle.
+
+## Dependencies
+
+- Blocked by: Nothing (this is a foundational crate)
+- Blocking: All 4 `main.rs` migrations (echo-tool, read-file, write-file, validate-skill must be updated to use `serve_stdio_tool` instead of inline boilerplate)
+
+## Risks & Edge Cases
+
+- **`tracing_subscriber` double-init:** If a caller accidentally initializes tracing before calling `serve_stdio_tool`, the `tracing_subscriber::fmt().init()` call will panic (or silently fail depending on version). This is acceptable for now since the function is intended to be called exactly once at program startup. A future enhancement could use `try_init()` instead, but that changes error semantics.
+- **`ServerHandler` trait path:** The re-export path `rmcp::handler::server::ServerHandler` must be verified against the actual `rmcp` v1 API. If the module path differs, the import must be adjusted. The `ServiceExt` trait import (`rmcp::ServiceExt`) is also required for the `.serve()` method.
+- **`rmcp` version compatibility:** The `rmcp = { version = "1", ... }` specifier must match what the existing tool crates already use. Since `tools/echo-tool/Cargo.toml` already uses `version = "1"`, this is consistent.
+- **Generic bound `T: ServerHandler`:** The `ServerHandler` trait from `rmcp` may have additional bounds (e.g., `Send`, `Sync`). The generic function signature must satisfy whatever `ServiceExt::serve` requires. If additional trait bounds are needed, they should be added to the function signature.
+
+## Verification
+
+- `crates/mcp-tool-harness/Cargo.toml` exists with `publish = false` and the four dependencies listed above.
+- `crates/mcp-tool-harness/src/lib.rs` exists and contains the `serve_stdio_tool` function with the specified signature.
+- `Cargo.toml` (root) includes `"crates/mcp-tool-harness"` in the workspace members.
+- `cargo check -p mcp-tool-harness` succeeds without errors.
+- `cargo clippy -p mcp-tool-harness` passes without warnings.
+- `cargo test -p mcp-tool-harness` passes (even if there are no tests yet).
+- The function re-exports `ServerHandler` so downstream crates can use `mcp_tool_harness::ServerHandler`.
+- No dependencies beyond `rmcp`, `tokio`, `tracing`, `tracing-subscriber` are present.

--- a/.claude/specs/issue-56/migrate-echo-tool-integration-tests.md
+++ b/.claude/specs/issue-56/migrate-echo-tool-integration-tests.md
@@ -1,0 +1,119 @@
+# Spec: Migrate echo-tool integration tests
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+
+Migrate `tools/echo-tool/tests/echo_server_test.rs` to use shared test utilities from `crates/mcp-test-utils`. Replace the local `spawn_echo_client()` helper with the `spawn_mcp_client!` macro, consolidate the three `tools_list_*` tests into a single test using `assert_single_tool`, and add `mcp-test-utils` as a dev-dependency. The two tool-specific call tests remain unchanged in logic.
+
+## Current State
+
+- **`tools/echo-tool/tests/echo_server_test.rs`** contains 5 integration tests and a local `spawn_echo_client()` helper function:
+  1. `tools_list_returns_echo_tool` -- asserts exactly 1 tool named `"echo"`
+  2. `tools_list_echo_has_correct_description` -- asserts description contains `"Returns the input message unchanged"`
+  3. `tools_list_echo_has_message_parameter` -- asserts `input_schema.properties` contains `"message"`
+  4. `tools_call_echo_returns_message` -- calls echo with `"hello"`, asserts response contains `"hello"`
+  5. `tools_call_echo_preserves_unicode` -- calls echo with a unicode string, asserts exact round-trip preservation
+
+- **`spawn_echo_client()`** is a local async function (lines 10-17) that creates a `TokioChildProcess` from `env!("CARGO_BIN_EXE_echo-tool")`, then calls `().serve(transport).await`. This exact pattern is duplicated across all 4 tool test files.
+
+- **Three `tools_list_*` tests** (tests 1-3) each independently spawn a client, call `list_tools`, and assert one property. These three assertions are the same pattern used across all 4 tool test files.
+
+- **`tools/echo-tool/Cargo.toml` `[dev-dependencies]`** currently contains:
+  ```toml
+  [dev-dependencies]
+  tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+  rmcp = { version = "1", features = ["client", "transport-child-process"] }
+  serde_json = "1"
+  ```
+
+- **`crates/mcp-test-utils`** (created by a prior task) provides:
+  - `spawn_mcp_client!($bin_path_expr)` -- a declarative macro that accepts a compile-time binary path expression (from `env!("CARGO_BIN_EXE_...")`) and returns `RunningService<RoleClient, ()>`. Encapsulates `TokioChildProcess::new` + `().serve(transport).await`.
+  - `assert_single_tool(client, expected_name, description_contains, expected_params)` -- an async function that calls `list_tools`, asserts exactly 1 tool, asserts name matches, asserts description contains the given substring, and asserts each expected param exists in `input_schema.properties`.
+
+## Requirements
+
+1. **Remove `spawn_echo_client()` function.** Delete the entire local helper (lines 9-17 of the current file).
+
+2. **Add `mcp-test-utils` dev-dependency.** Add `mcp-test-utils = { path = "../../crates/mcp-test-utils" }` to `[dev-dependencies]` in `tools/echo-tool/Cargo.toml`.
+
+3. **Replace all `spawn_echo_client().await` calls** with `mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_echo-tool"))`. This appears in every test function (5 occurrences total, reduced to 3 after consolidation).
+
+4. **Consolidate the three `tools_list_*` tests into a single test.** Replace `tools_list_returns_echo_tool`, `tools_list_echo_has_correct_description`, and `tools_list_echo_has_message_parameter` with a single test:
+   ```rust
+   #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+   async fn tools_list_advertises_echo_tool() {
+       let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_echo-tool"));
+       mcp_test_utils::assert_single_tool(
+           &client,
+           "echo",
+           "Returns the input message unchanged",
+           &["message"],
+       )
+       .await;
+       client.cancel().await.expect("failed to cancel client");
+   }
+   ```
+
+5. **Keep `tools_call_echo_returns_message` and `tools_call_echo_preserves_unicode` tests.** Update only the client spawning line to use the macro. All assertions and logic remain the same.
+
+6. **Retain `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`** on all test functions, consistent with the current configuration.
+
+7. **Update imports.** Remove `rmcp::service::RunningService`, `rmcp::RoleClient`, and `tokio::process::Command` since they are no longer needed directly. Keep `rmcp::model::CallToolRequestParams`, `rmcp::ServiceExt`, and `serde_json` for the call tests.
+
+## Implementation Details
+
+### File to modify: `tools/echo-tool/tests/echo_server_test.rs`
+
+The resulting file should contain 3 tests (down from 5) and no local helper function:
+
+| # | Test name | What it does |
+|---|-----------|--------------|
+| 1 | `tools_list_advertises_echo_tool` | Spawns client, calls `assert_single_tool` with name `"echo"`, description substring `"Returns the input message unchanged"`, and params `["message"]` |
+| 2 | `tools_call_echo_returns_message` | Spawns client, calls echo with `{ "message": "hello" }`, asserts response text contains `"hello"` |
+| 3 | `tools_call_echo_preserves_unicode` | Spawns client, calls echo with a unicode string, asserts exact text match |
+
+### File to modify: `tools/echo-tool/Cargo.toml`
+
+Add to `[dev-dependencies]`:
+
+```toml
+mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+```
+
+The existing `rmcp`, `tokio`, and `serde_json` dev-dependencies remain because the call tests still use `CallToolRequestParams`, `serde_json::json!`, and `#[tokio::test]`.
+
+### No other files created or modified
+
+This task only modifies the integration test file and `Cargo.toml`. No source code changes.
+
+## Dependencies
+
+- **Blocked by:**
+  - "Create `crates/mcp-test-utils` crate with `spawn_mcp_client!` macro" (Group 1, issue #56) -- the macro must exist.
+  - "Add `assert_single_tool` helper to `mcp-test-utils`" (Group 2, issue #56) -- the helper function must exist.
+
+- **Blocking:**
+  - "Run verification suite" (Group 5, issue #56) -- verification depends on all migrations being complete and passing.
+
+## Risks & Edge Cases
+
+1. **`assert_single_tool` signature mismatch.** The exact signature of `assert_single_tool` (whether it takes `&RunningService<RoleClient, ()>` or uses a trait bound) must match how the macro returns the client. If the signature differs from what is described in the task breakdown, adjust the call accordingly.
+
+2. **Macro import path.** The `spawn_mcp_client!` macro is invoked via `mcp_test_utils::spawn_mcp_client!`. If the crate re-exports the macro differently (e.g., requiring `use mcp_test_utils::spawn_mcp_client;`), adapt the import. Declarative macros exported with `#[macro_export]` live at the crate root.
+
+3. **Description substring stability.** The consolidated test asserts `description_contains: "Returns the input message unchanged"`. If the echo tool's description changes, this test will fail. This is the same risk as the current `tools_list_echo_has_correct_description` test -- no new risk introduced.
+
+4. **Test count reduction.** Going from 5 tests to 3 tests means that a failure in `assert_single_tool` will report as a single failure rather than pinpointing which of the three properties (name, description, params) failed. This is an acceptable trade-off because `assert_single_tool` should include descriptive assertion messages for each check internally.
+
+5. **Unused imports after refactor.** Removing the local helper eliminates the need for `TokioChildProcess`, `Command`, `RunningService`, and `RoleClient` imports. Failing to clean up imports will cause `cargo clippy` warnings.
+
+## Verification
+
+1. `cargo test -p echo-tool --test echo_server_test` compiles and all 3 test functions pass.
+2. `cargo clippy -p echo-tool --tests` reports no warnings.
+3. The `spawn_echo_client` function no longer exists in the file.
+4. The three `tools_list_returns_echo_tool`, `tools_list_echo_has_correct_description`, and `tools_list_echo_has_message_parameter` tests no longer exist.
+5. The `tools_call_echo_returns_message` and `tools_call_echo_preserves_unicode` tests still pass with identical assertion logic.
+6. `mcp-test-utils` appears in `[dev-dependencies]` of `tools/echo-tool/Cargo.toml`.
+7. `cargo test` across the full workspace still passes (no regressions).

--- a/.claude/specs/issue-56/migrate-echo-tool-main-rs-to-use-serve-stdio-tool.md
+++ b/.claude/specs/issue-56/migrate-echo-tool-main-rs-to-use-serve-stdio-tool.md
@@ -1,0 +1,90 @@
+# Spec: Migrate echo-tool main.rs to use `serve_stdio_tool`
+
+> From: Issue #56
+
+## Objective
+Replace the boilerplate in `tools/echo-tool/src/main.rs` with a single call to `mcp_tool_harness::serve_stdio_tool`, reducing the entrypoint to approximately 5 lines. Add the `mcp-tool-harness` crate as a dependency and remove tracing dependencies that are now handled internally by the harness.
+
+## Current State
+- `tools/echo-tool/src/main.rs` (24 lines) manually sets up `tracing_subscriber`, creates the `EchoTool`, calls `.serve(rmcp::transport::stdio())`, and calls `.waiting().await`.
+- `tools/echo-tool/Cargo.toml` lists direct dependencies on `rmcp`, `tokio`, `serde`, `serde_json`, `tracing`, and `tracing-subscriber`.
+- The tracing setup (stderr writer, env filter, ANSI disabled) and the serve-then-wait pattern are identical across tool binaries (e.g., `echo-tool`, `read-file`). This duplication is exactly what `mcp-tool-harness` eliminates.
+- `tools/echo-tool/src/echo.rs` defines `EchoTool` with `ServerHandler` impl and unit tests. This file is unchanged by this migration.
+
+## Requirements
+1. `tools/echo-tool/src/main.rs` calls `mcp_tool_harness::serve_stdio_tool(EchoTool::new(), "echo-tool").await` and contains no direct tracing setup or `rmcp` transport code.
+2. The `mcp-tool-harness` workspace crate is added as a dependency in `tools/echo-tool/Cargo.toml`.
+3. The `tracing` and `tracing-subscriber` direct dependencies are removed from `tools/echo-tool/Cargo.toml` if they are no longer used anywhere in `echo-tool` source files (including `echo.rs` and tests). If `echo.rs` or tests still reference `tracing` macros, keep the `tracing` dependency but still remove `tracing-subscriber`.
+4. The `rmcp` dependency remains because `echo.rs` uses `rmcp` types directly (`ServerHandler`, `ToolRouter`, `tool_router`, etc.).
+5. The `tokio` dependency remains because `#[tokio::main]` is still used in `main.rs` and `#[tokio::test]` in tests.
+6. All existing integration tests (`tools/echo-tool/tests/echo_server_test.rs`) and unit tests continue to pass without modification.
+7. The binary behavior is identical: starts MCP server over stdio, logs to stderr, advertises the `echo` tool, and exits when the transport closes.
+
+## Implementation Details
+
+### File: `tools/echo-tool/Cargo.toml`
+
+Add the `mcp-tool-harness` dependency as a workspace path dependency. Remove `tracing` and `tracing-subscriber` from `[dependencies]` if they are no longer referenced in the crate source. Keep all other dependencies and `[dev-dependencies]` unchanged.
+
+After migration, the `[dependencies]` section should look approximately like:
+
+```toml
+[dependencies]
+mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }
+rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
+tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+```
+
+Note: If `echo.rs` or its tests use `tracing::info!`, `tracing::debug!`, or similar macros, keep `tracing = "0.1"` in `[dependencies]`. The current `echo.rs` does not use any tracing macros, so both `tracing` and `tracing-subscriber` should be removable.
+
+### File: `tools/echo-tool/src/main.rs`
+
+Replace the entire file contents with:
+
+```rust
+mod echo;
+use echo::EchoTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(EchoTool::new(), "echo-tool").await
+}
+```
+
+This removes:
+- `use rmcp::ServiceExt;` (now internal to the harness)
+- `use tracing_subscriber::{self, EnvFilter};` (now internal to the harness)
+- The 5-line `tracing_subscriber::fmt()` setup block
+- The `tracing::info!("Starting echo-tool MCP server");` log line (the harness logs this using the provided name)
+- The `EchoTool::new().serve(rmcp::transport::stdio())` call (encapsulated by harness)
+- The `service.waiting().await?;` call (encapsulated by harness)
+
+### File: `tools/echo-tool/src/echo.rs`
+
+No changes. The `EchoTool` struct, `ServerHandler` impl, and unit tests remain as-is.
+
+## Dependencies
+- Blocked by: "Create `crates/mcp-tool-harness` crate"
+- Blocking: None
+
+## Risks & Edge Cases
+
+1. **Harness API mismatch:** The `serve_stdio_tool` function signature and return type must match what `main.rs` expects (`Result<(), Box<dyn std::error::Error>>`). If the harness returns a different error type, the `main.rs` return type or error conversion may need adjustment. Mitigation: confirm the harness API once the harness crate spec is finalized.
+
+2. **Tracing dependency still needed transitively:** Even after removing `tracing` and `tracing-subscriber` from `Cargo.toml`, the `mcp-tool-harness` crate brings them in transitively. If any code in `echo.rs` or tests uses `tracing` macros (e.g., added in a future change), the build will still succeed via transitive deps but this is fragile. Mitigation: grep for `tracing::` in the crate before removing the direct dependency; if found, keep `tracing` as a direct dep.
+
+3. **`rmcp::ServiceExt` no longer imported:** The current `main.rs` imports `rmcp::ServiceExt` for the `.serve()` method. After migration, this import is removed. If `echo.rs` also needed `ServiceExt` (it currently does not), the build would break. Mitigation: confirm `echo.rs` does not use `ServiceExt`.
+
+4. **Behavior parity:** The harness must configure tracing identically to the current setup (stderr writer, env filter, ANSI disabled) to maintain the same logging behavior. Differences (e.g., default log level, ANSI colors) would be visible to operators. Mitigation: this is the harness crate's responsibility; verify during integration testing.
+
+## Verification
+
+1. **Compilation:** `cargo check -p echo-tool` succeeds with no errors.
+2. **Lint:** `cargo clippy -p echo-tool -- -D warnings` produces no warnings.
+3. **Unit tests:** `cargo test -p echo-tool --lib` passes all existing tests in `echo.rs`.
+4. **Integration tests:** `cargo test -p echo-tool --test echo_server_test` passes all existing tests.
+5. **Line count:** `wc -l tools/echo-tool/src/main.rs` is under 10 lines.
+6. **No unused deps:** `tracing` and `tracing-subscriber` do not appear in `tools/echo-tool/Cargo.toml` `[dependencies]` (assuming no tracing usage in `echo.rs`).
+7. **Workspace tests:** `cargo test` across the full workspace passes with no regressions.

--- a/.claude/specs/issue-56/migrate-read-file-integration-tests.md
+++ b/.claude/specs/issue-56/migrate-read-file-integration-tests.md
@@ -1,0 +1,107 @@
+# Spec: Migrate read-file integration tests
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+
+Replace the hand-rolled `spawn_read_file_client` helper in the read-file integration tests with the shared `spawn_mcp_client!` macro from `mcp-test-utils`, and consolidate the three `tools_list_*` tests into a single test that calls `assert_single_tool`. Keep the tool-specific call tests (`tools_call_read_file_returns_content` and `tools_call_read_file_returns_error_for_missing_file`) as-is, only updating them to use the macro for client creation.
+
+## Current State
+
+- **`tools/read-file/tests/read_file_server_test.rs`** contains 5 integration tests with a local `spawn_read_file_client()` async function that duplicates the same spawn-and-connect boilerplate found in echo-tool, write-file, and validate-skill.
+- Three of those tests (`tools_list_returns_read_file_tool`, `tools_list_read_file_has_correct_description`, `tools_list_read_file_has_path_parameter`) each independently spawn a client, call `list_tools`, and assert one property. This pattern is identical across all 4 tool crates.
+- **`crates/mcp-test-utils`** will provide:
+  - `spawn_mcp_client!` macro: accepts a binary path expression and returns `RunningService<RoleClient, ()>`.
+  - `assert_single_tool` async function: takes a client reference, expected tool name, description substring, and list of expected parameter names; asserts all of these in one call.
+- **`tools/read-file/Cargo.toml`** currently has `rmcp` (client, transport-child-process), `tokio`, and `serde_json` as dev-dependencies. It does not yet depend on `mcp-test-utils`.
+
+## Requirements
+
+1. **Add `mcp-test-utils` dev-dependency** to `tools/read-file/Cargo.toml`:
+   ```toml
+   [dev-dependencies]
+   mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+   ```
+   Keep existing dev-dependencies (`tokio`, `rmcp`, `serde_json`) since the call tests still use `CallToolRequestParams` and `serde_json::json!`.
+
+2. **Remove `spawn_read_file_client` function** from `read_file_server_test.rs`. Replace all usages with `mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_read-file"))`.
+
+3. **Remove the three `tools_list_*` tests:**
+   - `tools_list_returns_read_file_tool`
+   - `tools_list_read_file_has_correct_description`
+   - `tools_list_read_file_has_path_parameter`
+
+4. **Add a single consolidated list test** that replaces the three removed tests:
+   ```rust
+   #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+   async fn tools_list_returns_read_file_tool() {
+       let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_read-file"));
+       mcp_test_utils::assert_single_tool(
+           &client,
+           "read_file",
+           "Read the contents of a file",
+           &["path"],
+       )
+       .await;
+       client.cancel().await.expect("failed to cancel client");
+   }
+   ```
+
+5. **Update `tools_call_read_file_returns_content`** to use the macro for client creation instead of `spawn_read_file_client().await`. The rest of the test body (temp file creation, `CallToolRequestParams`, assertions, cleanup) remains unchanged.
+
+6. **Update `tools_call_read_file_returns_error_for_missing_file`** to use the macro for client creation. The rest of the test body remains unchanged.
+
+7. **Remove unused imports** that were only needed by the deleted spawn helper or removed list tests. After migration, the imports should be:
+   ```rust
+   use rmcp::model::CallToolRequestParams;
+   ```
+   The `RunningService`, `TokioChildProcess`, `RoleClient`, `ServiceExt`, and `tokio::process::Command` imports should be removed since the macro handles those internally.
+
+## Implementation Details
+
+### File to modify: `tools/read-file/tests/read_file_server_test.rs`
+
+The file should go from 5 tests + 1 helper function down to 3 tests + 0 helper functions:
+
+| Before | After |
+|--------|-------|
+| `spawn_read_file_client()` helper | Removed (replaced by `spawn_mcp_client!` macro) |
+| `tools_list_returns_read_file_tool` | Consolidated into single test using `assert_single_tool` |
+| `tools_list_read_file_has_correct_description` | Removed (covered by `assert_single_tool`) |
+| `tools_list_read_file_has_path_parameter` | Removed (covered by `assert_single_tool`) |
+| `tools_call_read_file_returns_content` | Kept, updated to use macro |
+| `tools_call_read_file_returns_error_for_missing_file` | Kept, updated to use macro |
+
+### File to modify: `tools/read-file/Cargo.toml`
+
+Add `mcp-test-utils` path dependency under `[dev-dependencies]`. Do not remove existing dev-dependencies that are still used by the call tests.
+
+### No other files created or modified
+
+This task only modifies the two files listed above.
+
+## Dependencies
+
+- **Blocked by:**
+  - "Add `assert_single_tool` helper to `mcp-test-utils`" (Group 2, issue #56) -- the `assert_single_tool` function must exist.
+  - "Create `crates/mcp-test-utils` crate with `spawn_mcp_client!` macro" (Group 1, issue #56) -- the macro must exist.
+- **Blocking:**
+  - "Run verification suite" (Group 5, issue #56)
+
+## Risks & Edge Cases
+
+1. **Description substring sensitivity:** The `assert_single_tool` call checks that the tool description contains `"Read the contents of a file"`. If the tool's description is changed, this test will fail. This matches the current assertion in the existing test.
+
+2. **Macro re-export visibility:** The `spawn_mcp_client!` macro must be exported from `mcp_test_utils` via `#[macro_export]`. The calling test file uses the fully qualified `mcp_test_utils::spawn_mcp_client!` path.
+
+3. **Import cleanup:** If any removed import is still needed by the remaining call tests, the build will catch it immediately. The `CallToolRequestParams` import must be kept for the two remaining call tests.
+
+4. **Temp file cleanup in call test:** The `tools_call_read_file_returns_content` test creates a temp file but does not clean it up. This matches the current behavior and is acceptable for integration tests.
+
+## Verification
+
+1. `cargo test -p read-file` compiles and all 3 integration tests pass.
+2. `cargo clippy -p read-file --tests` reports no warnings.
+3. No `spawn_read_file_client` function remains in the codebase.
+4. The `tools_list_returns_read_file_tool` test validates name, description, and parameters in a single test via `assert_single_tool`.
+5. The two `tools_call_*` tests are functionally unchanged (same assertions, same temp file behavior).

--- a/.claude/specs/issue-56/migrate-read-file-main-rs-to-use-serve-stdio-tool.md
+++ b/.claude/specs/issue-56/migrate-read-file-main-rs-to-use-serve-stdio-tool.md
@@ -1,0 +1,76 @@
+# Spec: Migrate read-file main.rs to use `serve_stdio_tool`
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+Replace the boilerplate in `tools/read-file/src/main.rs` with a call to `mcp_tool_harness::serve_stdio_tool`, and update `tools/read-file/Cargo.toml` to depend on the harness crate while removing now-unnecessary direct dependencies.
+
+## Current State
+- `tools/read-file/src/main.rs` contains 24 lines of boilerplate: tracing initialisation, stdio transport setup, and service waiting. This is identical to every other tool entrypoint (`echo-tool`, `write-file`, `validate-skill`).
+- The `crates/mcp-tool-harness` crate (created by a separate task) exposes `serve_stdio_tool<T: ServerHandler>(tool: T, tool_name: &str)` that encapsulates all of this boilerplate.
+- `tools/read-file/src/read_file.rs` does not import `tracing` or `tracing-subscriber` directly, so those dependencies are only used by `main.rs` today.
+
+## Requirements
+1. Replace the body of `tools/read-file/src/main.rs` to call `mcp_tool_harness::serve_stdio_tool(ReadFileTool::new(), "read-file").await`.
+2. Add `mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }` to `[dependencies]` in `tools/read-file/Cargo.toml`.
+3. Remove the following direct dependencies from `tools/read-file/Cargo.toml` since they are no longer used by the crate itself (they are pulled transitively through the harness):
+   - `tracing`
+   - `tracing-subscriber`
+   - `rmcp` from `[dependencies]` (the harness re-exports the serve functionality; `rmcp` remains in `[dev-dependencies]` for integration tests).
+4. Keep `tokio` in `[dependencies]` (needed for the `#[tokio::main]` attribute).
+5. Keep `serde` and `serde_json` in `[dependencies]` (used by `read_file.rs`).
+6. The resulting `main.rs` must be under 10 lines (excluding blank lines and comments), matching the post-migration echo-tool pattern.
+7. No new external dependencies are introduced.
+
+## Implementation Details
+
+### File: `tools/read-file/src/main.rs`
+
+```rust
+mod read_file;
+use read_file::ReadFileTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(ReadFileTool::new(), "read-file").await
+}
+```
+
+### File: `tools/read-file/Cargo.toml`
+
+Changes to `[dependencies]`:
+- **Add:** `mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }`
+- **Remove:** `tracing`, `tracing-subscriber`, `rmcp` (from `[dependencies]` only)
+- **Keep:** `tokio`, `serde`, `serde_json`
+
+The `[dev-dependencies]` section remains unchanged (`tokio` with `rt-multi-thread`, `rmcp` with client features, `serde_json`).
+
+### Key decisions
+- **`rmcp` removed from `[dependencies]`:** The `ReadFileTool` struct in `read_file.rs` imports `rmcp` types (`ServerHandler`, `tool`, `schemars`, etc.) via `use rmcp::...`. However, `rmcp` is a dependency of `mcp-tool-harness`, and Cargo makes transitive dependencies available when they are re-exported. If `mcp-tool-harness` does not re-export `rmcp` publicly, then `rmcp` must be retained in `[dependencies]`. Verify at implementation time; if `read_file.rs` fails to compile without a direct `rmcp` dependency, keep it.
+- **`flavor = "current_thread"`:** Retained to match the existing behaviour and the harness function's expectations.
+- **No `use` import for harness:** The function is called with its fully-qualified path `mcp_tool_harness::serve_stdio_tool` to keep the file minimal and make the dependency obvious.
+
+## Dependencies
+- **Blocked by:** "Create `crates/mcp-tool-harness` crate with `serve_stdio_tool` function"
+- **Blocking:** "Run verification suite"
+
+## Risks & Edge Cases
+
+1. **Transitive `rmcp` availability:** If `mcp-tool-harness` does not re-export `rmcp` types publicly, the `read_file.rs` module will fail to compile after removing `rmcp` from direct dependencies. In that case, `rmcp` must remain in `[dependencies]`. Check with `cargo check -p read-file` after the change.
+
+2. **Tracing still works:** The harness initialises tracing internally. After migration, `tools/read-file` no longer controls tracing configuration directly. This is the intended design -- all tools share identical tracing setup through the harness.
+
+3. **Behavioural equivalence:** The harness function must produce identical runtime behaviour: tracing to stderr with ANSI disabled, `EnvFilter` from environment, info-level startup log `"Starting read-file MCP server"`, and `.waiting().await` for graceful shutdown. Any divergence is a bug in the harness, not in this migration.
+
+4. **Integration tests unaffected:** The integration tests in `tools/read-file/tests/` spawn the binary as a child process. They do not depend on the internal structure of `main.rs`, so they should continue to pass without modification.
+
+## Verification
+
+1. **Compilation:** `cargo check -p read-file` succeeds.
+2. **Lint:** `cargo clippy -p read-file` produces no warnings.
+3. **Line count:** `wc -l tools/read-file/src/main.rs` is under 10 lines.
+4. **Unit tests:** `cargo test -p read-file` passes.
+5. **Workspace tests:** `cargo test` across the full workspace still passes.
+6. **Server starts:** `cargo run -p read-file` logs "Starting read-file MCP server" to stderr and waits for input.
+7. **No direct tracing imports:** `grep -r 'tracing' tools/read-file/src/main.rs` returns no matches.
+8. **Dependency removed:** `tracing` and `tracing-subscriber` do not appear in `tools/read-file/Cargo.toml` `[dependencies]`.

--- a/.claude/specs/issue-56/migrate-skill-loader-tests-to-use-shared-fixture.md
+++ b/.claude/specs/issue-56/migrate-skill-loader-tests-to-use-shared-fixture.md
@@ -1,0 +1,74 @@
+# Spec: Migrate skill-loader tests to use shared fixture
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+
+Replace the local `valid_frontmatter()` helper in the `skill-loader` test module with the shared `mcp_test_utils::valid_skill_content()` function to eliminate a duplicated skill fixture. Update the one assertion that depends on the old fixture's `output.format: markdown` value, since the shared fixture uses `json`.
+
+## Current State
+
+- **`crates/skill-loader/src/lib.rs`** (lines 96-121) defines a `valid_frontmatter()` function inside `#[cfg(test)] mod tests`. It returns a YAML-frontmatter string with `output.format: markdown`.
+- Two tests call `valid_frontmatter()`:
+  - `parse_content_valid_returns_expected_manifest` (line 124) — parses the fixture and asserts field values, including `assert_eq!(manifest.output.format, "markdown")` on line 135.
+  - `parse_content_body_is_trimmed` (line 171) — replaces the preamble body text and re-parses. Does not assert on `output.format`.
+- **`mcp_test_utils::valid_skill_content()`** (not yet implemented; created by the predecessor task "Add shared skill fixture") returns an identical fixture except `output.format: json` instead of `markdown`. All other fields (`name`, `version`, `description`, `model`, `tools`, `constraints`, `output.schema`, preamble body) are the same.
+- **`crates/skill-loader/Cargo.toml`** currently has no `mcp-test-utils` dependency.
+
+## Requirements
+
+- Remove the `valid_frontmatter()` function from `crates/skill-loader/src/lib.rs`.
+- Replace all calls to `valid_frontmatter()` with `mcp_test_utils::valid_skill_content()`.
+- Update the assertion on line 135 from `assert_eq!(manifest.output.format, "markdown")` to `assert_eq!(manifest.output.format, "json")`.
+- Add `mcp-test-utils` as a dev-dependency in `crates/skill-loader/Cargo.toml`.
+- All existing tests in `skill-loader` must continue to pass.
+- No other test logic or assertions should change beyond the format field.
+
+## Implementation Details
+
+### Files to modify
+
+1. **`crates/skill-loader/Cargo.toml`**
+   - Add under `[dev-dependencies]`:
+     ```toml
+     mcp-test-utils = { path = "../mcp-test-utils" }
+     ```
+
+2. **`crates/skill-loader/src/lib.rs`**
+   - In the `#[cfg(test)] mod tests` block, remove the entire `valid_frontmatter()` function (lines 96-121).
+   - At the top of the test module, add `use mcp_test_utils::valid_skill_content;` (dev-dependencies are available in `#[cfg(test)]` modules).
+   - In `parse_content_valid_returns_expected_manifest`:
+     - Change `let content = valid_frontmatter();` to `let content = valid_skill_content();`.
+     - Change `assert_eq!(manifest.output.format, "markdown");` to `assert_eq!(manifest.output.format, "json");`.
+   - In `parse_content_body_is_trimmed`:
+     - Change `let content = valid_frontmatter().replace(...)` to `let content = valid_skill_content().replace(...)`.
+
+### Assertions that do NOT change
+
+- `assert_eq!(manifest.name, "test-skill")` — same in both fixtures.
+- `assert_eq!(manifest.version, "1.0.0")` — same.
+- `assert_eq!(manifest.description, "A test skill")` — same.
+- `assert_eq!(manifest.model.provider, "openai")` — same.
+- `assert_eq!(manifest.model.name, "gpt-4")` — same.
+- `assert_eq!(manifest.tools, vec!["read_file", "write_file"])` — same.
+- `assert_eq!(manifest.preamble, "This is the preamble body.")` — same.
+- The three error-path tests (`parse_content_missing_opening_delimiter_returns_parse_error`, `parse_content_missing_closing_delimiter_returns_parse_error`, `parse_content_invalid_yaml_fields_returns_parse_error`) do not use the fixture at all and are unchanged.
+
+## Dependencies
+
+- **Blocked by:** "Add shared skill fixture constants to `mcp-test-utils`" — `valid_skill_content()` must exist before this task can be implemented.
+- **Blocking:** "Run verification suite"
+
+## Risks & Edge Cases
+
+- **Format value mismatch:** The only semantic difference between the old fixture (`markdown`) and the shared fixture (`json`) is the `output.format` field. If any downstream logic in `skill-loader` validates or branches on the format value during parsing, the change from `markdown` to `json` could surface unexpected behavior. However, `parse_content` does not validate format values — it just stores the string. The `validate` function checks against allowed formats but is not called in the unit tests that use this fixture.
+- **Import path:** `mcp_test_utils` (with underscore) is the Rust crate name derived from `mcp-test-utils` (with hyphen) in `Cargo.toml`. The `use` statement must use the underscore form.
+- **No new external dependencies:** `mcp-test-utils` is a workspace-local crate with `publish = false`.
+
+## Verification
+
+1. `cargo check -p skill-loader` passes with no errors.
+2. `cargo test -p skill-loader` passes — all 5 tests in the `tests` module and all integration tests continue to pass.
+3. `cargo clippy -p skill-loader` produces no warnings.
+4. Confirm `valid_frontmatter` no longer appears anywhere in `crates/skill-loader/src/lib.rs`.
+5. Confirm `mcp-test-utils` appears in `[dev-dependencies]` in `crates/skill-loader/Cargo.toml`.

--- a/.claude/specs/issue-56/migrate-validate-skill-integration-tests.md
+++ b/.claude/specs/issue-56/migrate-validate-skill-integration-tests.md
@@ -1,0 +1,147 @@
+# Spec: Migrate validate-skill integration tests
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+
+Replace duplicated test helpers and fixtures in the validate-skill integration and unit tests with shared utilities from `mcp-test-utils`. Specifically: (1) replace the local `spawn_validate_skill_client()` function with the `spawn_mcp_client!` macro, (2) consolidate the three `tools_list_*` integration tests into a single test using `assert_single_tool`, (3) replace both `valid_skill_content()` (integration tests) and `valid_content()` (unit tests) with `mcp_test_utils::valid_skill_content()`, and (4) add `mcp-test-utils` as a dev-dependency.
+
+## Current State
+
+### Integration tests (`tools/validate-skill/tests/validate_skill_server_test.rs`)
+
+- Defines a local `spawn_validate_skill_client()` async function that creates a `TokioChildProcess` from `env!("CARGO_BIN_EXE_validate-skill")` and connects an MCP client. This is identical in structure to helpers in the other 3 tool test files.
+- Defines a local `valid_skill_content()` function returning a canonical valid skill YAML frontmatter string. This is identical to the fixture that will live in `mcp-test-utils`.
+- Contains three separate `tools_list_*` tests that each spawn a client, call `list_tools`, and assert on a single aspect:
+  - `tools_list_returns_validate_skill_tool` — asserts exactly 1 tool named `"validate_skill"`
+  - `tools_list_has_correct_description` — asserts the description contains `"Validate"`
+  - `tools_list_has_content_parameter` — asserts `input_schema.properties` contains `"content"`
+- Contains three tool-call tests that exercise the actual validation logic:
+  - `tools_call_with_valid_skill_returns_valid_true`
+  - `tools_call_with_missing_frontmatter_returns_valid_false`
+  - `tools_call_with_invalid_yaml_returns_valid_false`
+
+### Unit tests (`tools/validate-skill/src/validate_skill.rs`)
+
+- Contains a `valid_content()` function inside `#[cfg(test)] mod tests` that returns the same canonical skill fixture as the integration test's `valid_skill_content()`.
+- Used by the `valid_content_returns_success` unit test.
+
+### Cargo.toml (`tools/validate-skill/Cargo.toml`)
+
+- Dev-dependencies currently include `tokio`, `rmcp`, and `serde_json`. Does not include `mcp-test-utils`.
+
+## Requirements
+
+### 1. Add `mcp-test-utils` dev-dependency
+
+Add the following to `tools/validate-skill/Cargo.toml` under `[dev-dependencies]`:
+
+```toml
+mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+```
+
+### 2. Replace `spawn_validate_skill_client()` with macro
+
+In `tools/validate-skill/tests/validate_skill_server_test.rs`:
+
+- Remove the `spawn_validate_skill_client()` function entirely.
+- Remove the direct imports of `rmcp::transport::TokioChildProcess` and `tokio::process::Command` (no longer needed).
+- In every test that previously called `spawn_validate_skill_client().await`, replace with:
+  ```rust
+  let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_validate-skill"));
+  ```
+
+### 3. Consolidate `tools_list_*` tests with `assert_single_tool`
+
+- Remove all three tests: `tools_list_returns_validate_skill_tool`, `tools_list_has_correct_description`, `tools_list_has_content_parameter`.
+- Replace with a single test:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_validates_single_tool() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_validate-skill"));
+
+    mcp_test_utils::assert_single_tool(
+        &client,
+        "validate_skill",
+        "Validate",
+        &["content"],
+    )
+    .await;
+
+    client.cancel().await.expect("failed to cancel client");
+}
+```
+
+This single test covers all three prior assertions: tool count is 1, name matches `"validate_skill"`, description contains `"Validate"`, and `input_schema.properties` contains `"content"`.
+
+### 4. Replace `valid_skill_content()` in integration tests
+
+- Remove the local `valid_skill_content()` function from `validate_skill_server_test.rs`.
+- In `tools_call_with_valid_skill_returns_valid_true`, replace `valid_skill_content()` with `mcp_test_utils::valid_skill_content()`.
+
+### 5. Replace `valid_content()` in unit tests
+
+In `tools/validate-skill/src/validate_skill.rs`:
+
+- Remove the `valid_content()` function from `mod tests`.
+- In `valid_content_returns_success`, replace `valid_content()` with `mcp_test_utils::valid_skill_content()`.
+- The `call_validate` helper and all other unit tests remain unchanged.
+- Since `mcp-test-utils` is a dev-dependency, it is available in `#[cfg(test)]` unit test modules.
+
+### 6. Keep tool-call integration tests intact
+
+The following three tests stay in the integration test file with only the spawn-helper change (macro replaces function call). Their assertions and logic remain unchanged:
+
+- `tools_call_with_valid_skill_returns_valid_true`
+- `tools_call_with_missing_frontmatter_returns_valid_false`
+- `tools_call_with_invalid_yaml_returns_valid_false`
+
+## Implementation Details
+
+### Files to modify
+
+- `tools/validate-skill/Cargo.toml` — add `mcp-test-utils` dev-dependency
+- `tools/validate-skill/tests/validate_skill_server_test.rs` — replace spawn helper, consolidate list tests, replace fixture
+- `tools/validate-skill/src/validate_skill.rs` — replace `valid_content()` in unit tests with shared fixture
+
+### No new files to create
+
+### Imports after migration (integration test file)
+
+```rust
+use rmcp::{
+    model::CallToolRequestParams,
+    service::RunningService,
+    RoleClient, ServiceExt,
+};
+```
+
+Note: `TokioChildProcess` and `tokio::process::Command` are no longer imported directly — the macro handles them internally.
+
+### Expected test count change
+
+- Before: 6 integration tests + 5 unit tests = 11 total
+- After: 4 integration tests + 5 unit tests = 9 total
+- The 3 list tests collapse into 1; the 3 call tests remain.
+
+## Dependencies
+
+- **Blocked by:** "Add `assert_single_tool` helper" (Group 2), "Add shared skill fixture" (Group 2) — both must exist in `mcp-test-utils` before this migration.
+- **Blocking:** "Run verification suite" (Group 5)
+
+## Risks & Edge Cases
+
+- **Fixture content mismatch:** The shared `mcp_test_utils::valid_skill_content()` must return a string identical to the current local `valid_skill_content()` and `valid_content()`. If the shared fixture differs (e.g., different field values), unit test assertions like `assert_eq!(result["manifest"]["name"], "test-skill")` will fail. The shared fixture is defined as the canonical version; local assertions must match it.
+- **`output.format` discrepancy:** The task notes mention that skill-loader's fixture uses `format: markdown` while validate-skill uses `format: json`. The shared fixture uses `json`, which matches the current validate-skill fixture, so no assertion changes are needed here.
+- **Macro import path:** The `spawn_mcp_client!` macro is invoked as `mcp_test_utils::spawn_mcp_client!()`. Ensure the macro is `#[macro_export]`ed in the `mcp-test-utils` crate so it is available at the crate root path.
+- **Dev-dependency scope:** `mcp-test-utils` as a dev-dependency is available in both integration tests and `#[cfg(test)]` unit test modules, so using it in `validate_skill.rs` unit tests is valid.
+
+## Verification
+
+- `cargo test -p validate-skill` passes (all 9 remaining tests pass).
+- `cargo test -p validate-skill -- tools_list_validates_single_tool` passes.
+- `cargo test -p validate-skill -- valid_content_returns_success` passes (unit test using shared fixture).
+- `cargo clippy -p validate-skill` reports no new warnings.
+- No local `spawn_validate_skill_client` function exists in the test file.
+- No local `valid_skill_content` or `valid_content` fixture function exists in any validate-skill source file.

--- a/.claude/specs/issue-56/migrate-validate-skill-main-rs-to-use-serve-stdio-tool.md
+++ b/.claude/specs/issue-56/migrate-validate-skill-main-rs-to-use-serve-stdio-tool.md
@@ -1,0 +1,89 @@
+# Spec: Migrate validate-skill main.rs to use `serve_stdio_tool`
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+Replace the boilerplate in `tools/validate-skill/src/main.rs` with a single call to `mcp_tool_harness::serve_stdio_tool`, eliminating duplicated tracing setup and stdio-serving logic that is identical across all four MCP tool binaries.
+
+## Current State
+- `tools/validate-skill/src/main.rs` contains 24 lines of boilerplate: tracing subscriber initialization, info log, `tool.serve(rmcp::transport::stdio())`, and `service.waiting().await`.
+- This is identical in structure to `tools/echo-tool/src/main.rs`, `tools/read-file/src/main.rs`, and `tools/write-file/src/main.rs`.
+- `tools/validate-skill/Cargo.toml` directly depends on `rmcp`, `tokio`, `tracing`, and `tracing-subscriber` to support this boilerplate.
+- The `crates/mcp-tool-harness` crate does not yet exist. This task is blocked until it lands.
+
+## Requirements
+- Replace the body of `main.rs` with a call to `mcp_tool_harness::serve_stdio_tool(ValidateSkillTool::new(), "validate-skill").await`.
+- Keep the `mod validate_skill;` declaration and `use validate_skill::ValidateSkillTool;` import.
+- Add `mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }` to `[dependencies]` in `tools/validate-skill/Cargo.toml`.
+- Remove direct dependencies on `tracing`, `tracing-subscriber` from `Cargo.toml` if they are no longer used in `validate_skill.rs` or any other source file in the crate.
+- Retain `rmcp` in `[dependencies]` because `validate_skill.rs` uses rmcp macros and types directly.
+- Retain `tokio` in `[dependencies]` because `#[tokio::main]` is used in `main.rs`.
+- File must stay under 50 lines.
+
+## Implementation Details
+
+### File: `tools/validate-skill/src/main.rs`
+
+```rust
+mod validate_skill;
+use validate_skill::ValidateSkillTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(ValidateSkillTool::new(), "validate-skill").await
+}
+```
+
+### File: `tools/validate-skill/Cargo.toml`
+
+Add to `[dependencies]`:
+```toml
+mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }
+```
+
+Remove from `[dependencies]` (only if no other source file in the crate uses them):
+- `tracing`
+- `tracing-subscriber`
+
+Keep unchanged:
+- `rmcp` (used in `validate_skill.rs` for `#[tool]`, `ServerHandler`, etc.)
+- `tokio` (used for `#[tokio::main]`)
+- `serde`, `serde_json` (used in `validate_skill.rs`)
+- `skill-loader`, `agent-sdk` (used in `validate_skill.rs`)
+
+Before removing `tracing`, verify whether `validate_skill.rs` contains any `tracing::` calls. If it does, keep `tracing` as a dependency. `tracing-subscriber` is only used in `main.rs` boilerplate, so it can be removed.
+
+### Key decisions
+- **`flavor = "current_thread"`**: Retained from the current implementation. A single-threaded tokio runtime is sufficient for a stdio-based MCP server.
+- **`Box<dyn std::error::Error>`**: Kept as the return type, consistent with echo-tool pattern and avoiding extra dependencies.
+- **No `use` imports for rmcp or tracing in main.rs**: The harness handles all of that internally.
+
+### Line budget
+- Module declaration + use: 2 lines
+- `main` function: 4 lines
+- Blank line: 1 line
+- **Total: ~7 lines** (well under the 50-line limit)
+
+## Dependencies
+- Blocked by: "Create `crates/mcp-tool-harness` crate with `serve_stdio_tool` function"
+- Blocking: "Run verification suite"
+
+## Risks & Edge Cases
+
+1. **Harness crate not yet available:** This task cannot be implemented until `crates/mcp-tool-harness` is created and added to the workspace. Attempting to build before that will fail.
+
+2. **`tracing` usage in `validate_skill.rs`:** Before removing the `tracing` dependency, check whether `validate_skill.rs` uses `tracing::info!`, `tracing::error!`, or similar macros. If it does, `tracing` must remain in `Cargo.toml`. Only `tracing-subscriber` is guaranteed removable since it is only used in the current `main.rs` boilerplate.
+
+3. **Behavioral equivalence:** The harness function must produce identical runtime behavior: tracing to stderr with ANSI disabled, `EnvFilter` defaulting to `DEBUG`, and the same `"Starting validate-skill MCP server"` log message format. Any deviation in the harness would affect all migrated tools.
+
+4. **Dev-dependencies unchanged:** The `[dev-dependencies]` section (used for integration tests) is not modified by this task. Test migration is handled by a separate task.
+
+## Verification
+
+1. **File exists and is minimal:** `tools/validate-skill/src/main.rs` is under 10 lines.
+2. **Compilation:** `cargo check -p validate-skill` succeeds (once harness crate is available).
+3. **Lint:** `cargo clippy -p validate-skill` produces no warnings.
+4. **Server starts:** `cargo run -p validate-skill` logs "Starting validate-skill MCP server" to stderr and waits for MCP client input.
+5. **Integration tests pass:** `cargo test -p validate-skill` passes with no regressions.
+6. **Workspace tests:** `cargo test` across the full workspace still passes.
+7. **No removed dep regressions:** Grep the crate source for any `tracing_subscriber::` or `tracing::` usage to confirm dependency removal is safe.

--- a/.claude/specs/issue-56/migrate-write-file-integration-tests.md
+++ b/.claude/specs/issue-56/migrate-write-file-integration-tests.md
@@ -1,0 +1,128 @@
+# Spec: Migrate write-file integration tests
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+
+Replace duplicated test boilerplate in the `write-file` crate with shared utilities from `mcp-test-utils`. This covers three changes: (1) replace the hand-rolled `spawn_write_file_client()` helper with the `spawn_mcp_client!` macro, (2) consolidate the three `tools_list_*` integration tests into a single test using `assert_single_tool`, and (3) replace the local `unique_temp_dir` function in the unit tests with `mcp_test_utils::unique_temp_dir`. Add `mcp-test-utils` as a dev-dependency.
+
+## Current State
+
+- **`tools/write-file/tests/write_file_server_test.rs`** contains:
+  - A private `spawn_write_file_client()` async function (lines 10-17) that spawns the binary via `TokioChildProcess` and returns `RunningService<RoleClient, ()>`. This is identical in structure to the helpers in the other 3 tool crates.
+  - Three `tools_list_*` tests (`tools_list_returns_write_file_tool`, `tools_list_write_file_has_correct_description`, `tools_list_write_file_has_path_and_content_parameters`) that each independently spawn a client, call `list_tools`, assert one property, and tear down. These can be collapsed into one test.
+  - One tool-specific call test (`tools_call_write_file_creates_file`) that must be preserved as-is (aside from replacing the spawn helper).
+
+- **`tools/write-file/src/write_file.rs`** contains a local `unique_temp_dir(test_name: &str) -> PathBuf` function (lines 77-85) inside `#[cfg(test)] mod tests`. It creates a directory under `env::temp_dir().join("write_file_tests")`. This is the same function being extracted to `mcp-test-utils` (with the prefix changed to `spore_tests`).
+
+- **`tools/write-file/Cargo.toml`** has dev-dependencies for `tokio`, `rmcp` (client features), and `serde_json`, but does not yet reference `mcp-test-utils`.
+
+## Requirements
+
+### 1. Add `mcp-test-utils` dev-dependency
+
+Add the following to `tools/write-file/Cargo.toml` under `[dev-dependencies]`:
+
+```toml
+mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+```
+
+### 2. Replace `spawn_write_file_client()` with `spawn_mcp_client!` macro
+
+In `tools/write-file/tests/write_file_server_test.rs`:
+
+- Remove the `spawn_write_file_client()` function entirely (lines 9-17).
+- Remove the now-unnecessary imports: `transport::TokioChildProcess`, `ServiceExt`, `tokio::process::Command`. Keep `rmcp::{model::CallToolRequestParams, service::RunningService, RoleClient}` since they are still used by the call test.
+- At each call site, replace `spawn_write_file_client().await` with `mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_write-file"))`.
+
+### 3. Consolidate three `tools_list_*` tests into one
+
+Replace the three separate tests (`tools_list_returns_write_file_tool`, `tools_list_write_file_has_correct_description`, `tools_list_write_file_has_path_and_content_parameters`) with a single test:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_returns_write_file_tool() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_write-file"));
+
+    mcp_test_utils::assert_single_tool(
+        &client,
+        "write_file",
+        "Write content to a file",
+        &["path", "content"],
+    )
+    .await;
+
+    client.cancel().await.expect("failed to cancel client");
+}
+```
+
+This single test validates all three properties (tool name, description substring, parameter names) that were previously spread across three tests.
+
+### 4. Update the call test to use the macro
+
+The `tools_call_write_file_creates_file` test must be preserved with its existing logic, but replace the `spawn_write_file_client().await` call with `mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_write-file"))`.
+
+### 5. Replace local `unique_temp_dir` in unit tests
+
+In `tools/write-file/src/write_file.rs`, inside the `#[cfg(test)] mod tests` block:
+
+- Remove the local `unique_temp_dir` function (lines 77-85).
+- Remove `use std::env;` if it is no longer used after the removal.
+- Replace all calls to `unique_temp_dir("...")` with `mcp_test_utils::unique_temp_dir("...")`.
+
+The five unit tests that call `unique_temp_dir` are: `write_file_creates_file_with_content`, `write_file_creates_parent_directories`, `write_file_returns_byte_count`, `write_file_overwrites_existing`, `write_file_preserves_unicode`. The test `write_file_empty_path` does not use temp dirs and needs no change.
+
+Note: the shared `unique_temp_dir` uses the prefix `spore_tests` instead of `write_file_tests`. This is an intentional generalization and does not affect test behavior.
+
+## Implementation Details
+
+### File: `tools/write-file/Cargo.toml`
+
+Add under `[dev-dependencies]`:
+
+```toml
+mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+```
+
+### File: `tools/write-file/tests/write_file_server_test.rs`
+
+The final file should contain:
+- Imports for `rmcp::{model::CallToolRequestParams, service::RunningService, RoleClient}` (no `TokioChildProcess`, `ServiceExt`, or `tokio::process::Command`).
+- Two tests total: `tools_list_returns_write_file_tool` (consolidated) and `tools_call_write_file_creates_file` (preserved logic, updated spawn).
+- No `spawn_write_file_client` function.
+
+### File: `tools/write-file/src/write_file.rs`
+
+In the `#[cfg(test)] mod tests` block:
+- Remove the `unique_temp_dir` function definition.
+- Remove `use std::env;` (no longer needed; `std::fs` is still used).
+- All five temp-dir-using tests call `mcp_test_utils::unique_temp_dir(...)` instead.
+
+## Dependencies
+
+- **Blocked by:**
+  - "Add `assert_single_tool` helper" -- the `assert_single_tool` function must exist in `mcp-test-utils` before the consolidated list test can compile.
+  - "Add `unique_temp_dir` helper" -- the shared `unique_temp_dir` function must exist in `mcp-test-utils` before the unit tests can compile.
+- **Blocking:**
+  - "Run verification suite"
+
+## Risks & Edge Cases
+
+1. **Temp dir prefix change:** The shared helper uses `spore_tests` instead of `write_file_tests`. If any CI cleanup scripts or other tooling references the old prefix, they need updating. In practice this is unlikely since the old prefix was only used locally in this test module.
+
+2. **Import cleanup:** After removing `spawn_write_file_client`, ensure `TokioChildProcess`, `ServiceExt`, and `tokio::process::Command` are fully removed. The macro handles these internally.
+
+3. **`mcp-test-utils` as dev-dependency for unit tests:** In Rust, `dev-dependencies` are available to both integration tests (`tests/`) and unit tests (`#[cfg(test)]` in `src/`), so adding `mcp-test-utils` once in `[dev-dependencies]` covers both use cases.
+
+4. **Macro invocation syntax:** `spawn_mcp_client!` is a macro, not a function. Ensure the call uses `!` and passes the `env!()` expression directly (not as a variable), since `env!("CARGO_BIN_EXE_write-file")` must resolve at compile time in the calling crate.
+
+5. **Test name preservation:** The consolidated list test retains the name `tools_list_returns_write_file_tool` for continuity. The two removed test names (`tools_list_write_file_has_correct_description`, `tools_list_write_file_has_path_and_content_parameters`) are intentionally dropped since their assertions are covered by the consolidated test.
+
+## Verification
+
+1. `cargo test -p write-file` passes -- both integration tests and all six unit tests.
+2. `cargo clippy -p write-file --tests` reports no warnings.
+3. No `spawn_write_file_client` function exists in the codebase.
+4. No `unique_temp_dir` function exists in `tools/write-file/src/write_file.rs`.
+5. `tools/write-file/tests/write_file_server_test.rs` contains exactly 2 test functions.
+6. `tools/write-file/src/write_file.rs` unit test module references `mcp_test_utils::unique_temp_dir` (not a local definition).

--- a/.claude/specs/issue-56/migrate-write-file-main-rs-to-use-serve-stdio-tool.md
+++ b/.claude/specs/issue-56/migrate-write-file-main-rs-to-use-serve-stdio-tool.md
@@ -1,0 +1,76 @@
+# Spec: Migrate write-file main.rs to use `serve_stdio_tool`
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+Replace the hand-written boilerplate in `tools/write-file/src/main.rs` with a single call to `mcp_tool_harness::serve_stdio_tool`, matching the same migration pattern applied to echo-tool. This eliminates duplicated tracing setup and stdio-serving logic across tool entrypoints.
+
+## Current State
+- `tools/write-file/src/main.rs` contains 24 lines of boilerplate: tracing subscriber initialization, log statement, `.serve(rmcp::transport::stdio())`, and `.waiting().await`.
+- This is identical in structure to `tools/echo-tool/src/main.rs`, `tools/read-file/src/main.rs`, and `tools/validate-skill/src/main.rs`.
+- The `crates/mcp-tool-harness` crate (created in Group 1 of issue-56) will provide `serve_stdio_tool<T: ServerHandler>(tool: T, tool_name: &str)` that encapsulates all of this boilerplate.
+- `tools/write-file/src/write_file.rs` does not use `tracing` or `tracing-subscriber` directly, so those dependencies can be removed from `Cargo.toml`.
+
+## Requirements
+- Replace the body of `tools/write-file/src/main.rs` to delegate to `mcp_tool_harness::serve_stdio_tool`.
+- Add `mcp-tool-harness` as a dependency in `tools/write-file/Cargo.toml`.
+- Remove direct dependencies on `tracing`, `tracing-subscriber`, and `rmcp`'s `transport-io` feature from `tools/write-file/Cargo.toml` since they are no longer used directly. Keep `rmcp` with features `server` and `macros` (used by `write_file.rs`).
+- Remove the `tokio` `io-std` feature if it is no longer needed.
+- The resulting `main.rs` must be under 10 lines (excluding blank lines).
+
+## Implementation Details
+
+### File: `tools/write-file/src/main.rs`
+
+```rust
+mod write_file;
+use write_file::WriteFileTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(WriteFileTool::new(), "write-file").await
+}
+```
+
+### File: `tools/write-file/Cargo.toml`
+
+Changes to `[dependencies]`:
+- **Add:** `mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }`
+- **Remove:** `tracing = "0.1"`
+- **Remove:** `tracing-subscriber = { version = "0.3", features = ["env-filter"] }`
+- **Remove** `transport-io` from `rmcp` features (now handled by the harness)
+- **Keep:** `rmcp = { version = "1", features = ["server", "macros"] }` (used by `write_file.rs`)
+- **Keep:** `tokio = { version = "1", features = ["macros", "rt"] }` (needed for `#[tokio::main]`)
+- **Keep:** `serde`, `serde_json` (used by `write_file.rs`)
+
+The `[dev-dependencies]` section is unchanged.
+
+### Key decisions
+- **`flavor = "current_thread"` stays in main.rs:** The tokio runtime annotation must remain in the binary entrypoint. The harness function is `async` but not `#[tokio::main]` itself.
+- **Return type stays `Box<dyn std::error::Error>`:** Matches the harness function signature and avoids adding `anyhow`.
+- **Module declaration stays in main.rs:** `mod write_file;` must remain here since it declares the sibling module for the binary crate.
+
+## Dependencies
+- **Blocked by:** Create `crates/mcp-tool-harness` crate with `serve_stdio_tool` function (Group 1)
+- **Blocking:** Run verification suite (Group 5)
+
+## Risks & Edge Cases
+
+1. **Harness crate not yet available:** This task cannot be implemented until `crates/mcp-tool-harness` lands. The spec is written against the expected `serve_stdio_tool` signature from the task breakdown.
+
+2. **Removing `transport-io` from rmcp features:** The `transport-io` feature is only needed for `rmcp::transport::stdio()`, which moves into the harness. If `write_file.rs` uses any other rmcp transport APIs, this removal would break compilation. Confirmed: `write_file.rs` does not use transport APIs.
+
+3. **Tracing still works:** Even though `tracing` and `tracing-subscriber` are removed from this crate's direct dependencies, the harness initializes tracing before calling the tool. Any `tracing::info!()` calls in `write_file.rs` would still work via the transitive dependency -- but currently `write_file.rs` has zero tracing calls, so this is not a concern.
+
+4. **Dev-dependency on rmcp with `transport-child-process`:** The `[dev-dependencies]` section still pulls in rmcp with `client` and `transport-child-process` features for integration tests. This is unaffected by the main.rs migration.
+
+## Verification
+
+1. **File length:** `wc -l tools/write-file/src/main.rs` is under 10 lines.
+2. **Pattern match:** The file structurally mirrors the migrated echo-tool `main.rs`.
+3. **Compilation:** `cargo check -p write-file` succeeds.
+4. **Lint:** `cargo clippy -p write-file` produces no warnings.
+5. **Tests pass:** `cargo test -p write-file` passes (all existing unit and integration tests).
+6. **Server starts:** `cargo run -p write-file` logs "Starting write-file MCP server" to stderr and waits for input.
+7. **Workspace clean:** `cargo test` across the full workspace still passes.
+8. **No leftover imports:** `main.rs` does not import `rmcp::ServiceExt`, `tracing_subscriber`, or `tracing` directly.

--- a/.claude/specs/issue-56/run-verification-suite.md
+++ b/.claude/specs/issue-56/run-verification-suite.md
@@ -1,0 +1,131 @@
+# Spec: Run verification suite
+
+> From: .claude/tasks/issue-56.md
+
+## Objective
+Run the full build, test, lint, and type-check suite across the entire workspace and verify the five acceptance criteria for the shared-utilities extraction performed in issue-56: no duplicated spawn helpers, slim main.rs files, single-location temp dir helper, all tests passing, and clean clippy output.
+
+## Current State
+By the time this task runs, all preceding issue-56 tasks will have:
+1. Created `crates/mcp-tool-harness` with `serve_stdio_tool` function
+2. Created `crates/mcp-test-utils` with `spawn_mcp_client!` macro, `assert_single_tool` helper, `unique_temp_dir` helper, and `valid_skill_content` fixture
+3. Migrated all four tool `main.rs` files (`echo-tool`, `read-file`, `write-file`, `validate-skill`) to use `mcp_tool_harness::serve_stdio_tool`
+4. Migrated all four tool integration test files to use `spawn_mcp_client!` and `assert_single_tool` from `mcp-test-utils`
+5. Moved `unique_temp_dir` out of `write-file` into `mcp-test-utils`
+6. Consolidated skill fixture into `mcp_test_utils::valid_skill_content()` and updated `validate-skill` and `skill-loader` tests
+7. Added both new crates to the root `Cargo.toml` workspace members list
+
+The workspace members now include: `agent-sdk`, `skill-loader`, `tool-registry`, `agent-runtime`, `orchestrator`, `mcp-tool-harness`, `mcp-test-utils`, `echo-tool`, `read-file`, `write-file`, `validate-skill`.
+
+## Requirements
+1. `cargo build` (full workspace) exits with code 0
+2. `cargo test` (full workspace) exits with code 0 with all non-ignored tests passing
+3. `cargo clippy -- -D warnings` (full workspace) exits with code 0 with zero warnings
+4. `cargo check` (full workspace) exits with code 0
+5. No `spawn_*_client` helper function is defined in more than one file across the workspace
+6. No `main.rs` in `tools/*/src/main.rs` exceeds 5 lines excluding `use`/`mod` import lines
+7. `unique_temp_dir` is defined in exactly one place (`crates/mcp-test-utils/src/lib.rs`)
+8. No commented-out code or debug `println!` statements remain in any modified file
+
+## Implementation Details
+This task does not create or modify source files. It is a verification-only task. Run each step in order; if any step fails, diagnose the root cause and fix the relevant file before proceeding.
+
+### Step 1: Full workspace build
+```bash
+cargo build
+```
+Confirms all workspace members compile, including the two new crates (`mcp-tool-harness`, `mcp-test-utils`) and the migrated tools. Likely failure causes:
+- Missing dependency in `Cargo.toml` for a new or migrated crate
+- Import path errors after migration (e.g., `mcp_tool_harness::serve_stdio_tool` not found)
+- Macro export issues with `spawn_mcp_client!`
+
+### Step 2: Full workspace tests
+```bash
+cargo test
+```
+Runs all unit and integration tests across every workspace member. Tests marked `#[ignore]` are skipped and do not count as failures. Verify the test summary shows 0 failures. Likely failure causes:
+- `spawn_mcp_client!` macro not producing a valid client (transport or connection error)
+- `assert_single_tool` assertion mismatches after migration (wrong tool name, description, or parameter names)
+- `unique_temp_dir` path prefix change from `write_file_tests` to `spore_tests` causing test assumptions to break
+- `valid_skill_content()` fixture using `json` format where a test expected `markdown`
+
+### Step 3: Clippy lint check
+```bash
+cargo clippy -- -D warnings
+```
+The `-D warnings` flag promotes all warnings to errors. Verify clean exit with no output beyond "Finished". Likely failure causes:
+- Unused imports left behind after removing inlined helpers
+- Unused dependencies in `Cargo.toml` after moving `tracing`/`tracing-subscriber` to the harness crate
+- Dead code warnings for functions that were extracted but not fully removed from the original location
+
+### Step 4: Type check
+```bash
+cargo check
+```
+Full workspace type-check. This is faster than `cargo build` and catches type errors without linking. Serves as a final cross-crate consistency check.
+
+### Step 5: Structural acceptance checks
+Run the following verification checks from the workspace root:
+
+**5a. No duplicated `spawn_*_client` helpers:**
+Search the entire workspace for function definitions matching `fn spawn_*_client`. Each pattern (e.g., `spawn_echo_client`, `spawn_read_file_client`) must appear in zero files (fully replaced by the macro) or at most one file. If any `spawn_*_client` function definition appears in more than one file, the migration is incomplete.
+```bash
+grep -rn "fn spawn_.*_client" tools/ crates/
+```
+Expected: zero matches, or matches only within `mcp-test-utils` if a generic helper was kept.
+
+**5b. Slim `main.rs` files:**
+For each `tools/*/src/main.rs`, count the non-import lines (lines that do not start with `use ` or `mod `). Each must have at most 5 such lines.
+```bash
+for f in tools/*/src/main.rs; do
+  count=$(grep -cvE '^\s*(use |mod |//|$)' "$f")
+  echo "$f: $count non-import lines"
+  if [ "$count" -gt 5 ]; then
+    echo "FAIL: $f exceeds 5 non-import lines"
+  fi
+done
+```
+
+**5c. `unique_temp_dir` in exactly one place:**
+Search for the function definition across the workspace. It must appear in exactly one file: `crates/mcp-test-utils/src/lib.rs`.
+```bash
+grep -rn "fn unique_temp_dir" tools/ crates/
+```
+Expected: exactly one match in `crates/mcp-test-utils/src/lib.rs`.
+
+If any structural check fails, diagnose which migration task was incomplete and apply the minimal fix.
+
+### Files potentially touched (fixes only, if needed)
+- `tools/echo-tool/src/main.rs` -- leftover imports or boilerplate
+- `tools/read-file/src/main.rs` -- leftover imports or boilerplate
+- `tools/write-file/src/main.rs` -- leftover imports or boilerplate
+- `tools/validate-skill/src/main.rs` -- leftover imports or boilerplate
+- `tools/write-file/src/write_file.rs` -- leftover `unique_temp_dir` definition
+- `tools/validate-skill/src/validate_skill.rs` -- leftover fixture function
+- `tools/*/tests/*_server_test.rs` -- leftover `spawn_*_client` functions
+- `tools/*/Cargo.toml` -- unused dependency cleanup
+- `crates/skill-loader/src/lib.rs` -- fixture migration fix
+- `crates/mcp-test-utils/src/lib.rs` -- helper function fixes
+- `crates/mcp-tool-harness/src/lib.rs` -- `serve_stdio_tool` signature fixes
+
+## Dependencies
+- Blocked by: "Create `crates/mcp-tool-harness` crate", "Create `crates/mcp-test-utils` crate", "Add `assert_single_tool` helper", "Add `unique_temp_dir` helper", "Add shared skill fixture constants", "Migrate echo-tool main.rs", "Migrate read-file main.rs", "Migrate write-file main.rs", "Migrate validate-skill main.rs", "Migrate echo-tool integration tests", "Migrate read-file integration tests", "Migrate write-file integration tests", "Migrate validate-skill integration tests", "Migrate skill-loader tests to use shared fixture"
+- Blocking: None (this is the final task for issue-56)
+
+## Risks & Edge Cases
+- **Macro hygiene**: The `spawn_mcp_client!` macro must work correctly when invoked from different crate contexts. If the macro relies on items not re-exported or not in scope, tests will fail to compile. Fix by ensuring the macro uses fully qualified paths (e.g., `::rmcp::transport::TokioChildProcess`).
+- **Unused dependency warnings**: After moving `tracing` and `tracing-subscriber` from tool crates into `mcp-tool-harness`, clippy or cargo may warn about unused dependencies in the tool `Cargo.toml` files. Remove them if no other source file in that crate references them.
+- **Feature gate mismatches**: The `mcp-test-utils` crate needs `rmcp` with `client` and `transport-child-process` features. If these features are not correctly specified, integration tests will fail to compile.
+- **Skill fixture format divergence**: The canonical `valid_skill_content()` uses `format: json`. If any test in `skill-loader` was asserting `format: markdown`, that test must be updated to match the new canonical value.
+- **Cross-platform temp dir**: `unique_temp_dir` uses `std::env::temp_dir()`. On different platforms this resolves to different paths. Tests should not hardcode path separators or assume a specific temp directory structure.
+- **Edition 2024 lints**: The workspace uses `edition = "2024"`, which may surface new lints on the migrated code. Address each individually.
+
+## Verification (Pass/Fail Criteria)
+- **PASS**: `cargo build` exits with code 0
+- **PASS**: `cargo test` exits with code 0, summary shows 0 failures across all crates
+- **PASS**: `cargo clippy -- -D warnings` exits with code 0, no warning or error output
+- **PASS**: `cargo check` exits with code 0
+- **PASS**: `grep -rn "fn spawn_.*_client" tools/ crates/` returns zero matches or matches in at most one file
+- **PASS**: Every `tools/*/src/main.rs` has at most 5 non-import lines
+- **PASS**: `grep -rn "fn unique_temp_dir" tools/ crates/` returns exactly one match in `crates/mcp-test-utils/src/lib.rs`
+- **FAIL**: Any of the above checks does not meet its criterion

--- a/.claude/tasks/issue-50.md
+++ b/.claude/tasks/issue-50.md
@@ -1,0 +1,69 @@
+# Task Breakdown: implement register_agent MCP tool
+
+> Add a `register-agent` MCP tool binary that POSTs agent registration payloads to the orchestrator, following the established tool pattern (echo-tool / docker-push).
+
+## Group 1 — Scaffolding
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Create register-agent Cargo.toml** `[S]`
+      Create `tools/register-agent/Cargo.toml` following the docker-push pattern. Package name `register-agent`, edition 2024. Dependencies: `mcp-tool-harness` (path), `rmcp` (with transport-io, server, macros features), `tokio` (with macros, rt, io-std), `serde` (with derive), `serde_json`, and `reqwest` (with json feature) for HTTP POST to the orchestrator. Dev-dependencies: `mcp-test-utils` (path), `tokio` (with macros, rt, rt-multi-thread), `rmcp` (with client, transport-child-process), `serde_json`, and a lightweight mock server (prefer `axum` or bare `tokio::net::TcpListener` over adding `mockito`/`wiremock`).
+      Files: `tools/register-agent/Cargo.toml`
+      Blocking: "Implement register_agent tool logic", "Create main.rs entry point", "Write integration tests"
+
+- [x] **Add register-agent to workspace members** `[S]`
+      Add `"tools/register-agent"` to the `[workspace] members` array in the root `Cargo.toml`.
+      Files: `Cargo.toml`
+      Blocking: "Implement register_agent tool logic", "Create main.rs entry point", "Write integration tests"
+
+## Group 2 — Core Implementation
+
+_Depends on: Group 1_
+
+- [x] **Implement register_agent tool logic** `[M]`
+      Create `tools/register-agent/src/register_agent.rs` following the docker-push pattern. Define `RegisterAgentRequest` struct with fields: `name` (String), `url` (String), `description` (String). Define `RegisterAgentTool` struct with `tool_router: ToolRouter<Self>`. Implement input validation: reject empty `name`, `url`, and `description`; validate `url` format; validate `name` contains only safe characters. Read `ORCHESTRATOR_URL` from env var with default `http://orchestrator:8080`. Use `reqwest::Client` to POST JSON payload `{"name": ..., "url": ..., "description": ...}` to `{orchestrator_url}/register`. Return JSON `{"success": true, "agent_name": ..., "registered_url": ...}` on success, or `{"success": false, "agent_name": ..., "registered_url": "", "error": "..."}` on failure. Use `#[tool_router]` and `#[tool_handler]` macros. The tool method must be async since it makes HTTP calls — verify that `rmcp` `#[tool]` macro supports async fn.
+      Files: `tools/register-agent/src/register_agent.rs`
+      Blocked by: "Create register-agent Cargo.toml", "Add register-agent to workspace members"
+      Blocking: "Create main.rs entry point", "Write unit tests", "Write integration tests"
+
+- [x] **Create main.rs entry point** `[S]`
+      Create `tools/register-agent/src/main.rs` following the docker-push pattern: `mod register_agent; use register_agent::RegisterAgentTool;` then `#[tokio::main(flavor = "current_thread")] async fn main()` calling `mcp_tool_harness::serve_stdio_tool(RegisterAgentTool::new(), "register-agent").await`.
+      Files: `tools/register-agent/src/main.rs`
+      Blocked by: "Implement register_agent tool logic"
+      Blocking: "Write integration tests"
+
+## Group 3 — Tests and Documentation
+
+_Depends on: Group 2_
+
+- [x] **Write unit tests** `[M]`
+      Add `#[cfg(test)] mod tests` in `register_agent.rs`. Test input validation: empty name rejected, empty url rejected, empty description rejected, name with shell metacharacters rejected. Test error JSON structure on validation failure. For HTTP POST logic, stand up a lightweight mock HTTP server (use `axum` or `tokio::net::TcpListener`). Test: successful registration returns correct JSON, orchestrator returning 4xx/5xx produces error JSON, orchestrator unreachable produces error JSON with meaningful message.
+      Files: `tools/register-agent/src/register_agent.rs`
+      Blocked by: "Implement register_agent tool logic"
+      Blocking: None
+
+- [x] **Write integration tests (MCP server tests)** `[M]`
+      Create `tools/register-agent/tests/register_agent_server_test.rs` following the docker-push server test pattern. Tests: (1) `tools_list_returns_register_agent_tool` — spawn MCP client, assert single tool named `register_agent` with params `["name", "url", "description"]`; (2) `tools_call_with_empty_name_returns_error` — call tool with empty name, assert `success: false`; (3) `tools_call_with_valid_inputs_returns_structured_json` — call tool with valid inputs (orchestrator unreachable in CI, so assert response has expected JSON shape with `success` field present).
+      Files: `tools/register-agent/tests/register_agent_server_test.rs`
+      Blocked by: "Create main.rs entry point"
+      Blocking: None
+
+- [x] **Write README.md** `[S]`
+      Create `tools/register-agent/README.md` following the docker-build README pattern. Document: purpose, build/run/test commands, MCP Inspector command, parameters table (name, url, description), output JSON table (success, agent_name, registered_url, error), success/failure examples, environment variables (ORCHESTRATOR_URL with default), security considerations.
+      Files: `tools/register-agent/README.md`
+      Blocked by: "Implement register_agent tool logic"
+      Blocking: None
+
+## Key Design Decisions
+
+1. **reqwest dependency**: The issue calls for `reqwest` to POST to the orchestrator. Already used in the `orchestrator` crate, so not a new workspace-level dependency.
+2. **Async tool method**: Unlike docker-build/docker-push which use synchronous `std::process::Command`, this tool needs async HTTP via `reqwest`. Verify `rmcp` `#[tool]` macro supports async methods.
+3. **No orchestrator changes needed**: The tool POSTs to a registration endpoint assumed to exist. The orchestrator already has `register(&mut self, endpoint: AgentEndpoint)`. Wiring the HTTP endpoint is outside this issue's scope.
+4. **Mock strategy**: Use `axum` or bare `tokio::net::TcpListener` for test mocks to avoid adding new dependencies.
+
+### Critical Files for Implementation
+- `tools/docker-push/src/docker_push.rs` — Primary pattern to follow
+- `tools/docker-push/tests/docker_push_server_test.rs` — Integration test pattern
+- `tools/docker-push/Cargo.toml` — Dependency template; add `reqwest`
+- `Cargo.toml` — Root workspace; add `"tools/register-agent"` to members
+- `crates/orchestrator/src/agent_endpoint.rs` — `AgentEndpoint` struct the POST payload should align with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +753,22 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1136,6 +1167,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,10 +1230,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "orchestrator"
@@ -1195,7 +1281,7 @@ dependencies = [
  "async-trait",
  "axum",
  "futures",
- "reqwest",
+ "reqwest 0.13.2",
  "rig-core",
  "serde",
  "serde_json",
@@ -1280,6 +1366,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -1527,6 +1619,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "register-agent"
+version = "0.1.0"
+dependencies = [
+ "mcp-test-utils",
+ "mcp-tool-harness",
+ "reqwest 0.12.28",
+ "rmcp 1.2.0",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,7 +1736,7 @@ dependencies = [
  "nanoid",
  "ordered-float",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.13.2",
  "rmcp 0.16.0",
  "schemars 1.2.1",
  "serde",
@@ -2240,6 +2385,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,6 +2647,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ members = [
     "tools/cargo-build",
     "tools/docker-push",
     "tools/docker-build",
-    "tools/register-agent",
 ]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,13 @@ members = [
     "crates/mcp-test-utils",
     "tools/echo-tool",
     "tools/read-file",
+    "tools/register-agent",
     "tools/write-file",
     "tools/validate-skill",
     "tools/cargo-build",
     "tools/docker-push",
     "tools/docker-build",
+    "tools/register-agent",
 ]
 
 [profile.release]

--- a/tools/register-agent/Cargo.toml
+++ b/tools/register-agent/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "register-agent"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }
+rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
+tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", features = ["json"] }
+
+[dev-dependencies]
+mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "net"] }
+rmcp = { version = "1", features = ["client", "transport-child-process"] }
+serde_json = "1"

--- a/tools/register-agent/Cargo.toml
+++ b/tools/register-agent/Cargo.toml
@@ -9,7 +9,7 @@ rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
 tokio = { version = "1", features = ["macros", "rt", "io-std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.13", features = ["json"] }
 
 [dev-dependencies]
 mcp-test-utils = { path = "../../crates/mcp-test-utils" }

--- a/tools/register-agent/README.md
+++ b/tools/register-agent/README.md
@@ -34,7 +34,7 @@ cargo test -p register-agent
 
 | Name          | Type   | Required | Description                              |
 |---------------|--------|----------|------------------------------------------|
-| `name`        | string | yes      | Agent name (alphanumeric, hyphens, underscores)  |
+| `name`        | string | yes      | Agent name (alphanumeric, hyphens, underscores, dots) |
 | `url`         | string | yes      | Agent endpoint URL (must be valid URL format)    |
 | `description` | string | yes      | Human-readable description of the agent          |
 
@@ -81,7 +81,7 @@ The `ORCHESTRATOR_URL` environment variable sets the base URL for the orchestrat
 
 ## Security Considerations
 
-- **Name validation** -- Agent names are restricted to ASCII alphanumeric characters and `._-`. Shell metacharacters and whitespace are rejected.
+- **Name validation** -- Agent names are restricted to ASCII alphanumeric characters, dots, underscores, and hyphens (`._-`). Shell metacharacters and whitespace are rejected.
 - **URL validation** -- URLs must begin with `http://` or `https://`. Other schemes and empty values are rejected.
 - **Description validation** -- Descriptions must be non-empty to prevent registering agents without meaningful metadata.
 - **No shell execution** -- The tool sends HTTP requests directly via `reqwest` without spawning a shell, preventing shell injection attacks.

--- a/tools/register-agent/README.md
+++ b/tools/register-agent/README.md
@@ -1,0 +1,87 @@
+# register-agent
+
+An MCP tool server that registers an agent with the orchestrator by POSTing its name, URL, and description, returning structured JSON with registration status.
+
+## Build
+
+```sh
+cargo build -p register-agent
+```
+
+## Run
+
+```sh
+cargo run -p register-agent
+```
+
+The server uses stdio transport: it reads MCP messages from stdin and writes responses to stdout. All logging output is directed to stderr so it does not interfere with the MCP protocol stream.
+
+## Test with MCP Inspector
+
+```sh
+npx @modelcontextprotocol/inspector cargo run -p register-agent
+```
+
+This launches the MCP Inspector, which connects to the register-agent server and provides an interactive UI for sending requests and viewing responses. Use it to verify that the tool advertises its capabilities and handles calls correctly.
+
+## Test
+
+```sh
+cargo test -p register-agent
+```
+
+## Parameters
+
+| Name          | Type   | Required | Description                              |
+|---------------|--------|----------|------------------------------------------|
+| `name`        | string | yes      | Agent name (alphanumeric, hyphens, underscores)  |
+| `url`         | string | yes      | Agent endpoint URL (must be valid URL format)    |
+| `description` | string | yes      | Human-readable description of the agent          |
+
+## Output
+
+The tool returns a JSON response with the following fields:
+
+| Field            | Type    | Description                                          |
+|------------------|---------|------------------------------------------------------|
+| `success`        | boolean | Whether the registration completed successfully          |
+| `agent_name`     | string  | The name of the registered agent                         |
+| `registered_url` | string  | The URL at which the agent was registered (empty on failure) |
+| `error`          | string  | Error message (empty on success, present on failure)     |
+
+### Success example
+
+```json
+{
+  "success": true,
+  "agent_name": "my-agent",
+  "registered_url": "http://my-agent:8080",
+  "error": ""
+}
+```
+
+### Failure example
+
+```json
+{
+  "success": false,
+  "agent_name": "my-agent",
+  "registered_url": "",
+  "error": "Failed to register agent: orchestrator returned 503"
+}
+```
+
+## Environment Variables
+
+| Variable           | Description                                                              |
+|-------------------|--------------------------------------------------------------------------|
+| `ORCHESTRATOR_URL` | Base URL of the orchestrator service (default: `http://orchestrator:8080`) |
+
+The `ORCHESTRATOR_URL` environment variable sets the base URL for the orchestrator. If not set, it defaults to `http://orchestrator:8080`. The registration payload is POSTed to `{ORCHESTRATOR_URL}/register`.
+
+## Security Considerations
+
+- **Name validation** -- Agent names are restricted to ASCII alphanumeric characters and `._-`. Shell metacharacters and whitespace are rejected.
+- **URL validation** -- URLs must begin with `http://` or `https://`. Other schemes and empty values are rejected.
+- **Description validation** -- Descriptions must be non-empty to prevent registering agents without meaningful metadata.
+- **No shell execution** -- The tool sends HTTP requests directly via `reqwest` without spawning a shell, preventing shell injection attacks.

--- a/tools/register-agent/src/main.rs
+++ b/tools/register-agent/src/main.rs
@@ -1,0 +1,7 @@
+mod register_agent;
+use register_agent::RegisterAgentTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(RegisterAgentTool::new(), "register-agent").await
+}

--- a/tools/register-agent/src/register_agent.rs
+++ b/tools/register-agent/src/register_agent.rs
@@ -1,0 +1,330 @@
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct RegisterAgentRequest {
+    /// Name of the agent to register
+    pub name: String,
+    /// URL where the agent can be reached
+    pub url: String,
+    /// Human-readable description of the agent
+    pub description: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RegisterAgentTool {
+    tool_router: ToolRouter<Self>,
+}
+
+impl RegisterAgentTool {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+fn validate_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("name must not be empty".to_string());
+    }
+    for ch in name.chars() {
+        if !ch.is_ascii_alphanumeric() && !matches!(ch, '.' | '_' | '-') {
+            return Err(format!("invalid character '{ch}' in agent name"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_url(url: &str) -> Result<(), String> {
+    if url.is_empty() {
+        return Err("url must not be empty".to_string());
+    }
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Err("url must start with http:// or https://".to_string());
+    }
+    Ok(())
+}
+
+fn validate_description(description: &str) -> Result<(), String> {
+    if description.is_empty() {
+        return Err("description must not be empty".to_string());
+    }
+    Ok(())
+}
+
+fn build_error_json(name: &str, reason: &str) -> String {
+    serde_json::json!({
+        "success": false,
+        "agent_name": name,
+        "registered_url": "",
+        "error": reason,
+    })
+    .to_string()
+}
+
+fn resolve_orchestrator_url() -> String {
+    let url = std::env::var("ORCHESTRATOR_URL")
+        .unwrap_or_else(|_| "http://orchestrator:8080".to_string());
+    url.trim_end_matches('/').to_string()
+}
+
+#[tool_router]
+impl RegisterAgentTool {
+    #[tool(description = "Register an agent with the orchestrator")]
+    async fn register_agent(
+        &self,
+        Parameters(request): Parameters<RegisterAgentRequest>,
+    ) -> String {
+        if let Err(reason) = validate_name(&request.name) {
+            return build_error_json(&request.name, &format!("Invalid name: {reason}"));
+        }
+        if let Err(reason) = validate_url(&request.url) {
+            return build_error_json(&request.name, &format!("Invalid url: {reason}"));
+        }
+        if let Err(reason) = validate_description(&request.description) {
+            return build_error_json(
+                &request.name,
+                &format!("Invalid description: {reason}"),
+            );
+        }
+
+        let base_url = resolve_orchestrator_url();
+        let register_url = format!("{base_url}/register");
+
+        let payload = serde_json::json!({
+            "name": request.name,
+            "url": request.url,
+            "description": request.description,
+        });
+
+        let result = reqwest::Client::new()
+            .post(&register_url)
+            .json(&payload)
+            .send()
+            .await;
+
+        match result {
+            Ok(response) if response.status().is_success() => {
+                serde_json::json!({
+                    "success": true,
+                    "agent_name": request.name,
+                    "registered_url": request.url,
+                })
+                .to_string()
+            }
+            Ok(response) => {
+                let status = response.status();
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| String::new());
+                build_error_json(
+                    &request.name,
+                    &format!("HTTP {status}: {body}"),
+                )
+            }
+            Err(e) => build_error_json(&request.name, &format!("Request failed: {e}")),
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for RegisterAgentTool {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Convenience helper that calls the register_agent tool method.
+    async fn call_register_agent(
+        tool: &RegisterAgentTool,
+        name: &str,
+        url: &str,
+        description: &str,
+    ) -> String {
+        tool.register_agent(Parameters(RegisterAgentRequest {
+            name: name.to_string(),
+            url: url.to_string(),
+            description: description.to_string(),
+        }))
+        .await
+    }
+
+    // ── Validation tests (spec: 9 required test cases) ──
+
+    #[tokio::test]
+    async fn rejects_empty_name() {
+        let tool = RegisterAgentTool::new();
+        let result = call_register_agent(&tool, "", "http://localhost:8080", "A test agent").await;
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["error"].as_str().unwrap().to_lowercase().contains("name"));
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_url() {
+        let tool = RegisterAgentTool::new();
+        let result = call_register_agent(&tool, "my-agent", "", "A test agent").await;
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["error"].as_str().unwrap().to_lowercase().contains("url"));
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_description() {
+        let tool = RegisterAgentTool::new();
+        let result = call_register_agent(&tool, "my-agent", "http://localhost:8080", "").await;
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json["error"]
+            .as_str()
+            .unwrap()
+            .to_lowercase()
+            .contains("description"));
+    }
+
+    #[tokio::test]
+    async fn rejects_name_with_shell_metachar() {
+        let tool = RegisterAgentTool::new();
+        for bad_name in &["foo;bar", "foo|bar", "$(cmd)"] {
+            let result =
+                call_register_agent(&tool, bad_name, "http://localhost:8080", "A test agent")
+                    .await;
+            let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+            assert_eq!(
+                json["success"], false,
+                "expected rejection for name '{bad_name}'"
+            );
+        }
+    }
+
+    // ── Error JSON structure test ──
+
+    #[tokio::test]
+    async fn error_json_has_expected_structure() {
+        let tool = RegisterAgentTool::new();
+        let result = call_register_agent(&tool, "", "http://localhost:8080", "A test agent").await;
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(json.get("agent_name").is_some(), "missing 'agent_name' field");
+        assert!(
+            json.get("registered_url").is_some(),
+            "missing 'registered_url' field"
+        );
+        assert!(json.get("error").is_some(), "missing 'error' field");
+        assert!(
+            !json["error"].as_str().unwrap().is_empty(),
+            "error should be non-empty"
+        );
+        assert_eq!(json["registered_url"], "");
+    }
+
+    // ── Mock HTTP server helpers ──
+
+    /// Start a mock TCP server that responds with the given status and body.
+    async fn start_mock_server(status: u16, body: &str) -> String {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let response_line = format!("HTTP/1.1 {status} OK\r\n");
+        let body = body.to_string();
+
+        tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                use tokio::io::AsyncReadExt;
+                let mut buf = vec![0u8; 4096];
+                let _ = stream.read(&mut buf).await;
+                let response = format!(
+                    "{response_line}Content-Type: text/plain\r\nContent-Length: {}\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            }
+        });
+
+        format!("http://127.0.0.1:{}", addr.port())
+    }
+
+    /// Find a free port with no listener (for the unreachable test).
+    async fn find_unused_port() -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        port
+    }
+
+    /// Mutex that serializes tests which manipulate the ORCHESTRATOR_URL env var,
+    /// preventing race conditions when the test harness runs tests in parallel.
+    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Call register_agent against a specific orchestrator URL via env var.
+    /// Acquires ENV_MUTEX to prevent parallel env var races.
+    async fn call_register_with_orchestrator(orchestrator_url: &str) -> serde_json::Value {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        // Safety: test-only env manipulation; required unsafe in Rust 2024 edition.
+        // The ENV_MUTEX guard ensures no other test reads/writes this var concurrently.
+        unsafe { std::env::set_var("ORCHESTRATOR_URL", orchestrator_url) };
+        let tool = RegisterAgentTool::new();
+        let result =
+            call_register_agent(&tool, "test-agent", "http://localhost:9999", "A test agent")
+                .await;
+        unsafe { std::env::remove_var("ORCHESTRATOR_URL") };
+        serde_json::from_str(&result).unwrap()
+    }
+
+    // ── Mock HTTP server tests ──
+
+    #[tokio::test]
+    async fn successful_registration_returns_correct_json() {
+        let base_url = start_mock_server(200, "OK").await;
+        let json = call_register_with_orchestrator(&base_url).await;
+        assert_eq!(json["success"], true);
+        assert_eq!(json["agent_name"], "test-agent");
+        assert_eq!(json["registered_url"], "http://localhost:9999");
+    }
+
+    #[tokio::test]
+    async fn orchestrator_4xx_produces_error_json() {
+        let base_url = start_mock_server(400, "Bad Request").await;
+        let json = call_register_with_orchestrator(&base_url).await;
+        assert_eq!(json["success"], false);
+        let error = json["error"].as_str().unwrap();
+        assert!(!error.is_empty(), "error field should be non-empty");
+    }
+
+    #[tokio::test]
+    async fn orchestrator_5xx_produces_error_json() {
+        let base_url = start_mock_server(500, "Internal Server Error").await;
+        let json = call_register_with_orchestrator(&base_url).await;
+        assert_eq!(json["success"], false);
+        let error = json["error"].as_str().unwrap();
+        assert!(!error.is_empty(), "error field should be non-empty");
+    }
+
+    #[tokio::test]
+    async fn orchestrator_unreachable_produces_error_json() {
+        let port = find_unused_port().await;
+        let base_url = format!("http://127.0.0.1:{port}");
+        let json = call_register_with_orchestrator(&base_url).await;
+        assert_eq!(json["success"], false);
+        let error = json["error"].as_str().unwrap().to_lowercase();
+        assert!(
+            error.contains("connect")
+                || error.contains("connection")
+                || error.contains("refused")
+                || error.contains("error sending request"),
+            "error should mention connection failure, got: {error}"
+        );
+    }
+}

--- a/tools/register-agent/src/register_agent.rs
+++ b/tools/register-agent/src/register_agent.rs
@@ -114,10 +114,19 @@ impl RegisterAgentTool {
             "description": request.description,
         });
 
-        let client = reqwest::Client::builder()
+        let client = match reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(5))
             .timeout(std::time::Duration::from_secs(30))
             .build()
-            .unwrap_or_else(|_| reqwest::Client::new());
+        {
+            Ok(c) => c,
+            Err(e) => {
+                return build_error_json(
+                    &request.name,
+                    &format!("Failed to create HTTP client: {e}"),
+                );
+            }
+        };
 
         let result = client
             .post(&register_url)

--- a/tools/register-agent/src/register_agent.rs
+++ b/tools/register-agent/src/register_agent.rs
@@ -17,12 +17,22 @@ pub struct RegisterAgentRequest {
 #[derive(Debug, Clone)]
 pub struct RegisterAgentTool {
     tool_router: ToolRouter<Self>,
+    orchestrator_url: Option<String>,
 }
 
 impl RegisterAgentTool {
     pub fn new() -> Self {
         Self {
             tool_router: Self::tool_router(),
+            orchestrator_url: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_orchestrator_url(url: &str) -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            orchestrator_url: Some(url.to_string()),
         }
     }
 }
@@ -92,7 +102,10 @@ impl RegisterAgentTool {
             );
         }
 
-        let base_url = resolve_orchestrator_url();
+        let base_url = self
+            .orchestrator_url
+            .clone()
+            .unwrap_or_else(resolve_orchestrator_url);
         let register_url = format!("{base_url}/register");
 
         let payload = serde_json::json!({
@@ -101,7 +114,12 @@ impl RegisterAgentTool {
             "description": request.description,
         });
 
-        let result = reqwest::Client::new()
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+
+        let result = client
             .post(&register_url)
             .json(&payload)
             .send()
@@ -113,6 +131,7 @@ impl RegisterAgentTool {
                     "success": true,
                     "agent_name": request.name,
                     "registered_url": request.url,
+                    "error": "",
                 })
                 .to_string()
             }
@@ -236,7 +255,13 @@ mod tests {
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let response_line = format!("HTTP/1.1 {status} OK\r\n");
+        let reason = match status {
+            200 => "OK",
+            400 => "Bad Request",
+            500 => "Internal Server Error",
+            _ => "Unknown",
+        };
+        let response_line = format!("HTTP/1.1 {status} {reason}\r\n");
         let body = body.to_string();
 
         tokio::spawn(async move {
@@ -264,22 +289,13 @@ mod tests {
         port
     }
 
-    /// Mutex that serializes tests which manipulate the ORCHESTRATOR_URL env var,
-    /// preventing race conditions when the test harness runs tests in parallel.
-    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    /// Call register_agent against a specific orchestrator URL via env var.
-    /// Acquires ENV_MUTEX to prevent parallel env var races.
+    /// Call register_agent against a specific orchestrator URL using the
+    /// `with_orchestrator_url` constructor, avoiding env var mutation.
     async fn call_register_with_orchestrator(orchestrator_url: &str) -> serde_json::Value {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        // Safety: test-only env manipulation; required unsafe in Rust 2024 edition.
-        // The ENV_MUTEX guard ensures no other test reads/writes this var concurrently.
-        unsafe { std::env::set_var("ORCHESTRATOR_URL", orchestrator_url) };
-        let tool = RegisterAgentTool::new();
+        let tool = RegisterAgentTool::with_orchestrator_url(orchestrator_url);
         let result =
             call_register_agent(&tool, "test-agent", "http://localhost:9999", "A test agent")
                 .await;
-        unsafe { std::env::remove_var("ORCHESTRATOR_URL") };
         serde_json::from_str(&result).unwrap()
     }
 

--- a/tools/register-agent/tests/register_agent_server_test.rs
+++ b/tools/register-agent/tests/register_agent_server_test.rs
@@ -1,0 +1,94 @@
+use rmcp::model::CallToolRequestParams;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_returns_register_agent_tool() {
+    let client =
+        mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_register-agent")).await;
+    mcp_test_utils::assert_single_tool(
+        &client,
+        "register_agent",
+        "Register an agent",
+        &["name", "url", "description"],
+    )
+    .await;
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_with_empty_name_returns_error() {
+    let client =
+        mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_register-agent")).await;
+
+    let params = CallToolRequestParams::new("register_agent").with_arguments(
+        serde_json::json!({
+            "name": "",
+            "url": "http://example.com",
+            "description": "A test agent"
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value =
+        serde_json::from_str(&text.text).expect("should parse as JSON");
+    assert_eq!(json["success"], false, "should fail for empty name");
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_with_valid_inputs_returns_structured_json() {
+    let client =
+        mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_register-agent")).await;
+
+    let params = CallToolRequestParams::new("register_agent").with_arguments(
+        serde_json::json!({
+            "name": "test-agent",
+            "url": "http://localhost:9999",
+            "description": "A test agent"
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value =
+        serde_json::from_str(&text.text).expect("should parse as JSON");
+    assert!(
+        json.get("success").is_some(),
+        "response should have 'success' field"
+    );
+    assert!(
+        json.get("agent_name").is_some(),
+        "response should have 'agent_name' field"
+    );
+    assert!(
+        json.get("registered_url").is_some(),
+        "response should have 'registered_url' field"
+    );
+
+    client.cancel().await.expect("failed to cancel client");
+}

--- a/tools/register-agent/tests/register_agent_server_test.rs
+++ b/tools/register-agent/tests/register_agent_server_test.rs
@@ -50,6 +50,9 @@ async fn tools_call_with_empty_name_returns_error() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn tools_call_with_valid_inputs_returns_structured_json() {
+    // Point orchestrator to a localhost port that will refuse connections quickly,
+    // avoiding DNS resolution delays for the default http://orchestrator:8080.
+    unsafe { std::env::set_var("ORCHESTRATOR_URL", "http://127.0.0.1:1") };
     let client =
         mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_register-agent")).await;
 


### PR DESCRIPTION
## Summary

Add a `register-agent` MCP tool binary that POSTs agent registration payloads to the orchestrator's `/register` endpoint via `reqwest`. This is the first async MCP tool in the codebase, following the established tool pattern (docker-push/docker-build) with async tool method support confirmed in rmcp macros v1.2.0.

## Changes

### Group 1 — Scaffolding
- ✅ Create register-agent Cargo.toml
- ✅ Add register-agent to workspace members

### Group 2 — Core Implementation
- ✅ Implement register_agent tool logic (async HTTP POST via reqwest)
- ✅ Create main.rs entry point

### Group 3 — Tests and Documentation
- ✅ Write unit tests (validation + mock HTTP server via TcpListener)
- ✅ Write integration tests (MCP server tests)
- ✅ Write README.md

## Test plan

- `cargo build -p register-agent` — crate builds cleanly
- `cargo clippy -p register-agent` — no lint warnings
- `cargo check -p register-agent` — no type errors
- `cargo test -p register-agent` — all unit and integration tests pass

## Issue

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)