### PR TITLE
feat(tools): implement list_agents MCP tool (#51)

### DIFF
--- a/.claude/specs/issue-51/add-tools-list-agents-to-workspace-cargo-toml.md
+++ b/.claude/specs/issue-51/add-tools-list-agents-to-workspace-cargo-toml.md
@@ -1,0 +1,55 @@
+# Spec: Add `"tools/list-agents"` to workspace `Cargo.toml`
+> From: .claude/tasks/issue-51.md
+
+## Objective
+Add `"tools/list-agents"` as a new member entry in the root workspace `Cargo.toml` so the `list-agents` tool crate is included in the Cargo workspace and participates in builds, tests, and other workspace-wide commands.
+
+## Current State
+The root `Cargo.toml` defines a `[workspace]` with `resolver = "2"` and the following members:
+- `crates/agent-sdk`
+- `crates/skill-loader`
+- `crates/tool-registry`
+- `crates/agent-runtime`
+- `crates/mcp-tool-harness`
+- `crates/orchestrator`
+- `crates/mcp-test-utils`
+- `tools/echo-tool`
+- `tools/read-file`
+- `tools/register-agent`
+- `tools/write-file`
+- `tools/validate-skill`
+- `tools/cargo-build`
+- `tools/docker-push`
+- `tools/docker-build`
+
+There is no `tools/list-agents` directory on disk yet. This spec only covers the `Cargo.toml` change; the actual crate scaffolding is handled by a separate task.
+
+## Requirements
+1. Append `"tools/list-agents"` to the `members` array in the `[workspace]` section of the root `Cargo.toml`.
+2. Place it in alphabetical order among the `tools/*` entries (after `tools/echo-tool`, before `tools/read-file`).
+3. Do not modify any other part of the file.
+
+## Implementation Details
+- File to edit: `/workspaces/spore/Cargo.toml`
+- Add the line `    "tools/list-agents",` between `"tools/echo-tool"` and `"tools/read-file"` in the `members` list.
+- The resulting members list for tools should read:
+  ```
+  "tools/echo-tool",
+  "tools/list-agents",
+  "tools/read-file",
+  "tools/register-agent",
+  ...
+  ```
+
+## Dependencies
+- Blocked by: none (Group 1)
+- Blocking: "Run verification suite"
+
+## Risks & Edge Cases
+- Adding the member before the `tools/list-agents` crate directory exists will cause `cargo` commands to fail with a missing-manifest error. Ensure the crate scaffolding task runs before (or alongside) this change so the workspace resolves cleanly.
+- If additional tool crates are added concurrently, merge conflicts in the `members` list are possible. Resolve by keeping entries in alphabetical order within each prefix group (`crates/`, `tools/`).
+
+## Verification
+1. Run `cargo check` (or `cargo build`) and confirm no workspace resolution errors related to the new member.
+2. Run `cargo test` and confirm the full suite passes.
+3. Visually inspect `Cargo.toml` to confirm `"tools/list-agents"` appears exactly once and in alphabetical order among `tools/*` entries.

--- a/.claude/specs/issue-51/create-tools-list-agents-cargo-toml.md
+++ b/.claude/specs/issue-51/create-tools-list-agents-cargo-toml.md
@@ -1,0 +1,44 @@
+# Spec: Create `tools/list-agents/Cargo.toml`
+> From: .claude/tasks/issue-51.md
+
+## Objective
+Create the Cargo.toml manifest for the `list-agents` MCP tool crate, following the same structure as `tools/register-agent/Cargo.toml` but without the `reqwest` dependency (this tool only reads environment variables, it does not make HTTP requests).
+
+## Current State
+The `tools/list-agents/` directory does not yet exist. The `tools/register-agent/Cargo.toml` serves as the reference template. It declares `mcp-tool-harness` (path dep), `rmcp` with transport/server/macros features, `tokio`, `serde`, `serde_json`, and `reqwest`. Dev-dependencies include `mcp-test-utils`, `tokio` with `rt-multi-thread`, `rmcp` with client/transport features, and `serde_json`.
+
+## Requirements
+1. Create `tools/list-agents/Cargo.toml` with `name = "list-agents"`, `version = "0.1.0"`, `edition = "2024"`.
+2. Dependencies (identical to `register-agent` minus `reqwest`):
+   - `mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }`
+   - `rmcp = { version = "1", features = ["transport-io", "server", "macros"] }`
+   - `tokio = { version = "1", features = ["macros", "rt", "io-std"] }`
+   - `serde = { version = "1", features = ["derive"] }`
+   - `serde_json = "1"`
+3. Dev-dependencies (same as `register-agent`):
+   - `mcp-test-utils = { path = "../../crates/mcp-test-utils" }`
+   - `tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "net"] }`
+   - `rmcp = { version = "1", features = ["client", "transport-child-process"] }`
+   - `serde_json = "1"`
+4. No `reqwest` dependency in either `[dependencies]` or `[dev-dependencies]`.
+
+## Implementation Details
+- Copy `tools/register-agent/Cargo.toml` as the starting point.
+- Change `name` from `"register-agent"` to `"list-agents"`.
+- Remove the `reqwest` line from `[dependencies]`.
+- Keep everything else unchanged.
+- Ensure the workspace `Cargo.toml` at the repo root includes `"tools/list-agents"` in its `members` list (this may be handled by a separate spec/task).
+
+## Dependencies
+- Blocked by: none (Group 1)
+- Blocking: "Implement `ListAgentsTool` struct and handler", "Write `main.rs`", "Write integration tests"
+
+## Risks & Edge Cases
+- The `../../crates/mcp-tool-harness` and `../../crates/mcp-test-utils` relative paths assume the standard two-level nesting under `tools/list-agents/`. If the directory is placed elsewhere, paths will break.
+- The crate will not compile until `src/main.rs` (or `src/lib.rs`) exists; this is expected since the Cargo.toml is created first as a Group 1 task.
+- The workspace root `Cargo.toml` must list this crate as a member for `cargo build` to pick it up.
+
+## Verification
+1. Run `cargo metadata --manifest-path tools/list-agents/Cargo.toml --no-deps` and confirm the package name is `list-agents` with the correct dependency set.
+2. Confirm `reqwest` does not appear anywhere in the file.
+3. Confirm the dependency versions and feature flags match the spec above exactly.

--- a/.claude/specs/issue-51/implement-list-agents-tool-struct-and-handler.md
+++ b/.claude/specs/issue-51/implement-list-agents-tool-struct-and-handler.md
@@ -1,0 +1,94 @@
+# Spec: Implement `ListAgentsTool` struct and handler
+> From: .claude/tasks/issue-51.md
+
+## Objective
+Create `tools/list-agents/src/list_agents.rs` containing the `ListAgentsTool` MCP tool struct and handler. The tool reads agent configuration from environment variables (mirroring `crates/orchestrator/src/config.rs`), supports optional filtering, and returns a JSON array of agents.
+
+## Current State
+- No `list_agents.rs` file exists yet.
+- `crates/orchestrator/src/config.rs` already implements `AGENT_ENDPOINTS` / `AGENT_DESCRIPTIONS` parsing via `parse_comma_pairs`, but that logic lives behind `OrchestratorError` and is not reusable as a library. The list-agents tool must reimplement equivalent parsing locally.
+- Existing tool patterns (`echo.rs`, `register_agent.rs`) establish the `ToolRouter<Self>` / `#[tool_router]` / `#[tool_handler]` boilerplate.
+
+## Requirements
+
+### Structs
+1. `ListAgentsRequest` -- derive `Debug, serde::Deserialize, schemars::JsonSchema`.
+   - One field: `filter: Option<String>` with doc comment `/// Optional substring to filter agents by name or description`.
+2. `ListAgentsTool` -- derive `Debug, Clone`.
+   - Field: `tool_router: ToolRouter<Self>`.
+   - Constructor `pub fn new() -> Self` that calls `Self::tool_router()`.
+
+### Agent resolution (pure functions)
+Extract env-var reading and parsing into pure helper functions so tests can call them without mutating process env vars.
+
+1. `fn parse_endpoints(raw: &str) -> Result<Vec<(String, String)>, String>` -- split on `,`, then on `=`, trim whitespace, reject empty keys/values. Return descriptive error on malformed input.
+2. `fn parse_descriptions(raw: &str) -> HashMap<String, String>` -- same comma/equals split but lenient: skip malformed pairs silently (descriptions are optional metadata).
+3. `fn build_agent_list(endpoints: &[(String, String)], descriptions: &HashMap<String, String>) -> Vec<AgentInfo>` -- join on agent name; missing description defaults to `""`.
+4. `fn filter_agents(agents: &[AgentInfo], filter: &str) -> Vec<AgentInfo>` -- case-insensitive substring match on both `name` and `description`. Empty filter returns all agents.
+
+### AgentInfo helper struct
+```rust
+#[derive(Debug, Clone, serde::Serialize)]
+struct AgentInfo {
+    name: String,
+    url: String,
+    description: String,
+}
+```
+Not public -- internal to the module.
+
+### Tool handler (`#[tool_router]` impl)
+- Method: `fn list_agents(&self, Parameters(request): Parameters<ListAgentsRequest>) -> String`.
+- Read `AGENT_ENDPOINTS` via `std::env::var`. If missing or empty, return `{"agents": []}`.
+- Parse endpoints with `parse_endpoints`. On error, return `{"agents": [], "error": "<message>"}`.
+- Read `AGENT_DESCRIPTIONS` via `std::env::var`. If missing or empty, use empty `HashMap`.
+- Parse descriptions with `parse_descriptions`.
+- Build agent list with `build_agent_list`.
+- If `filter` is `Some(f)` and `f` is non-empty, apply `filter_agents`.
+- Serialize result as `{"agents": [...]}` via `serde_json::json!`.
+
+### ServerHandler impl
+Standard boilerplate matching `echo.rs`:
+```rust
+#[tool_handler]
+impl ServerHandler for ListAgentsTool {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+}
+```
+
+## Dependencies
+- `rmcp` (already in workspace) -- `ToolRouter`, `Parameters`, `ServerCapabilities`, `ServerInfo`, `schemars`, `tool`, `tool_handler`, `tool_router`, `ServerHandler`.
+- `serde`, `serde_json`, `schemars` -- already in workspace.
+- No new crate dependencies required.
+
+Blocked by: "Create `tools/list-agents/Cargo.toml`" (the crate must exist before this file compiles).
+
+## Risks & Edge Cases
+
+1. **Env var mutation in tests** -- Process-wide env vars cause test flakiness under parallel execution. All parsing logic must be in pure functions that accept `&str` inputs so unit tests never call `std::env::set_var`.
+2. **Malformed `AGENT_ENDPOINTS`** -- entries like `foo` (no `=`), `=bar` (empty key), `foo=` (empty value). `parse_endpoints` must return an error; the handler must surface it in the `error` field without panicking.
+3. **Malformed `AGENT_DESCRIPTIONS`** -- same edge cases but handled leniently (skip bad pairs) because descriptions are optional.
+4. **Whitespace** -- leading/trailing whitespace around commas, keys, and values must be trimmed (matching `config.rs` behavior).
+5. **Empty filter string** -- `Some("")` should behave the same as `None` (return all agents).
+6. **Unicode in names/descriptions** -- substring matching must use `.to_lowercase()` for case-insensitive comparison, which handles ASCII correctly. Non-ASCII case folding is out of scope.
+
+## Verification
+
+### Unit tests (6 required, in `#[cfg(test)] mod tests`)
+All tests call pure functions directly -- no env var mutation.
+
+1. **`test_empty_endpoints`** -- `parse_endpoints("")` returns `Ok(vec![])`. `build_agent_list(&[], &HashMap::new())` returns empty vec. Full flow returns `{"agents": []}`.
+2. **`test_single_agent`** -- `parse_endpoints("alpha=http://a:8080")` returns one pair. `build_agent_list` with matching description produces one `AgentInfo`. JSON output has one entry with all three fields.
+3. **`test_multiple_agents`** -- `parse_endpoints("a=http://a:80,b=http://b:80")` returns two pairs. Descriptions map has entry for `a` only. Result: agent `a` has description, agent `b` has `""`.
+4. **`test_filter_matches_name`** -- Three agents, filter `"alp"`. Only agents whose name contains `"alp"` are returned.
+5. **`test_filter_case_insensitive`** -- Agent named `"Alpha"`, filter `"ALPHA"`. Must match.
+6. **`test_missing_descriptions`** -- Endpoints present, descriptions map empty. All agents returned with `description: ""`.
+
+### Manual verification
+After implementation, run:
+```bash
+cargo test -p list-agents
+cargo clippy -p list-agents
+```

--- a/.claude/specs/issue-51/run-verification-suite.md
+++ b/.claude/specs/issue-51/run-verification-suite.md
@@ -1,0 +1,44 @@
+# Spec: Run verification suite
+> From: .claude/tasks/issue-51.md
+
+## Objective
+Run the full verification suite for the `list-agents` crate to confirm that all acceptance criteria from issue-51 are satisfied: the crate builds, tests pass, clippy is clean, and the workspace type-checks.
+
+## Current State
+This is the final task in the issue-51 breakdown. All previous tasks (scaffold, core implementation, integration tests, README) must be complete before this task runs. No code changes are produced by this task — it is purely a validation gate.
+
+## Requirements
+1. `cargo build -p list-agents` succeeds with no errors
+2. `cargo test -p list-agents` passes all unit and integration tests
+3. `cargo clippy -p list-agents` reports no warnings or errors
+4. `cargo check` (workspace-wide) succeeds, confirming the new crate does not break any existing workspace member
+5. The MCP tool is named `list_agents` in tools/list output
+6. The tool returns structured JSON: `{"agents": [{name, url, description}, ...]}`
+7. The tool reads `AGENT_ENDPOINTS` and `AGENT_DESCRIPTIONS` environment variables
+8. The tool returns an empty array `{"agents": []}` when no agents are registered
+
+## Implementation Details
+This task produces no code. Execute the following commands in order, stopping on the first failure:
+
+1. **Build**: `cargo build -p list-agents`
+2. **Test**: `cargo test -p list-agents`
+3. **Lint**: `cargo clippy -p list-agents -- -D warnings`
+4. **Workspace check**: `cargo check`
+
+If all four commands exit 0, review test names and output to confirm that the acceptance criteria in Requirements 5-8 are covered by existing tests. Specifically verify:
+- An integration test asserts the tool name is `"list_agents"`
+- A unit or integration test asserts the JSON output shape contains an `"agents"` array
+- A test sets `AGENT_ENDPOINTS` / `AGENT_DESCRIPTIONS` and verifies parsed output
+- A test with no env vars set asserts an empty agents array is returned
+
+## Dependencies
+- Blocked by: All previous tasks (Create Cargo.toml, Add to workspace, Implement ListAgentsTool, Write main.rs, Write integration tests, Write README)
+- Blocking: None
+
+## Risks & Edge Cases
+- **Flaky env var tests**: Unit tests that mutate `std::env` can race with each other under the default multi-threaded test runner. If tests fail intermittently, re-run with `cargo test -p list-agents -- --test-threads=1` to confirm, then fix the underlying isolation issue rather than masking it.
+- **Clippy false positives**: If a new clippy lint was introduced in a recent toolchain update, address it before marking verification complete — do not allow `#[allow(...)]` without justification.
+- **Workspace breakage**: `cargo check` covers the entire workspace. A failure here may indicate a dependency conflict or feature flag issue introduced by the new crate, not necessarily a bug in `list-agents` itself.
+
+## Verification
+This task *is* the verification step. Success means all four commands pass and the acceptance criteria are confirmed covered by tests. Report the results (pass/fail, any warnings) to the user. Do not merge or push — just report status.

--- a/.claude/specs/issue-51/write-integration-tests.md
+++ b/.claude/specs/issue-51/write-integration-tests.md
@@ -1,0 +1,81 @@
+# Spec: Write integration tests
+> From: .claude/tasks/issue-51.md
+
+## Objective
+Create `tools/list-agents/tests/list_agents_server_test.rs` with three integration tests that verify the `list-agents` MCP server binary works correctly end-to-end: tool discovery, empty-state behavior, and env-var-driven agent listing.
+
+## Current State
+- `mcp-test-utils` crate provides `spawn_mcp_client!` macro and `assert_single_tool` helper, both used by existing integration tests (e.g., `tools/register-agent/tests/register_agent_server_test.rs`).
+- The `list-agents` binary and `ListAgentsTool` handler do not exist yet; this spec is blocked by the `main.rs` and handler implementation tasks.
+- The established integration test pattern uses `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`, spawns the server via `spawn_mcp_client!`, exercises tools through the `rmcp` client API, and cancels the client at the end.
+
+## Requirements
+1. **`tools_list_returns_list_agents_tool`** — Call `list_tools` on the spawned server and verify:
+   - Exactly one tool is returned.
+   - Tool name is `"list_agents"`.
+   - Description contains the substring `"agent"`.
+   - Input schema properties include `["filter"]`.
+   - Use `mcp_test_utils::assert_single_tool` for all assertions.
+
+2. **`tools_call_returns_empty_when_no_agents`** — Call `list_agents` with no arguments (or empty filter), without setting `AGENT_ENDPOINTS` / `AGENT_DESCRIPTIONS`:
+   - Parse the response text as JSON.
+   - Assert `json["agents"]` is an empty array (`[]`).
+
+3. **`tools_call_returns_agents_from_env`** — Before spawning the child process, set env vars:
+   - `AGENT_ENDPOINTS=foo=http://localhost:8080,bar=http://localhost:9090`
+   - `AGENT_DESCRIPTIONS=foo=A foo agent,bar=A bar agent`
+   - Call `list_agents` with no filter.
+   - Parse the response text as JSON.
+   - Assert `json["agents"]` contains two entries with correct `name`, `url`, and `description` fields.
+
+## Implementation Details
+
+### File location
+`tools/list-agents/tests/list_agents_server_test.rs`
+
+### Imports
+```rust
+use rmcp::model::CallToolRequestParams;
+```
+The `mcp_test_utils` crate is used via its macro path (`mcp_test_utils::spawn_mcp_client!` and `mcp_test_utils::assert_single_tool`).
+
+### Test 1: `tools_list_returns_list_agents_tool`
+- Spawn client with `mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_list-agents")).await`.
+- Call `mcp_test_utils::assert_single_tool(&client, "list_agents", "agent", &["filter"]).await`.
+- Cancel the client.
+
+### Test 2: `tools_call_returns_empty_when_no_agents`
+- Spawn client (no env vars set).
+- Build `CallToolRequestParams::new("list_agents")` with an empty arguments object `{}`.
+- Call `client.peer().call_tool(params).await`.
+- Extract first content item as text, parse as JSON.
+- Assert `json["agents"]` is an array and is empty.
+- Cancel the client.
+
+### Test 3: `tools_call_returns_agents_from_env`
+- Use `unsafe { std::env::set_var(...) }` to set `AGENT_ENDPOINTS` and `AGENT_DESCRIPTIONS` before spawning. The `unsafe` block is required because `set_var` is unsafe in recent Rust editions (the child process inherits the parent's environment at spawn time).
+- Spawn client.
+- Build `CallToolRequestParams::new("list_agents")` with empty arguments.
+- Call tool, extract text, parse JSON.
+- Assert `json["agents"]` is an array of length 2.
+- Assert each entry has `name`, `url`, and `description` fields with expected values. Since array order is not guaranteed, either sort before comparing or check that both expected agents exist somewhere in the array.
+- Cancel the client.
+- Clean up env vars with `unsafe { std::env::remove_var(...) }` to avoid polluting other tests (though since each test spawns a separate child process, cross-test contamination of the *child* is not a concern; this is for parent-process hygiene).
+
+### Pattern notes
+- Every test function uses `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`.
+- Every test ends with `client.cancel().await.expect("failed to cancel client")`.
+- Response parsing follows the same chain: `.content.first().as_text().text` then `serde_json::from_str`.
+
+## Dependencies
+- **Blocked by:** `main.rs` implementation (Group 2) and `ListAgentsTool` handler (Group 2).
+- **Crate dependencies (dev):** `mcp-test-utils` (path), `tokio` (rt-multi-thread), `rmcp` (client, transport-child-process), `serde_json`. These must be declared in `tools/list-agents/Cargo.toml` (handled by the Cargo.toml task).
+
+## Risks & Edge Cases
+1. **Env var race conditions:** `std::env::set_var` mutates global process state and is not thread-safe. Since `cargo test` runs tests in parallel threads by default, setting env vars in one test can leak into another. Mitigation: test 3 is the only test that sets env vars, and the child process captures env at spawn time, so the main risk is if two tests run simultaneously and one reads stale env. Using unique var names or `--test-threads=1` would eliminate the risk, but the established codebase pattern (see `register_agent_server_test.rs` line 55) accepts this trade-off.
+2. **Array ordering:** The order of agents in the response JSON array may not match insertion order. The test should not assume a specific order; check for membership rather than index equality.
+3. **Binary not found:** `env!("CARGO_BIN_EXE_list-agents")` is resolved at compile time by Cargo. If the binary target name in `Cargo.toml` does not match `list-agents`, compilation will fail with a clear error.
+
+## Verification
+- `cargo test -p list-agents --test list_agents_server_test` — all three tests pass.
+- `cargo clippy -p list-agents` — no warnings on the test file.

--- a/.claude/specs/issue-51/write-main-rs.md
+++ b/.claude/specs/issue-51/write-main-rs.md
@@ -1,0 +1,47 @@
+# Spec: Write `src/main.rs`
+> From: .claude/tasks/issue-51.md
+
+## Objective
+Create the entrypoint file `tools/list-agents/src/main.rs` that wires up the `ListAgentsTool` struct to the MCP stdio harness, following the identical pattern used by every other tool binary in the workspace.
+
+## Current State
+The file `tools/list-agents/src/main.rs` does not exist yet. The sibling tools (`echo-tool`, `register-agent`, etc.) each have a ~7-line `main.rs` that declares the tool module, imports the tool struct, and calls `mcp_tool_harness::serve_stdio_tool`.
+
+## Requirements
+1. Declare `mod list_agents;` to pull in the sibling module file.
+2. Import `ListAgentsTool` from that module.
+3. Define `#[tokio::main(flavor = "current_thread")]` async main returning `Result<(), Box<dyn std::error::Error>>`.
+4. Call `mcp_tool_harness::serve_stdio_tool(ListAgentsTool::new(), "list-agents").await` and return its result.
+5. File must be under 10 lines total.
+
+## Implementation Details
+The file should mirror `tools/echo-tool/src/main.rs` exactly in structure:
+
+```
+mod list_agents;
+use list_agents::ListAgentsTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(ListAgentsTool::new(), "list-agents").await
+}
+```
+
+Key conventions carried over from existing tools:
+- `flavor = "current_thread"` (single-threaded Tokio runtime, consistent across all tool binaries).
+- The tool name string passed to `serve_stdio_tool` matches the crate/binary name (`"list-agents"`).
+- No additional imports, logging setup, or configuration — the harness handles all of that.
+
+## Dependencies
+- **Blocked by**: "Implement `ListAgentsTool` struct and handler" — the `list_agents` module (and its `ListAgentsTool` struct with `new()`) must exist before this file compiles.
+- **Blocking**: "Write integration tests" — tests will invoke this binary.
+- **Crate dependencies**: `tokio`, `mcp_tool_harness` (already declared in the workspace `Cargo.toml` for other tools).
+
+## Risks & Edge Cases
+- **Module naming**: The module is `list_agents` (underscores), matching the filename `list_agents.rs`. The binary/tool name is `list-agents` (hyphens). This follows Rust convention and is consistent with `register-agent` / `register_agent`.
+- **No standalone risk**: This file is pure boilerplate with no logic of its own; all risk lives in the `ListAgentsTool` implementation and the harness.
+
+## Verification
+1. `cargo check -p list-agents` compiles without errors (requires the `list_agents` module to exist).
+2. `cargo build -p list-agents` produces a binary.
+3. The binary, when run, starts an MCP stdio server that advertises the `list-agents` tool (verified by integration tests in a later task).

--- a/.claude/specs/issue-51/write-readme.md
+++ b/.claude/specs/issue-51/write-readme.md
@@ -1,0 +1,44 @@
+# Spec: Write `README.md`
+> From: .claude/tasks/issue-51.md
+
+## Objective
+Create `tools/list-agents/README.md` that documents the list-agents MCP tool server, following the established pattern from `tools/register-agent/README.md`.
+
+## Current State
+No `tools/list-agents/` directory or README exists yet. The `tools/register-agent/README.md` serves as the canonical template for tool documentation, covering description, build/run/test commands, MCP Inspector usage, parameters, output format, environment variables, and security considerations.
+
+## Requirements
+1. **Description**: One-line summary explaining that list-agents is an MCP tool server that reads agent registrations from environment variables and returns them as a filtered JSON array.
+2. **Build section**: `cargo build -p list-agents`
+3. **Run section**: `cargo run -p list-agents` with note about stdio transport (stdin/stdout for MCP, stderr for logging).
+4. **MCP Inspector section**: `npx @modelcontextprotocol/inspector cargo run -p list-agents` with brief explanation.
+5. **Test section**: `cargo test -p list-agents`
+6. **Parameters table**: Single optional parameter `filter` (type `string`, required `no`) for case-insensitive substring matching against agent name or description.
+7. **Output section**: Document the JSON response shape `{"agents": [{name, url, description}, ...]}` with optional `error` field. Include a success example with multiple agents, a filtered example, an empty-result example, and an error example.
+8. **Environment Variables table**: Document `AGENT_ENDPOINTS` (comma-separated `name=url` pairs, required for any agents to appear) and `AGENT_DESCRIPTIONS` (comma-separated `name=description` pairs, optional — agents without a matching description get an empty string).
+9. **Usage examples**: Show how to set env vars and invoke the tool, including filter usage.
+
+## Implementation Details
+- Mirror the exact markdown structure of `tools/register-agent/README.md`: heading hierarchy, table formatting, code block language tags, section ordering.
+- Sections in order: description, Build, Run, Test with MCP Inspector, Test, Parameters, Output (with sub-examples), Environment Variables.
+- Since list-agents makes no HTTP calls and only reads env vars, omit the Security Considerations section. This is a key difference from register-agent — there is no shell execution, no URL validation needed, and no network requests.
+- The `AGENT_ENDPOINTS` format is `name=url,name2=url2`. The `AGENT_DESCRIPTIONS` format is `name=description,name2=description2`. Document both with examples.
+- Output examples to include:
+  - **Success with agents**: Two agents returned, both with name/url/description populated.
+  - **Empty result**: `{"agents": []}` when no env vars are set or no agents match the filter.
+  - **Error example**: `{"agents": [], "error": "..."}` when env var parsing fails.
+
+## Dependencies
+- `tools/register-agent/README.md` — pattern to follow (already exists)
+- `.claude/tasks/issue-51.md` — task definition with parameter and output details
+
+## Risks & Edge Cases
+- The README must stay consistent with the actual implementation once built. If parameter names or output fields change during implementation, the README must be updated accordingly.
+- The env var format documentation must exactly match the parsing logic in `crates/orchestrator/src/config.rs` (`parse_comma_pairs`).
+
+## Verification
+- Confirm the README follows the same structure as `tools/register-agent/README.md` (heading order, table format, code block style).
+- Confirm all sections from the task description are present: description, build/run/test commands, MCP Inspector command, input parameters, output format, env var configuration, usage examples.
+- Confirm the parameter table lists `filter` as optional with type `string`.
+- Confirm the output format documents the `{"agents": [...]}` shape with `name`, `url`, and `description` fields per agent.
+- Confirm both `AGENT_ENDPOINTS` and `AGENT_DESCRIPTIONS` env vars are documented with their format.

--- a/.claude/tasks/issue-51.md
+++ b/.claude/tasks/issue-51.md
@@ -1,0 +1,109 @@
+# Task Breakdown: Implement list_agents MCP tool
+
+> Implement `list_agents` as a standalone Rust MCP server binary that reads agent registrations from `AGENT_ENDPOINTS` and `AGENT_DESCRIPTIONS` environment variables and returns them as a JSON array, following the established tool pattern.
+
+## Group 1 — Scaffold the crate
+
+_Tasks in this group can be done in parallel._
+
+- [x] **Create `tools/list-agents/Cargo.toml`** `[S]`
+      Copy `tools/register-agent/Cargo.toml` and change `name = "list-agents"`. Keep the same dependency set: `mcp-tool-harness` (path), `rmcp` with `transport-io`/`server`/`macros`, `tokio` with `macros`/`rt`/`io-std`, `serde` with `derive`, `serde_json`. No `reqwest` needed since this tool only reads env vars (no HTTP calls). Dev-dependencies: `mcp-test-utils` (path), `tokio` with `rt-multi-thread`, `rmcp` with `client`/`transport-child-process`, `serde_json`.
+      Files: `tools/list-agents/Cargo.toml`
+      Blocking: "Implement `ListAgentsTool` struct and handler", "Write `main.rs`", "Write integration tests"
+
+- [x] **Add `"tools/list-agents"` to workspace `Cargo.toml`** `[S]`
+      Add `"tools/list-agents"` to the `members` list in the root `Cargo.toml`, after the existing `"tools/docker-build"` entry.
+      Files: `Cargo.toml`
+      Blocking: "Run verification suite"
+
+## Group 2 — Core implementation
+
+_Depends on: Group 1_
+
+- [x] **Implement `ListAgentsTool` struct and handler in `src/list_agents.rs`** `[M]`
+      Create `tools/list-agents/src/list_agents.rs`. Define `ListAgentsRequest` with `#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]` containing one optional field:
+      - `filter: Option<String>` — optional substring to match against agent name or description
+
+      Define `ListAgentsTool { tool_router: ToolRouter<Self> }` with `new()` calling `Self::tool_router()`.
+
+      **Agent resolution from env vars:** Reuse the same parsing logic as `crates/orchestrator/src/config.rs`:
+      - Read `AGENT_ENDPOINTS` env var: comma-separated `name=url` pairs
+      - Read `AGENT_DESCRIPTIONS` env var (optional): comma-separated `name=description` pairs
+      - Build a list of `{name, url, description}` objects by joining on agent name
+      - If `AGENT_ENDPOINTS` is missing or empty, return an empty JSON array (not an error, per the spec)
+
+      **Filtering:** If `filter` is provided and non-empty, case-insensitively match it against both `name` and `description`, returning only agents where either field contains the filter substring.
+
+      **Output:** Return a JSON string: `{"agents": [{name, url, description}, ...]}`. On parse errors in the env vars, return `{"agents": [], "error": "<message>"}`.
+
+      Implement `ServerHandler` with `#[tool_handler]` returning tools-enabled capabilities.
+
+      **Unit tests** in `#[cfg(test)] mod tests`:
+      1. `returns_empty_array_when_no_env_vars` — with no env vars set, assert response contains `"agents": []`
+      2. `parses_single_agent_from_env` — set `AGENT_ENDPOINTS=foo=http://localhost:8080` and `AGENT_DESCRIPTIONS=foo=A test agent`, assert one agent returned with correct fields
+      3. `parses_multiple_agents_from_env` — set env vars with two comma-separated entries, assert both are returned
+      4. `filter_narrows_results` — set env vars with two agents, call with filter matching only one, assert only the matching agent is returned
+      5. `filter_is_case_insensitive` — set env var with agent name "MyAgent", filter with "myagent", assert it matches
+      6. `missing_description_returns_empty_string` — set only `AGENT_ENDPOINTS`, assert agent is returned with empty description
+
+      Note: Extract core logic into pure functions that accept parsed data, testing those independently. Only one or two tests should exercise the env var reading path to avoid race conditions.
+
+      Files: `tools/list-agents/src/list_agents.rs`
+      Blocked by: "Create `tools/list-agents/Cargo.toml`"
+      Blocking: "Write `main.rs`", "Write integration tests"
+
+- [x] **Write `src/main.rs`** `[S]`
+      Create `tools/list-agents/src/main.rs`. Mirror `tools/echo-tool/src/main.rs`: declare `mod list_agents;`, use `ListAgentsTool`, call `mcp_tool_harness::serve_stdio_tool(ListAgentsTool::new(), "list-agents").await`. Under 10 lines.
+      Files: `tools/list-agents/src/main.rs`
+      Blocked by: "Implement `ListAgentsTool` struct and handler"
+      Blocking: "Write integration tests"
+
+## Group 3 — Integration tests and documentation
+
+_Depends on: Group 2_
+
+- [x] **Write integration tests in `tests/list_agents_server_test.rs`** `[M]`
+      Create `tools/list-agents/tests/list_agents_server_test.rs`. Use `spawn_mcp_client!(env!("CARGO_BIN_EXE_list-agents"))` pattern from `mcp-test-utils`.
+
+      Tests (each `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`):
+      1. `tools_list_returns_list_agents_tool` — use `mcp_test_utils::assert_single_tool` to verify tool name is `"list_agents"`, description contains `"agent"`, and parameters include `["filter"]`.
+      2. `tools_call_returns_empty_when_no_agents` — call `list_agents` with no filter and no env vars set, parse response, assert `agents` is an empty array.
+      3. `tools_call_returns_agents_from_env` — set `AGENT_ENDPOINTS` and `AGENT_DESCRIPTIONS` env vars before spawning the binary, call `list_agents`, assert agents are returned correctly.
+
+      Note: Since integration tests spawn a child process, env vars must be set before the process starts. Use `std::env::set_var` before `spawn_mcp_client!` to pass env vars to the child process.
+
+      Files: `tools/list-agents/tests/list_agents_server_test.rs`
+      Blocked by: "Write `main.rs`"
+      Blocking: None
+
+- [x] **Write `README.md`** `[S]`
+      Create `tools/list-agents/README.md` following the pattern from `tools/register-agent/README.md`. Include: description, build/run/test commands, MCP Inspector command, input parameters (optional `filter`), output format (JSON array of `{name, url, description}`), environment variable configuration (`AGENT_ENDPOINTS`, `AGENT_DESCRIPTIONS`), and usage examples.
+      Files: `tools/list-agents/README.md`
+      Non-blocking
+
+## Group 4 — Verification
+
+_Depends on: Groups 1-3_
+
+- [ ] **Run verification suite** `[S]`
+      Run `cargo build -p list-agents`, `cargo test -p list-agents`, `cargo clippy -p list-agents`, and `cargo check` (workspace-wide). Verify all acceptance criteria: build succeeds, tests pass, tool is named `list_agents` in MCP tools/list, returns structured JSON array, works with `AGENT_ENDPOINTS` and `AGENT_DESCRIPTIONS` env vars, returns empty array when no agents are registered.
+      Files: (none — command-line verification only)
+      Blocked by: All previous tasks
+      Blocking: None
+
+## Implementation Notes
+
+1. **No new dependencies needed**: All dependencies (`rmcp`, `tokio`, `serde`, `serde_json`, `mcp-tool-harness`) are already used by existing tools. Unlike `register-agent`, this tool does NOT need `reqwest` since it reads from environment variables rather than making HTTP calls.
+
+2. **Env var parsing mirrors orchestrator config**: The `AGENT_ENDPOINTS` and `AGENT_DESCRIPTIONS` parsing logic in `crates/orchestrator/src/config.rs` (`parse_comma_pairs`) is the reference for how these env vars are structured (`name=value,name2=value2`). The list-agents tool should parse them identically.
+
+3. **Thread safety for env var tests**: Extract core logic into pure functions that accept parsed data and test those independently. Only one or two tests should exercise the env var reading path.
+
+4. **Filter semantics**: Case-insensitive substring matching on both `name` and `description`.
+
+### Critical Files for Implementation
+- `tools/echo-tool/src/echo.rs` — Simplest reference pattern for tool struct, macros, and test layout
+- `crates/orchestrator/src/config.rs` — `AGENT_ENDPOINTS`/`AGENT_DESCRIPTIONS` env var parsing logic to replicate
+- `tools/register-agent/src/register_agent.rs` — Agent-related tool with validation and async handler pattern
+- `Cargo.toml` — Workspace members list to update
+- `crates/mcp-test-utils/src/lib.rs` — Test utilities for integration tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,21 +463,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,22 +738,6 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1058,6 +1027,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "list-agents"
+version = "0.1.0"
+dependencies = [
+ "mcp-test-utils",
+ "mcp-tool-harness",
+ "rmcp 1.2.0",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,23 +1148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,48 +1194,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "orchestrator"
@@ -1281,7 +1207,7 @@ dependencies = [
  "async-trait",
  "axum",
  "futures",
- "reqwest 0.13.2",
+ "reqwest",
  "rig-core",
  "serde",
  "serde_json",
@@ -1366,12 +1292,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -1624,51 +1544,11 @@ version = "0.1.0"
 dependencies = [
  "mcp-test-utils",
  "mcp-tool-harness",
- "reqwest 0.12.28",
+ "reqwest",
  "rmcp 1.2.0",
  "serde",
  "serde_json",
  "tokio",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -1736,7 +1616,7 @@ dependencies = [
  "nanoid",
  "ordered-float",
  "pin-project-lite",
- "reqwest 0.13.2",
+ "reqwest",
  "rmcp 0.16.0",
  "schemars 1.2.1",
  "serde",
@@ -2385,16 +2265,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,12 +2517,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/orchestrator",
     "crates/mcp-test-utils",
     "tools/echo-tool",
+    "tools/list-agents",
     "tools/read-file",
     "tools/register-agent",
     "tools/write-file",

--- a/tools/list-agents/Cargo.toml
+++ b/tools/list-agents/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "list-agents"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mcp-tool-harness = { path = "../../crates/mcp-tool-harness" }
+rmcp = { version = "1", features = ["transport-io", "server", "macros"] }
+tokio = { version = "1", features = ["macros", "rt", "io-std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+mcp-test-utils = { path = "../../crates/mcp-test-utils" }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "net"] }
+rmcp = { version = "1", features = ["client", "transport-child-process"] }
+serde_json = "1"

--- a/tools/list-agents/README.md
+++ b/tools/list-agents/README.md
@@ -43,7 +43,7 @@ The tool returns a JSON response with the following fields:
 | Field    | Type   | Description                                              |
 |----------|--------|----------------------------------------------------------|
 | `agents` | array  | Array of agent objects with `name`, `url`, `description` |
-| `error`  | string | Error message (empty on success, present on failure)     |
+| `error`  | string | Optional error message. Only present on failure.         |
 
 ### Success example
 

--- a/tools/list-agents/README.md
+++ b/tools/list-agents/README.md
@@ -1,0 +1,129 @@
+# list-agents
+
+An MCP tool server that reads agent registrations from environment variables and returns a filtered JSON array of registered agents.
+
+## Build
+
+```sh
+cargo build -p list-agents
+```
+
+## Run
+
+```sh
+cargo run -p list-agents
+```
+
+The server uses stdio transport: it reads MCP messages from stdin and writes responses to stdout. All logging output is directed to stderr so it does not interfere with the MCP protocol stream.
+
+## Test with MCP Inspector
+
+```sh
+npx @modelcontextprotocol/inspector cargo run -p list-agents
+```
+
+This launches the MCP Inspector, which connects to the list-agents server and provides an interactive UI for sending requests and viewing responses. Use it to verify that the tool advertises its capabilities and handles calls correctly.
+
+## Test
+
+```sh
+cargo test -p list-agents
+```
+
+## Parameters
+
+| Name     | Type   | Required | Description                                                        |
+|----------|--------|----------|--------------------------------------------------------------------|
+| `filter` | string | no       | Case-insensitive substring match against agent name and description |
+
+## Output
+
+The tool returns a JSON response with the following fields:
+
+| Field    | Type   | Description                                              |
+|----------|--------|----------------------------------------------------------|
+| `agents` | array  | Array of agent objects with `name`, `url`, `description` |
+| `error`  | string | Error message (empty on success, present on failure)     |
+
+### Success example
+
+```json
+{
+  "agents": [
+    {
+      "name": "skill-writer",
+      "url": "http://skill-writer:8080",
+      "description": "Writes skill files from templates"
+    },
+    {
+      "name": "tool-coder",
+      "url": "http://tool-coder:9090",
+      "description": "Generates MCP tool implementations"
+    }
+  ]
+}
+```
+
+### Filtered example
+
+When `filter` is set to `"skill"`, only agents whose name or description contains "skill" (case-insensitive) are returned:
+
+```json
+{
+  "agents": [
+    {
+      "name": "skill-writer",
+      "url": "http://skill-writer:8080",
+      "description": "Writes skill files from templates"
+    }
+  ]
+}
+```
+
+### Empty result example
+
+```json
+{
+  "agents": []
+}
+```
+
+### Error example
+
+```json
+{
+  "agents": [],
+  "error": "AGENT_ENDPOINTS is not set"
+}
+```
+
+## Environment Variables
+
+| Variable              | Required | Description                                                    |
+|-----------------------|----------|----------------------------------------------------------------|
+| `AGENT_ENDPOINTS`     | yes      | Comma-separated list of `name=url` pairs (e.g. `a=http://a:8080,b=http://b:9090`) |
+| `AGENT_DESCRIPTIONS`  | no       | Comma-separated list of `name=description` pairs (e.g. `a=My agent,b=Other agent`) |
+
+`AGENT_ENDPOINTS` defines which agents are available. Each entry is a `name=url` pair separated by commas. Whitespace around names and URLs is trimmed.
+
+`AGENT_DESCRIPTIONS` provides optional human-readable descriptions for agents. Entries that cannot be parsed are silently skipped. Agents without a matching description entry receive an empty description string.
+
+## Usage
+
+Set environment variables and run the server:
+
+```sh
+AGENT_ENDPOINTS="skill-writer=http://skill-writer:8080,tool-coder=http://tool-coder:9090" \
+AGENT_DESCRIPTIONS="skill-writer=Writes skill files from templates,tool-coder=Generates MCP tool implementations" \
+cargo run -p list-agents
+```
+
+To test with a filter using MCP Inspector:
+
+```sh
+AGENT_ENDPOINTS="skill-writer=http://skill-writer:8080,tool-coder=http://tool-coder:9090" \
+AGENT_DESCRIPTIONS="skill-writer=Writes skill files from templates,tool-coder=Generates MCP tool implementations" \
+npx @modelcontextprotocol/inspector cargo run -p list-agents
+```
+
+Then call the `list_agents` tool with `{"filter": "skill"}` to see only matching agents.

--- a/tools/list-agents/README.md
+++ b/tools/list-agents/README.md
@@ -93,7 +93,7 @@ When `filter` is set to `"skill"`, only agents whose name or description contain
 ```json
 {
   "agents": [],
-  "error": "AGENT_ENDPOINTS is not set"
+  "error": "invalid pair 'bad-entry', expected 'key=value'"
 }
 ```
 
@@ -101,7 +101,7 @@ When `filter` is set to `"skill"`, only agents whose name or description contain
 
 | Variable              | Required | Description                                                    |
 |-----------------------|----------|----------------------------------------------------------------|
-| `AGENT_ENDPOINTS`     | yes      | Comma-separated list of `name=url` pairs (e.g. `a=http://a:8080,b=http://b:9090`) |
+| `AGENT_ENDPOINTS`     | no       | Comma-separated list of `name=url` pairs (e.g. `a=http://a:8080,b=http://b:9090`). Returns empty array if unset. |
 | `AGENT_DESCRIPTIONS`  | no       | Comma-separated list of `name=description` pairs (e.g. `a=My agent,b=Other agent`) |
 
 `AGENT_ENDPOINTS` defines which agents are available. Each entry is a `name=url` pair separated by commas. Whitespace around names and URLs is trimmed.

--- a/tools/list-agents/src/list_agents.rs
+++ b/tools/list-agents/src/list_agents.rs
@@ -36,23 +36,21 @@ struct AgentInfo {
 ///
 /// Format: "name1=url1,name2=url2". Trims whitespace, rejects empty keys/values.
 fn parse_endpoints(raw: &str) -> Result<Vec<(String, String)>, String> {
-    let mut results = Vec::new();
-    for entry in raw.split(',') {
-        let entry = entry.trim();
-        if entry.is_empty() {
-            continue;
-        }
-        let (key, value) = entry
-            .split_once('=')
-            .ok_or_else(|| format!("invalid pair '{entry}', expected 'key=value'"))?;
-        let key = key.trim().to_string();
-        let value = value.trim().to_string();
-        if key.is_empty() || value.is_empty() {
-            return Err(format!("empty key or value in pair '{entry}'"));
-        }
-        results.push((key, value));
-    }
-    Ok(results)
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|entry| {
+            let (key, value) = entry
+                .split_once('=')
+                .ok_or_else(|| format!("invalid pair '{entry}', expected 'key=value'"))?;
+            let key = key.trim();
+            let value = value.trim();
+            if key.is_empty() || value.is_empty() {
+                return Err(format!("empty key or value in pair '{entry}'"));
+            }
+            Ok((key.to_string(), value.to_string()))
+        })
+        .collect()
 }
 
 /// Parse a raw AGENT_DESCRIPTIONS string into a map of name -> description.

--- a/tools/list-agents/src/list_agents.rs
+++ b/tools/list-agents/src/list_agents.rs
@@ -1,0 +1,225 @@
+use std::collections::HashMap;
+
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ListAgentsRequest {
+    /// Optional filter string to narrow results by name or description (case-insensitive substring match)
+    pub filter: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ListAgentsTool {
+    tool_router: ToolRouter<Self>,
+}
+
+impl ListAgentsTool {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct AgentInfo {
+    name: String,
+    url: String,
+    description: String,
+}
+
+/// Parse a raw AGENT_ENDPOINTS string into a list of (name, url) pairs.
+///
+/// Format: "name1=url1,name2=url2". Trims whitespace, rejects empty keys/values.
+fn parse_endpoints(raw: &str) -> Result<Vec<(String, String)>, String> {
+    let mut results = Vec::new();
+    for entry in raw.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let (key, value) = entry
+            .split_once('=')
+            .ok_or_else(|| format!("invalid pair '{entry}', expected 'key=value'"))?;
+        let key = key.trim().to_string();
+        let value = value.trim().to_string();
+        if key.is_empty() || value.is_empty() {
+            return Err(format!("empty key or value in pair '{entry}'"));
+        }
+        results.push((key, value));
+    }
+    Ok(results)
+}
+
+/// Parse a raw AGENT_DESCRIPTIONS string into a map of name -> description.
+///
+/// Format: "name1=desc1,name2=desc2". Lenient: skips malformed pairs.
+fn parse_descriptions(raw: &str) -> HashMap<String, String> {
+    raw.split(',')
+        .filter_map(|entry| {
+            let (key, value) = entry.split_once('=')?;
+            let key = key.trim().to_string();
+            let value = value.trim().to_string();
+            if key.is_empty() || value.is_empty() {
+                return None;
+            }
+            Some((key, value))
+        })
+        .collect()
+}
+
+/// Build a list of AgentInfo from parsed endpoints and descriptions.
+fn build_agent_list(
+    endpoints: &[(String, String)],
+    descriptions: &HashMap<String, String>,
+) -> Vec<AgentInfo> {
+    endpoints
+        .iter()
+        .map(|(name, url)| AgentInfo {
+            name: name.clone(),
+            url: url.clone(),
+            description: descriptions.get(name).cloned().unwrap_or_default(),
+        })
+        .collect()
+}
+
+/// Filter agents by case-insensitive substring match on name and description.
+fn filter_agents(agents: &[AgentInfo], filter: &str) -> Vec<AgentInfo> {
+    let lower_filter = filter.to_lowercase();
+    agents
+        .iter()
+        .filter(|agent| {
+            agent.name.to_lowercase().contains(&lower_filter)
+                || agent.description.to_lowercase().contains(&lower_filter)
+        })
+        .cloned()
+        .collect()
+}
+
+#[tool_router]
+impl ListAgentsTool {
+    #[tool(description = "List registered agents, optionally filtered by name or description")]
+    fn list_agents(&self, Parameters(request): Parameters<ListAgentsRequest>) -> String {
+        let endpoints_raw = match std::env::var("AGENT_ENDPOINTS") {
+            Ok(val) if !val.trim().is_empty() => val,
+            _ => return serde_json::json!({"agents": []}).to_string(),
+        };
+
+        let endpoints = match parse_endpoints(&endpoints_raw) {
+            Ok(eps) => eps,
+            Err(msg) => {
+                return serde_json::json!({"agents": [], "error": msg}).to_string();
+            }
+        };
+
+        let descriptions = match std::env::var("AGENT_DESCRIPTIONS") {
+            Ok(val) if !val.trim().is_empty() => parse_descriptions(&val),
+            _ => HashMap::new(),
+        };
+
+        let agents = build_agent_list(&endpoints, &descriptions);
+
+        let agents = match request.filter.as_deref() {
+            Some(f) if !f.is_empty() => filter_agents(&agents, f),
+            _ => agents,
+        };
+
+        serde_json::json!({"agents": agents}).to_string()
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for ListAgentsTool {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_endpoints() {
+        let result = parse_endpoints("");
+        assert_eq!(result.unwrap(), vec![]);
+    }
+
+    #[test]
+    fn test_single_agent() {
+        let endpoints = parse_endpoints("builder=http://localhost:8001").unwrap();
+        let descriptions = parse_descriptions("builder=Builds things");
+        let agents = build_agent_list(&endpoints, &descriptions);
+
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].name, "builder");
+        assert_eq!(agents[0].url, "http://localhost:8001");
+        assert_eq!(agents[0].description, "Builds things");
+    }
+
+    #[test]
+    fn test_multiple_agents() {
+        let endpoints =
+            parse_endpoints("builder=http://localhost:8001,runner=http://localhost:8002").unwrap();
+        let descriptions = parse_descriptions("builder=Builds things");
+        let agents = build_agent_list(&endpoints, &descriptions);
+
+        assert_eq!(agents.len(), 2);
+        assert_eq!(agents[0].name, "builder");
+        assert_eq!(agents[0].description, "Builds things");
+        assert_eq!(agents[1].name, "runner");
+        assert_eq!(agents[1].url, "http://localhost:8002");
+        assert_eq!(agents[1].description, "");
+    }
+
+    #[test]
+    fn test_filter_matches_name() {
+        let agents = vec![
+            AgentInfo {
+                name: "builder".to_string(),
+                url: "http://localhost:8001".to_string(),
+                description: "Builds things".to_string(),
+            },
+            AgentInfo {
+                name: "runner".to_string(),
+                url: "http://localhost:8002".to_string(),
+                description: "Runs tasks".to_string(),
+            },
+        ];
+
+        let filtered = filter_agents(&agents, "build");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "builder");
+    }
+
+    #[test]
+    fn test_filter_case_insensitive() {
+        let agents = vec![AgentInfo {
+            name: "Builder".to_string(),
+            url: "http://localhost:8001".to_string(),
+            description: "Builds Things".to_string(),
+        }];
+
+        let filtered = filter_agents(&agents, "BUILD");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "Builder");
+
+        let filtered = filter_agents(&agents, "things");
+        assert_eq!(filtered.len(), 1);
+    }
+
+    #[test]
+    fn test_missing_descriptions() {
+        let endpoints = parse_endpoints("agent1=http://a:1,agent2=http://b:2").unwrap();
+        let descriptions = HashMap::new();
+        let agents = build_agent_list(&endpoints, &descriptions);
+
+        assert_eq!(agents.len(), 2);
+        assert_eq!(agents[0].description, "");
+        assert_eq!(agents[1].description, "");
+    }
+}

--- a/tools/list-agents/src/main.rs
+++ b/tools/list-agents/src/main.rs
@@ -1,0 +1,7 @@
+mod list_agents;
+use list_agents::ListAgentsTool;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mcp_tool_harness::serve_stdio_tool(ListAgentsTool::new(), "list-agents").await
+}

--- a/tools/list-agents/tests/list_agents_server_test.rs
+++ b/tools/list-agents/tests/list_agents_server_test.rs
@@ -35,12 +35,7 @@ async fn tools_call_returns_empty_when_no_agents() {
     let client =
         spawn_client_with_env(&[], &["AGENT_ENDPOINTS", "AGENT_DESCRIPTIONS"]).await;
 
-    let params = CallToolRequestParams::new("list_agents").with_arguments(
-        serde_json::json!({})
-            .as_object()
-            .unwrap()
-            .clone(),
-    );
+    let params = CallToolRequestParams::new("list_agents");
     let result = client
         .peer()
         .call_tool(params)
@@ -80,12 +75,7 @@ async fn tools_call_returns_agents_from_env() {
     )
     .await;
 
-    let params = CallToolRequestParams::new("list_agents").with_arguments(
-        serde_json::json!({})
-            .as_object()
-            .unwrap()
-            .clone(),
-    );
+    let params = CallToolRequestParams::new("list_agents");
     let result = client
         .peer()
         .call_tool(params)

--- a/tools/list-agents/tests/list_agents_server_test.rs
+++ b/tools/list-agents/tests/list_agents_server_test.rs
@@ -1,0 +1,122 @@
+use rmcp::model::CallToolRequestParams;
+
+/// Spawn an MCP client whose child process has explicit env var overrides.
+///
+/// Uses `env_remove` to unset specific vars and `env` to set key-value pairs,
+/// avoiding mutation of the parent process's global environment.
+async fn spawn_client_with_env(
+    envs: &[(&str, &str)],
+    env_removes: &[&str],
+) -> mcp_test_utils::RunningService<mcp_test_utils::RoleClient, ()> {
+    let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_list-agents"));
+    for key in env_removes {
+        cmd.env_remove(key);
+    }
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    let transport =
+        rmcp::transport::TokioChildProcess::new(cmd).expect("failed to spawn MCP server binary");
+    <() as mcp_test_utils::ServiceExt<mcp_test_utils::RoleClient>>::serve((), transport)
+        .await
+        .expect("failed to connect to MCP server")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_returns_list_agents_tool() {
+    let client = mcp_test_utils::spawn_mcp_client!(env!("CARGO_BIN_EXE_list-agents")).await;
+    mcp_test_utils::assert_single_tool(&client, "list_agents", "agent", &["filter"]).await;
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_returns_empty_when_no_agents() {
+    // Remove env vars on the child process only, avoiding global mutation.
+    let client =
+        spawn_client_with_env(&[], &["AGENT_ENDPOINTS", "AGENT_DESCRIPTIONS"]).await;
+
+    let params = CallToolRequestParams::new("list_agents").with_arguments(
+        serde_json::json!({})
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value =
+        serde_json::from_str(&text.text).expect("should parse as JSON");
+
+    let agents = json["agents"].as_array().expect("agents should be an array");
+    assert!(agents.is_empty(), "agents should be empty when no env vars set");
+
+    client.cancel().await.expect("failed to cancel client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_call_returns_agents_from_env() {
+    // Set env vars on the child process only, avoiding global mutation.
+    let client = spawn_client_with_env(
+        &[
+            (
+                "AGENT_ENDPOINTS",
+                "foo=http://localhost:8080,bar=http://localhost:9090",
+            ),
+            (
+                "AGENT_DESCRIPTIONS",
+                "foo=A foo agent,bar=A bar agent",
+            ),
+        ],
+        &[],
+    )
+    .await;
+
+    let params = CallToolRequestParams::new("list_agents").with_arguments(
+        serde_json::json!({})
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let result = client
+        .peer()
+        .call_tool(params)
+        .await
+        .expect("call_tool");
+
+    let text = result
+        .content
+        .first()
+        .expect("should have content")
+        .as_text()
+        .expect("first content should be text");
+    let json: serde_json::Value =
+        serde_json::from_str(&text.text).expect("should parse as JSON");
+
+    let agents = json["agents"].as_array().expect("agents should be an array");
+    assert_eq!(agents.len(), 2, "should have 2 agents");
+
+    // Don't assume array order -- check membership
+    let has_foo = agents.iter().any(|a| {
+        a["name"] == "foo"
+            && a["url"] == "http://localhost:8080"
+            && a["description"] == "A foo agent"
+    });
+    let has_bar = agents.iter().any(|a| {
+        a["name"] == "bar"
+            && a["url"] == "http://localhost:9090"
+            && a["description"] == "A bar agent"
+    });
+    assert!(has_foo, "should contain foo agent with correct fields");
+    assert!(has_bar, "should contain bar agent with correct fields");
+
+    client.cancel().await.expect("failed to cancel client");
+}


### PR DESCRIPTION
## Summary

Add a `list-agents` MCP tool binary that reads agent registrations from `AGENT_ENDPOINTS` and `AGENT_DESCRIPTIONS` environment variables and returns them as a filtered JSON array. Uses pure functions for all parsing and filtering logic to enable safe parallel testing without env var mutation.

## Changes

### Group 1 — Scaffold the crate
- ✅ Create `tools/list-agents/Cargo.toml`
- ✅ Add `"tools/list-agents"` to workspace `Cargo.toml`

### Group 2 — Core implementation
- ✅ Implement `ListAgentsTool` struct and handler in `src/list_agents.rs`
- ✅ Write `src/main.rs`

### Group 3 — Integration tests and documentation
- ✅ Write integration tests in `tests/list_agents_server_test.rs`
- ✅ Write `README.md`

### Group 4 — Verification
- ✅ Run verification suite

## Test plan

- `cargo build -p list-agents` — crate builds cleanly
- `cargo clippy -p list-agents` — no lint warnings
- `cargo check -p list-agents` — no type errors
- `cargo test -p list-agents` — all 9 tests pass (6 unit + 3 integration)

## Issue

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)